### PR TITLE
tests: split envtest suite and run in parallel jobs

### DIFF
--- a/.github/workflows/__envtest_tests.yaml
+++ b/.github/workflows/__envtest_tests.yaml
@@ -20,12 +20,13 @@ jobs:
   envtest-tests:
     timeout-minutes: ${{ fromJSON(vars.GHA_EXTENDED_TIMEOUT_MINUTES || 60) }}
     runs-on: ubuntu-latest
-    name: ${{ matrix.command }} - ${{ format('{0}', inputs.cluster_version) }}
+    name: ${{ matrix.testcase }} - ${{ format('{0}', inputs.cluster_version) }}
     strategy:
       matrix:
         include:
-          - command: gateway
-          - command: base
+          - testcase: konnect-api-gw
+          - testcase: gateway
+          - testcase: .
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -86,7 +87,9 @@ jobs:
         # Remove patch number as envtest releases are not provided for every patch version
         VERSION="${VERSION%.*}"
         echo "Cluster version: $VERSION"
-        make test.envtest.${{ matrix.command }} CLUSTER_VERSION=${VERSION}
+        make test.envtest \
+          CLUSTER_VERSION=${VERSION} \
+          ENVTEST_TEST_PATHS=./test/envtest/${{ matrix.testcase }}
 
     - name: collect test coverage
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/.github/workflows/__envtest_tests.yaml
+++ b/.github/workflows/__envtest_tests.yaml
@@ -20,7 +20,12 @@ jobs:
   envtest-tests:
     timeout-minutes: ${{ fromJSON(vars.GHA_EXTENDED_TIMEOUT_MINUTES || 60) }}
     runs-on: ubuntu-latest
-    name: ${{ format('{0}', inputs.cluster_version) }}
+    name: ${{ matrix.command }} - ${{ format('{0}', inputs.cluster_version) }}
+    strategy:
+      matrix:
+        include:
+          - command: gateway
+          - command: base
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
@@ -81,7 +86,7 @@ jobs:
         # Remove patch number as envtest releases are not provided for every patch version
         VERSION="${VERSION%.*}"
         echo "Cluster version: $VERSION"
-        make test.envtest CLUSTER_VERSION=${VERSION}
+        make test.envtest.${{ matrix.command }} CLUSTER_VERSION=${VERSION}
 
     - name: collect test coverage
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/Makefile
+++ b/Makefile
@@ -642,11 +642,6 @@ _test.envtest: gotestsum setup-envtest
 # To run the envtest suite with pretty format use:
 # GOTESTSUM_FORMAT=testname make test.envtest
 
-.PHONY: test.envtest.gateway
-test.envtest.gateway:
-	ENVTEST_TEST_PATHS=./test/envtest/gateway/... \
-		$(MAKE) _test.envtest
-
 .PHONY: test.envtest.base
 test.envtest.base:
 	ENVTEST_TEST_PATHS=./test/envtest/ \

--- a/Makefile
+++ b/Makefile
@@ -615,10 +615,11 @@ test.unit:
 test.unit.pretty:
 	@$(MAKE) _test.unit GOTESTSUM_FORMAT=pkgname GOTESTFLAGS="$(GOTESTFLAGS)" UNIT_TEST_PATHS="$(UNIT_TEST_PATHS)"
 
-ENVTEST_TEST_PATHS := ./test/envtest/...
+ENVTEST_TEST_PATHS ?= ./test/envtest/...
 ENVTEST_TIMEOUT ?= 30m
-PKG_LIST=./controller/...,./internal/...,./pkg/...,./modules/...
+PKG_LIST = ./controller/...,./internal/...,./pkg/...,./modules/...
 TEST_DIR ?= $(PROJECT_DIR)
+ENVTEST_GOTESTSUM_FORMAT ?= standard-verbose
 
 .PHONY: _test.envtest
 _test.envtest: gotestsum setup-envtest
@@ -626,7 +627,7 @@ _test.envtest: gotestsum setup-envtest
 	cd $(TEST_DIR) && \
 	KUBECONFIG=$(KUBECONFIG) \
 	KUBEBUILDER_ASSETS="$(shell $(SETUP_ENVTEST) use $(CLUSTER_VERSION) -p path)" \
-	GOTESTSUM_FORMAT=$(GOTESTSUM_FORMAT) \
+	GOTESTSUM_FORMAT=$(ENVTEST_GOTESTSUM_FORMAT) \
 		$(GOTESTSUM) -- \
 		$(GOTESTFLAGS) \
 		-race \
@@ -638,13 +639,22 @@ _test.envtest: gotestsum setup-envtest
 		-ldflags "$(LDFLAGS_COMMON) $(LDFLAGS)" \
 		$(ENVTEST_TEST_PATHS)
 
+# To run the envtest suite with pretty format use:
+# GOTESTSUM_FORMAT=testname make test.envtest
+
+.PHONY: test.envtest.gateway
+test.envtest.gateway:
+	ENVTEST_TEST_PATHS=./test/envtest/gateway/... \
+		$(MAKE) _test.envtest
+
+.PHONY: test.envtest.base
+test.envtest.base:
+	ENVTEST_TEST_PATHS=./test/envtest/ \
+		$(MAKE) _test.envtest
+
 .PHONY: test.envtest
 test.envtest:
-	$(MAKE) _test.envtest GOTESTSUM_FORMAT=standard-verbose
-
-.PHONY: test.envtest.pretty
-test.envtest.pretty:
-	$(MAKE) _test.envtest GOTESTSUM_FORMAT=testname
+	$(MAKE) _test.envtest
 
 .PHONY: test.crds-validation
 test.crds-validation:

--- a/test/envtest/assert.go
+++ b/test/envtest/assert.go
@@ -11,7 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func assertCollectObjectExistsAndHasKonnectID(
+func AssertCollectObjectExistsAndHasKonnectID(
 	t *testing.T,
 	ctx context.Context,
 	clientNamespaced client.Client,
@@ -50,7 +50,7 @@ func (a MockTestingTAdapter) Logf(format string, args ...any) {
 	a.t.Logf(format, args...)
 }
 
-// eventuallyAssertSDKExpectations waits for the SDK to have all its expectations met.
+// EventuallyAssertSDKExpectations waits for the SDK to have all its expectations met.
 // This is useful to ensure that all expected calls to the SDK have been made up
 // to a certain point in the test.
 //
@@ -59,7 +59,7 @@ func (a MockTestingTAdapter) Logf(format string, args ...any) {
 //
 // This function uses an adapter for assert.CollectT to allow it to be used with
 // AssertExpectations, which requires a mock.TestingT interface.
-func eventuallyAssertSDKExpectations(
+func EventuallyAssertSDKExpectations(
 	t *testing.T,
 	sdk interface {
 		AssertExpectations(mock.TestingT) bool
@@ -91,8 +91,8 @@ func eventuallyAssertSDKExpectations(
 	)
 }
 
-// assertsAnd returns a function that performs a logical AND of the given asserts.
-func assertsAnd[
+// AssertsAnd returns a function that performs a logical AND of the given asserts.
+func AssertsAnd[
 	T client.Object,
 ](
 	asserts ...func(T) bool,
@@ -108,7 +108,8 @@ func assertsAnd[
 	}
 }
 
-func assertNot[
+// AssertNot returns a function that negates the given assert.
+func AssertNot[
 	T client.Object,
 ](
 	assert func(T) bool,

--- a/test/envtest/asserts_conditions.go
+++ b/test/envtest/asserts_conditions.go
@@ -1,6 +1,8 @@
 package envtest
 
 import (
+	"github.com/samber/lo"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	commonv1alpha1 "github.com/kong/kong-operator/v2/api/common/v1alpha1"
@@ -8,7 +10,7 @@ import (
 	k8sutils "github.com/kong/kong-operator/v2/pkg/utils/kubernetes"
 )
 
-func conditionsAreSetWhenReferencedControlPlaneIsMissing[
+func ConditionsAreSetWhenReferencedControlPlaneIsMissing[
 	T interface {
 		client.Object
 		k8sutils.ConditionsAware
@@ -32,7 +34,7 @@ func conditionsAreSetWhenReferencedControlPlaneIsMissing[
 	}
 }
 
-func conditionProgrammedIsSetToTrueAndCPRefIsKonnectNamespacedRef[
+func ConditionProgrammedIsSetToTrueAndCPRefIsKonnectNamespacedRef[
 	T interface {
 		client.Object
 		k8sutils.ConditionsAware
@@ -55,10 +57,29 @@ func conditionProgrammedIsSetToTrueAndCPRefIsKonnectNamespacedRef[
 	}
 }
 
-func objectHasConditionProgrammedSetToTrue[
+// ObjectHasConditionProgrammedSetToTrue returns a function that checks if the given
+// object has the "Programmed" condition set to true.
+func ObjectHasConditionProgrammedSetToTrue[
 	T k8sutils.ConditionsAware,
 ]() func(T) bool {
 	return func(obj T) bool {
 		return k8sutils.IsProgrammed(obj)
 	}
+}
+
+func ConditionsContainProgrammedFalse(conds []metav1.Condition) bool {
+	return conditionsContainProgrammed(conds, metav1.ConditionFalse)
+}
+
+func ConditionsContainProgrammedTrue(conds []metav1.Condition) bool {
+	return conditionsContainProgrammed(conds, metav1.ConditionTrue)
+}
+
+func conditionsContainProgrammed(conds []metav1.Condition, status metav1.ConditionStatus) bool {
+	return lo.ContainsBy(conds,
+		func(condition metav1.Condition) bool {
+			return condition.Type == konnectv1alpha1.KonnectEntityProgrammedConditionType &&
+				condition.Status == status
+		},
+	)
 }

--- a/test/envtest/asserts_konnect.go
+++ b/test/envtest/asserts_konnect.go
@@ -1,6 +1,8 @@
 package envtest
 
-func objectMatchesKonnectID[
+// ObjectMatchesKonnectID returns a function that checks if an object's
+// Konnect ID matches the given ID.
+func ObjectMatchesKonnectID[
 	T interface {
 		GetKonnectID() string
 	},

--- a/test/envtest/asserts_meta.go
+++ b/test/envtest/asserts_meta.go
@@ -5,7 +5,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 )
 
-func objectHasFinalizer[
+// ObjectHasFinalizer returns a function that checks if the given object
+// has the specified finalizer.
+func ObjectHasFinalizer[
 	T client.Object,
 ](finalizer string) func(obj T) bool {
 	return func(obj T) bool {

--- a/test/envtest/asserts_objectmeta.go
+++ b/test/envtest/asserts_objectmeta.go
@@ -4,7 +4,9 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-func objectMatchesName[
+// ObjectMatchesName returns a function that checks if the given object has
+// the same name as the provided object to match.
+func ObjectMatchesName[
 	T client.Object,
 ](objToMatch T) func(T) bool {
 	return func(obj T) bool {

--- a/test/envtest/consts.go
+++ b/test/envtest/consts.go
@@ -1,15 +1,23 @@
 package envtest
 
-import "time"
+import (
+	"github.com/kong/kong-operator/v2/test/envtest/consts"
+)
+
+// This file is mostly serving one purpose:
+// to allow gradual refactoring of envtest suite.
+// Currently, tests living in test/envtest use these consts. Changing this to
+// use consts fro test/envtest/consts/ would require changing a lot of files at once.
+// We want to avoid that by using this file and moving the source of truth to test/envtest/consts/.
 
 const (
 	// konnectInfiniteSyncTime is used for tests that want to verify behavior of the reconcilers not relying on the fixed
 	// sync period. It's set to 60m that is virtually infinite for the tests.
-	konnectInfiniteSyncTime = time.Minute * 60
+	konnectInfiniteSyncTime = consts.KonnectInfiniteSyncTime
 
 	// waitTime is a generic wait time for the tests' eventual conditions.
-	waitTime = 10 * time.Second
+	waitTime = consts.WaitTime
 
 	// tickTime is a generic tick time for the tests' eventual conditions.
-	tickTime = 250 * time.Millisecond
+	tickTime = consts.TickTime
 )

--- a/test/envtest/consts/consts.go
+++ b/test/envtest/consts/consts.go
@@ -1,0 +1,15 @@
+package consts
+
+import "time"
+
+const (
+	// KonnectInfiniteSyncTime is used for tests that want to verify behavior of the reconcilers not relying on the fixed
+	// sync period. It's set to 60m that is virtually infinite for the tests.
+	KonnectInfiniteSyncTime = time.Minute * 60
+
+	// WaitTime is a generic wait time for the tests' eventual conditions.
+	WaitTime = 10 * time.Second
+
+	// TickTime is a generic tick time for the tests' eventual conditions.
+	TickTime = 250 * time.Millisecond
+)

--- a/test/envtest/consts/errors.go
+++ b/test/envtest/consts/errors.go
@@ -1,0 +1,19 @@
+package consts
+
+const (
+	// ErrBodyDataConstraintError is a JSON error response body for a data constraint error.
+	ErrBodyDataConstraintError = `{
+			"code": 3,
+			"message": "data constraint error",
+			"details": [
+				{
+					"@type": "type.googleapis.com/kong.admin.model.v1.ErrorDetail",
+					"type": "ERROR_TYPE_REFERENCE",
+					"field": "name",
+					"messages": [
+						"name (type: unique) constraint failed"
+					]
+				}
+			]
+		}`
+)

--- a/test/envtest/create/gateway.go
+++ b/test/envtest/create/gateway.go
@@ -1,0 +1,101 @@
+package create
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kong/kong-operator/v2/ingress-controller/test/controllers/gateway"
+	"github.com/kong/kong-operator/v2/ingress-controller/test/gatewayapi"
+	"github.com/kong/kong-operator/v2/ingress-controller/test/util/builder"
+	"github.com/kong/kong-operator/v2/test/helpers/deploy"
+)
+
+// PublishServiceName is the name of the publish service used in Gateway API tests.
+const PublishServiceName = "publish-svc"
+
+// Gateway deploys a Gateway, GatewayClass and an ingress service for use in tests.
+func Gateway(ctx context.Context, t *testing.T, client client.Client) (gatewayapi.Gateway, gatewayapi.GatewayClass) {
+	gwc := gatewayapi.GatewayClass{
+		Spec: gatewayapi.GatewayClassSpec{
+			ControllerName: gateway.GetControllerName(),
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: "gwc-",
+			Annotations: map[string]string{
+				"konghq.com/gatewayclass-unmanaged": "placeholder",
+			},
+		},
+	}
+	require.NoError(t, client.Create(ctx, &gwc))
+	t.Cleanup(func() { _ = client.Delete(ctx, &gwc) })
+
+	gw := GatewayUsingGatewayClass(ctx, t, client, gwc)
+
+	return gw, gwc
+}
+
+// Namespace creates namespace using the provided client and returns it.
+func Namespace(ctx context.Context, t *testing.T, cl client.Client) *corev1.Namespace {
+	t.Helper()
+
+	labelOpts := func(obj client.Object) {
+		ns, ok := obj.(*corev1.Namespace)
+		if !ok {
+			t.Fatalf("expected *corev1.Namespace, got %T", obj)
+		}
+		ns.Labels = map[string]string{
+			"test": "envtest",
+		}
+
+	}
+	return deploy.Namespace(t, ctx, cl, labelOpts)
+}
+
+// GatewayUsingGatewayClass deploys a Gateway, GatewayClass
+// and an ingress service for use in tests.
+func GatewayUsingGatewayClass(ctx context.Context, t *testing.T, client client.Client, gwc gatewayapi.GatewayClass) gatewayapi.Gateway {
+	ns := Namespace(ctx, t, client)
+
+	publishSvc := corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: ns.Name,
+			Name:      PublishServiceName,
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: builder.NewServicePort().
+				WithName("http").
+				WithProtocol(corev1.ProtocolTCP).
+				WithPort(8000).
+				IntoSlice(),
+		},
+	}
+	require.NoError(t, client.Create(ctx, &publishSvc))
+	t.Cleanup(func() { _ = client.Delete(ctx, &publishSvc) })
+
+	gw := gatewayapi.Gateway{
+		Spec: gatewayapi.GatewaySpec{
+			GatewayClassName: gatewayapi.ObjectName(gwc.Name),
+			Listeners: []gatewayapi.Listener{
+				{
+					Name:          "http",
+					Protocol:      gatewayapi.HTTPProtocolType,
+					Port:          gatewayapi.PortNumber(8000),
+					AllowedRoutes: builder.NewAllowedRoutesFromAllNamespaces(),
+				},
+			},
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:    ns.Name,
+			GenerateName: "gw-",
+		},
+	}
+	require.NoError(t, client.Create(ctx, &gw))
+	t.Cleanup(func() { _ = client.Delete(ctx, &gw) })
+
+	return gw
+}

--- a/test/envtest/create/httproute.go
+++ b/test/envtest/create/httproute.go
@@ -1,0 +1,84 @@
+package create
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	ctrlclient "sigs.k8s.io/controller-runtime/pkg/client"
+
+	"github.com/kong/kong-operator/v2/ingress-controller/test/gatewayapi"
+	"github.com/kong/kong-operator/v2/ingress-controller/test/util"
+)
+
+// HTTPRoutes creates a number of dummy HTTPRoutes for the given Gateway.
+func HTTPRoutes(
+	ctx context.Context,
+	t *testing.T,
+	ctrlClient ctrlclient.Client,
+	gw gatewayapi.Gateway,
+	numOfRoutes int,
+) []*gatewayapi.HTTPRoute {
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "backend-svc",
+			Namespace: gw.Namespace,
+		},
+		Spec: corev1.ServiceSpec{
+			Ports: []corev1.ServicePort{
+				{
+					Name:     "http",
+					Protocol: corev1.ProtocolTCP,
+					Port:     80,
+				},
+			},
+		},
+	}
+	require.NoError(t, ctrlClient.Create(ctx, svc))
+	t.Cleanup(func() { _ = ctrlClient.Delete(ctx, svc) })
+
+	routes := make([]*gatewayapi.HTTPRoute, 0, numOfRoutes)
+	for range numOfRoutes {
+		httpPort := gatewayapi.PortNumber(80)
+		pathMatchPrefix := gatewayapi.PathMatchPathPrefix
+		httpRoute := &gatewayapi.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				GenerateName: "httproute-",
+				Namespace:    gw.Namespace,
+			},
+			Spec: gatewayapi.HTTPRouteSpec{
+				CommonRouteSpec: gatewayapi.CommonRouteSpec{
+					ParentRefs: []gatewayapi.ParentReference{{
+						Name: gatewayapi.ObjectName(gw.Name),
+					}},
+				},
+				Rules: []gatewayapi.HTTPRouteRule{{
+					Matches: []gatewayapi.HTTPRouteMatch{
+						{
+							Path: &gatewayapi.HTTPPathMatch{
+								Type:  &pathMatchPrefix,
+								Value: new("/test-http-route"),
+							},
+						},
+					},
+					BackendRefs: []gatewayapi.HTTPBackendRef{{
+						BackendRef: gatewayapi.BackendRef{
+							BackendObjectReference: gatewayapi.BackendObjectReference{
+								Name: gatewayapi.ObjectName("backend-svc"),
+								Port: &httpPort,
+								Kind: util.StringToGatewayAPIKindPtr("Service"),
+							},
+						},
+					}},
+				}},
+			},
+		}
+
+		require.NoError(t, ctrlClient.Create(ctx, httpRoute))
+		t.Cleanup(func() { _ = ctrlClient.Delete(ctx, httpRoute) })
+		routes = append(routes, httpRoute)
+	}
+	return routes
+}

--- a/test/envtest/errors.go
+++ b/test/envtest/errors.go
@@ -1,19 +1,8 @@
 package envtest
 
+import "github.com/kong/kong-operator/v2/test/envtest/consts"
+
 const (
 	// ErrBodyDataConstraintError is a JSON error response body for a data constraint error.
-	ErrBodyDataConstraintError = `{
-			"code": 3,
-			"message": "data constraint error",
-			"details": [
-				{
-					"@type": "type.googleapis.com/kong.admin.model.v1.ErrorDetail",
-					"type": "ERROR_TYPE_REFERENCE",
-					"field": "name",
-					"messages": [
-						"name (type: unique) constraint failed"
-					]
-				}
-			]
-		}`
+	ErrBodyDataConstraintError = consts.ErrBodyDataConstraintError
 )

--- a/test/envtest/gateway/gateway_envtest_test.go
+++ b/test/envtest/gateway/gateway_envtest_test.go
@@ -20,12 +20,13 @@ import (
 	kogateway "github.com/kong/kong-operator/v2/controller/gateway"
 	secretcert "github.com/kong/kong-operator/v2/controller/secret_cert"
 	"github.com/kong/kong-operator/v2/ingress-controller/test/gatewayapi"
-	"github.com/kong/kong-operator/v2/ingress-controller/test/util"
 	gwtypes "github.com/kong/kong-operator/v2/internal/types"
 	managerscheme "github.com/kong/kong-operator/v2/modules/manager/scheme"
 	"github.com/kong/kong-operator/v2/pkg/consts"
 	testutils "github.com/kong/kong-operator/v2/pkg/utils/test"
 	"github.com/kong/kong-operator/v2/pkg/vars"
+	"github.com/kong/kong-operator/v2/test/envtest"
+	"github.com/kong/kong-operator/v2/test/envtest/create"
 	certhelper "github.com/kong/kong-operator/v2/test/helpers/certificate"
 )
 
@@ -34,19 +35,19 @@ func TestGatewayAddressOverride(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
-	scheme := Scheme(t, WithGatewayAPI, WithKong)
-	envcfg, _ := Setup(t, ctx, scheme, WithInstallGatewayCRDs(true))
-	ctrlClient := NewControllerClient(t, scheme, envcfg)
+	scheme := envtest.Scheme(t, envtest.WithGatewayAPI, envtest.WithKong)
+	envcfg, _ := envtest.Setup(t, ctx, scheme, envtest.WithInstallGatewayCRDs(true))
+	ctrlClient := envtest.NewControllerClient(t, scheme, envcfg)
 
 	expected := []string{"10.0.0.1", "10.0.0.2"}
 	udp := []string{"10.0.0.3", "10.0.0.4"}
-	gw, _ := deployGateway(ctx, t, ctrlClient)
-	RunManager(ctx, t, envcfg,
-		AdminAPIOptFns(),
-		WithPublishService(gw.Namespace),
-		WithPublishStatusAddress(expected, udp),
-		WithGatewayFeatureEnabled,
-		WithGatewayAPIControllers(),
+	gw, _ := create.Gateway(ctx, t, ctrlClient)
+	envtest.RunManager(ctx, t, envcfg,
+		envtest.AdminAPIOptFns(),
+		envtest.WithPublishService(gw.Namespace),
+		envtest.WithPublishStatusAddress(expected, udp),
+		envtest.WithGatewayFeatureEnabled,
+		envtest.WithGatewayAPIControllers(),
 	)
 
 	allExpected := slices.Concat(expected, udp)
@@ -84,20 +85,20 @@ func TestGatewayReconciliation_MoreThan100Routes(t *testing.T) {
 
 	ctx, cancel := context.WithCancel(t.Context())
 	defer cancel()
-	scheme := Scheme(t, WithGatewayAPI, WithKong)
-	envcfg, _ := Setup(t, ctx, scheme, WithInstallGatewayCRDs(true))
-	ctrlClient := NewControllerClient(t, scheme, envcfg)
+	scheme := envtest.Scheme(t, envtest.WithGatewayAPI, envtest.WithKong)
+	envcfg, _ := envtest.Setup(t, ctx, scheme, envtest.WithInstallGatewayCRDs(true))
+	ctrlClient := envtest.NewControllerClient(t, scheme, envcfg)
 
-	gw, _ := deployGateway(ctx, t, ctrlClient)
-	RunManager(ctx, t, envcfg,
-		AdminAPIOptFns(),
-		WithPublishService(gw.Namespace),
-		WithGatewayFeatureEnabled,
-		WithGatewayAPIControllers(),
+	gw, _ := create.Gateway(ctx, t, ctrlClient)
+	envtest.RunManager(ctx, t, envcfg,
+		envtest.AdminAPIOptFns(),
+		envtest.WithPublishService(gw.Namespace),
+		envtest.WithGatewayFeatureEnabled,
+		envtest.WithGatewayAPIControllers(),
 	)
 
 	const numOfRoutes = 120
-	createHTTPRoutes(ctx, t, ctrlClient, gw, numOfRoutes)
+	create.HTTPRoutes(ctx, t, ctrlClient, gw, numOfRoutes)
 
 	require.Eventually(t, func() bool {
 		err := ctrlClient.Get(ctx, k8stypes.NamespacedName{Namespace: gw.Namespace, Name: gw.Name}, &gw)
@@ -118,76 +119,6 @@ func TestGatewayReconciliation_MoreThan100Routes(t *testing.T) {
 		}
 		return true
 	}, waitTime, tickTime, "failed to reconcile all HTTPRoutes")
-}
-
-// createHTTPRoutes creates a number of dummy HTTPRoutes for the given Gateway.
-func createHTTPRoutes(
-	ctx context.Context,
-	t *testing.T,
-	ctrlClient ctrlclient.Client,
-	gw gatewayapi.Gateway,
-	numOfRoutes int,
-) []*gatewayapi.HTTPRoute {
-	svc := &corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "backend-svc",
-			Namespace: gw.Namespace,
-		},
-		Spec: corev1.ServiceSpec{
-			Ports: []corev1.ServicePort{
-				{
-					Name:     "http",
-					Protocol: corev1.ProtocolTCP,
-					Port:     80,
-				},
-			},
-		},
-	}
-	require.NoError(t, ctrlClient.Create(ctx, svc))
-	t.Cleanup(func() { _ = ctrlClient.Delete(ctx, svc) })
-
-	routes := make([]*gatewayapi.HTTPRoute, 0, numOfRoutes)
-	for range numOfRoutes {
-		httpPort := gatewayapi.PortNumber(80)
-		pathMatchPrefix := gatewayapi.PathMatchPathPrefix
-		httpRoute := &gatewayapi.HTTPRoute{
-			ObjectMeta: metav1.ObjectMeta{
-				GenerateName: "httproute-",
-				Namespace:    gw.Namespace,
-			},
-			Spec: gatewayapi.HTTPRouteSpec{
-				CommonRouteSpec: gatewayapi.CommonRouteSpec{
-					ParentRefs: []gatewayapi.ParentReference{{
-						Name: gatewayapi.ObjectName(gw.Name),
-					}},
-				},
-				Rules: []gatewayapi.HTTPRouteRule{{
-					Matches: []gatewayapi.HTTPRouteMatch{
-						{
-							Path: &gatewayapi.HTTPPathMatch{
-								Type:  &pathMatchPrefix,
-								Value: new("/test-http-route"),
-							},
-						},
-					},
-					BackendRefs: []gatewayapi.HTTPBackendRef{{
-						BackendRef: gatewayapi.BackendRef{
-							BackendObjectReference: gatewayapi.BackendObjectReference{
-								Name: gatewayapi.ObjectName("backend-svc"),
-								Port: &httpPort,
-								Kind: util.StringToGatewayAPIKindPtr("Service"),
-							},
-						},
-					}},
-				}},
-			},
-		}
-
-		require.NoError(t, ctrlClient.Create(ctx, httpRoute))
-		t.Cleanup(func() { _ = ctrlClient.Delete(ctx, httpRoute) })
-		routes = append(routes, httpRoute)
-	}
-	return routes
 }
 
 // TestGatewayInfrastructureLabels verifies that labels and annotations set in
@@ -211,8 +142,8 @@ func TestGatewayInfrastructureLabels(t *testing.T) {
 	defer cancel()
 
 	scheme := managerscheme.Get()
-	envcfg, ns := Setup(t, ctx, scheme, WithInstallGatewayCRDs(true))
-	mgr, logs := NewManager(t, ctx, envcfg, scheme)
+	envcfg, ns := envtest.Setup(t, ctx, scheme, envtest.WithInstallGatewayCRDs(true))
+	mgr, logs := envtest.NewManager(t, ctx, envcfg, scheme)
 	c := mgr.GetClient()
 
 	// Create the cluster CA secret required by the DataPlane reconciler.
@@ -237,7 +168,7 @@ func TestGatewayInfrastructureLabels(t *testing.T) {
 	t.Cleanup(func() { _ = c.Delete(ctx, caSecret) })
 
 	// Start KO Gateway and DataPlane reconcilers.
-	StartReconcilers(ctx, t, mgr, logs,
+	envtest.StartReconcilers(ctx, t, mgr, logs,
 		&kogateway.Reconciler{
 			Client:                c,
 			Scheme:                scheme,

--- a/test/envtest/gateway/gateway_grpcroute_envtest_test.go
+++ b/test/envtest/gateway/gateway_grpcroute_envtest_test.go
@@ -16,6 +16,7 @@ import (
 	managerscheme "github.com/kong/kong-operator/v2/modules/manager/scheme"
 	testutils "github.com/kong/kong-operator/v2/pkg/utils/test"
 	"github.com/kong/kong-operator/v2/pkg/vars"
+	"github.com/kong/kong-operator/v2/test/envtest"
 )
 
 func TestGatewayGRPCRouteAttachedRoutes(t *testing.T) {
@@ -29,8 +30,8 @@ func TestGatewayGRPCRouteAttachedRoutes(t *testing.T) {
 	ctx := t.Context()
 	scheme := managerscheme.Get()
 
-	cfg, ns := Setup(t, ctx, scheme, WithInstallGatewayCRDs(true))
-	mgr, logs := NewManager(t, ctx, cfg, scheme)
+	cfg, ns := envtest.Setup(t, ctx, scheme, envtest.WithInstallGatewayCRDs(true))
+	mgr, logs := envtest.NewManager(t, ctx, cfg, scheme)
 
 	r := &kogateway.Reconciler{
 		Client:                mgr.GetClient(),
@@ -38,7 +39,7 @@ func TestGatewayGRPCRouteAttachedRoutes(t *testing.T) {
 		Namespace:             ns.Name,
 		DefaultDataPlaneImage: "kong:latest",
 	}
-	StartReconcilers(ctx, t, mgr, logs, r)
+	envtest.StartReconcilers(ctx, t, mgr, logs, r)
 
 	c := mgr.GetClient()
 

--- a/test/envtest/gateway/gateway_konnect_auth_referencegrant_envtest_test.go
+++ b/test/envtest/gateway/gateway_konnect_auth_referencegrant_envtest_test.go
@@ -15,6 +15,8 @@ import (
 	managerscheme "github.com/kong/kong-operator/v2/modules/manager/scheme"
 	testutils "github.com/kong/kong-operator/v2/pkg/utils/test"
 	"github.com/kong/kong-operator/v2/pkg/vars"
+	"github.com/kong/kong-operator/v2/test/envtest"
+	"github.com/kong/kong-operator/v2/test/envtest/consts"
 	"github.com/kong/kong-operator/v2/test/helpers/deploy"
 )
 
@@ -24,8 +26,8 @@ func TestGatewayKonnectAPIAuthReferenceGrant(t *testing.T) {
 	scheme := managerscheme.Get()
 	ctx := t.Context()
 
-	cfg, gwNs := Setup(t, ctx, scheme, WithInstallGatewayCRDs(true))
-	mgr, logs := NewManager(t, ctx, cfg, scheme)
+	cfg, gwNs := envtest.Setup(t, ctx, scheme, envtest.WithInstallGatewayCRDs(true))
+	mgr, logs := envtest.NewManager(t, ctx, cfg, scheme)
 
 	r := &kogateway.Reconciler{
 		Client:                mgr.GetClient(),
@@ -33,7 +35,7 @@ func TestGatewayKonnectAPIAuthReferenceGrant(t *testing.T) {
 		Namespace:             gwNs.Name,
 		DefaultDataPlaneImage: "kong:latest",
 	}
-	StartReconcilers(ctx, t, mgr, logs, r)
+	envtest.StartReconcilers(ctx, t, mgr, logs, r)
 
 	c := mgr.GetClient()
 
@@ -57,7 +59,7 @@ func TestGatewayKonnectAPIAuthReferenceGrant(t *testing.T) {
 	t.Cleanup(func() { _ = c.Delete(ctx, gc) })
 
 	t.Log("patching GatewayClass status to Accepted=True")
-	require.Eventually(t, testutils.GatewayClassAcceptedStatusUpdate(t, ctx, gc.Name, c), waitTime, tickTime)
+	require.Eventually(t, testutils.GatewayClassAcceptedStatusUpdate(t, ctx, gc.Name, c), consts.WaitTime, consts.TickTime)
 
 	// Create a Gateway that uses the GatewayClass.
 	gw := deploy.Gateway(t, ctx, c,
@@ -82,7 +84,7 @@ func TestGatewayKonnectAPIAuthReferenceGrant(t *testing.T) {
 				}
 			}
 			return false
-		}, waitTime, tickTime, "derived KonnectGatewayControlPlane grant should not exist without user grant")
+		}, consts.WaitTime, consts.TickTime, "derived KonnectGatewayControlPlane grant should not exist without user grant")
 	})
 
 	t.Run("derived grant is created after user creates KongReferenceGrant", func(t *testing.T) {
@@ -119,7 +121,7 @@ func TestGatewayKonnectAPIAuthReferenceGrant(t *testing.T) {
 				}
 			}
 			return false
-		}, waitTime, tickTime, "derived KonnectGatewayControlPlane grant should be created")
+		}, consts.WaitTime, consts.TickTime, "derived KonnectGatewayControlPlane grant should be created")
 
 		t.Run("derived grant is removed after user deletes KongReferenceGrant", func(t *testing.T) {
 			t.Log("deleting user KongReferenceGrant")
@@ -138,7 +140,7 @@ func TestGatewayKonnectAPIAuthReferenceGrant(t *testing.T) {
 					}
 				}
 				return true
-			}, waitTime, tickTime, "derived grant should be cleaned up after user grant is deleted")
+			}, consts.WaitTime, consts.TickTime, "derived grant should be cleaned up after user grant is deleted")
 		})
 	})
 
@@ -176,7 +178,7 @@ func TestGatewayKonnectAPIAuthReferenceGrant(t *testing.T) {
 				}
 			}
 			return false
-		}, waitTime, tickTime, "derived grant should be created when user grant allows any auth name")
+		}, consts.WaitTime, consts.TickTime, "derived grant should be created when user grant allows any auth name")
 
 		t.Log("cleaning up user grant for next sub-test")
 		require.NoError(t, c.Delete(ctx, userGrant))
@@ -192,7 +194,7 @@ func TestGatewayKonnectAPIAuthReferenceGrant(t *testing.T) {
 				}
 			}
 			return true
-		}, waitTime, tickTime, "derived grant should be cleaned up")
+		}, consts.WaitTime, consts.TickTime, "derived grant should be cleaned up")
 	})
 }
 
@@ -218,8 +220,8 @@ func TestGatewayKonnectAPIAuthReferenceGrant_CleanupOnGatewayDeletion(t *testing
 	scheme := managerscheme.Get()
 	ctx := t.Context()
 
-	cfg, gwNs := Setup(t, ctx, scheme, WithInstallGatewayCRDs(true))
-	mgr, logs := NewManager(t, ctx, cfg, scheme)
+	cfg, gwNs := envtest.Setup(t, ctx, scheme, envtest.WithInstallGatewayCRDs(true))
+	mgr, logs := envtest.NewManager(t, ctx, cfg, scheme)
 
 	r := &kogateway.Reconciler{
 		Client:                mgr.GetClient(),
@@ -227,7 +229,7 @@ func TestGatewayKonnectAPIAuthReferenceGrant_CleanupOnGatewayDeletion(t *testing
 		Namespace:             gwNs.Name,
 		DefaultDataPlaneImage: "kong:latest",
 	}
-	StartReconcilers(ctx, t, mgr, logs, r)
+	envtest.StartReconcilers(ctx, t, mgr, logs, r)
 
 	c := mgr.GetClient()
 	authNs := deploy.Namespace(t, ctx, c)
@@ -246,7 +248,7 @@ func TestGatewayKonnectAPIAuthReferenceGrant_CleanupOnGatewayDeletion(t *testing
 	t.Cleanup(func() { _ = c.Delete(ctx, gc) })
 
 	t.Log("patching GatewayClass status to Accepted=True")
-	require.Eventually(t, testutils.GatewayClassAcceptedStatusUpdate(t, ctx, gc.Name, c), waitTime, tickTime)
+	require.Eventually(t, testutils.GatewayClassAcceptedStatusUpdate(t, ctx, gc.Name, c), consts.WaitTime, consts.TickTime)
 
 	// Create user KongReferenceGrant first.
 	userGrant := deploy.KongReferenceGrant(t, ctx, c,
@@ -287,7 +289,7 @@ func TestGatewayKonnectAPIAuthReferenceGrant_CleanupOnGatewayDeletion(t *testing
 			}
 		}
 		return false
-	}, waitTime, tickTime, "derived grant should exist")
+	}, consts.WaitTime, consts.TickTime, "derived grant should exist")
 
 	t.Log("deleting Gateway to trigger cleanup")
 	require.NoError(t, c.Delete(ctx, gw))
@@ -308,6 +310,6 @@ func TestGatewayKonnectAPIAuthReferenceGrant_CleanupOnGatewayDeletion(t *testing
 			}
 		}
 		return true
-	}, waitTime, tickTime, "derived grant should be cleaned up after Gateway deletion")
+	}, consts.WaitTime, consts.TickTime, "derived grant should be cleaned up after Gateway deletion")
 
 }

--- a/test/envtest/gateway/gateway_secret_watch_envtest_test.go
+++ b/test/envtest/gateway/gateway_secret_watch_envtest_test.go
@@ -14,6 +14,8 @@ import (
 	managerscheme "github.com/kong/kong-operator/v2/modules/manager/scheme"
 	testutils "github.com/kong/kong-operator/v2/pkg/utils/test"
 	"github.com/kong/kong-operator/v2/pkg/vars"
+	"github.com/kong/kong-operator/v2/test/envtest"
+	"github.com/kong/kong-operator/v2/test/envtest/consts"
 	certhelper "github.com/kong/kong-operator/v2/test/helpers/certificate"
 )
 
@@ -24,8 +26,8 @@ func TestGatewaySecretWatch_UpdatesResolvedRefsOnSecretRotation(t *testing.T) {
 	scheme := managerscheme.Get()
 	ctx := t.Context()
 
-	cfg, ns := Setup(t, ctx, scheme, WithInstallGatewayCRDs(true))
-	mgr, logs := NewManager(t, ctx, cfg, scheme)
+	cfg, ns := envtest.Setup(t, ctx, scheme, envtest.WithInstallGatewayCRDs(true))
+	mgr, logs := envtest.NewManager(t, ctx, cfg, scheme)
 
 	r := &kogateway.Reconciler{
 		Client:                mgr.GetClient(),
@@ -33,7 +35,7 @@ func TestGatewaySecretWatch_UpdatesResolvedRefsOnSecretRotation(t *testing.T) {
 		Namespace:             ns.Name,
 		DefaultDataPlaneImage: "kong:latest",
 	}
-	StartReconcilers(ctx, t, mgr, logs, r)
+	envtest.StartReconcilers(ctx, t, mgr, logs, r)
 
 	c := mgr.GetClient()
 
@@ -47,7 +49,7 @@ func TestGatewaySecretWatch_UpdatesResolvedRefsOnSecretRotation(t *testing.T) {
 	require.NoError(t, c.Create(ctx, gc))
 
 	t.Log("patching GatewayClass status to Accepted=True")
-	require.Eventually(t, testutils.GatewayClassAcceptedStatusUpdate(t, ctx, gc.Name, c), waitTime, tickTime)
+	require.Eventually(t, testutils.GatewayClassAcceptedStatusUpdate(t, ctx, gc.Name, c), consts.WaitTime, consts.TickTime)
 
 	// Create an initial INVALID TLS Secret referenced by the Gateway listener.
 	secretName := "test-cert"
@@ -85,7 +87,7 @@ func TestGatewaySecretWatch_UpdatesResolvedRefsOnSecretRotation(t *testing.T) {
 
 	t.Log("verifying that the invalid Secret results in ResolvedRefs=False (InvalidCertificateRef)")
 	gwNN := types.NamespacedName{Namespace: ns.Name, Name: gw.Name}
-	require.Eventually(t, testutils.GatewayListenerResolvedRefsCondition(t, ctx, gwNN, c, metav1.ConditionFalse), waitTime, tickTime)
+	require.Eventually(t, testutils.GatewayListenerResolvedRefsCondition(t, ctx, gwNN, c, metav1.ConditionFalse), consts.WaitTime, consts.TickTime)
 
 	t.Log("rotating the Secret with a valid TLS certificate and key")
 	certPEM, keyPEM := certhelper.MustGenerateCertPEMFormat()
@@ -99,5 +101,5 @@ func TestGatewaySecretWatch_UpdatesResolvedRefsOnSecretRotation(t *testing.T) {
 	}, client.MergeFrom(bad)))
 
 	t.Log("verifying that after rotation the Secret watch enqueues the Gateway and ResolvedRefs becomes True")
-	require.Eventually(t, testutils.GatewayListenerResolvedRefsCondition(t, ctx, gwNN, c, metav1.ConditionTrue), waitTime, tickTime)
+	require.Eventually(t, testutils.GatewayListenerResolvedRefsCondition(t, ctx, gwNN, c, metav1.ConditionTrue), consts.WaitTime, consts.TickTime)
 }

--- a/test/envtest/gateway/gatewayclass_envtest_test.go
+++ b/test/envtest/gateway/gatewayclass_envtest_test.go
@@ -23,6 +23,8 @@ import (
 	"github.com/kong/kong-operator/v2/ingress-controller/test/helpers/conditions"
 	"github.com/kong/kong-operator/v2/ingress-controller/test/mocks"
 	"github.com/kong/kong-operator/v2/ingress-controller/test/util/builder"
+	"github.com/kong/kong-operator/v2/test/envtest"
+	"github.com/kong/kong-operator/v2/test/envtest/create"
 	"github.com/kong/kong-operator/v2/test/helpers/asserts"
 )
 
@@ -36,7 +38,7 @@ type testcaseGatewayWithGatewayClassReconciliation struct {
 		cl client.Client,
 		gwc gatewayapi.GatewayClass,
 		gw gatewayapi.Gateway,
-		ns corev1.Namespace,
+		ns *corev1.Namespace,
 	)
 }
 
@@ -53,8 +55,8 @@ func TestGatewayWithGatewayClassReconciliation(t *testing.T) {
 	)
 
 	ctx := t.Context()
-	scheme := Scheme(t, WithGatewayAPI)
-	cfg, _ := Setup(t, ctx, scheme, WithInstallGatewayCRDs(true))
+	scheme := envtest.Scheme(t, envtest.WithGatewayAPI)
+	cfg, _ := envtest.Setup(t, ctx, scheme, envtest.WithInstallGatewayCRDs(true))
 
 	testcases := []testcaseGatewayWithGatewayClassReconciliation{
 		{
@@ -86,7 +88,7 @@ func TestGatewayWithGatewayClassReconciliation(t *testing.T) {
 				cl client.Client,
 				gwc gatewayapi.GatewayClass,
 				gw gatewayapi.Gateway,
-				ns corev1.Namespace,
+				ns *corev1.Namespace,
 			) {
 				t.Logf("deploying gateway class %s", gwc.Name)
 				require.NoError(t, cl.Create(ctx, &gwc))
@@ -156,7 +158,7 @@ func TestGatewayWithGatewayClassReconciliation(t *testing.T) {
 				cl client.Client,
 				gwc gatewayapi.GatewayClass,
 				gw gatewayapi.Gateway,
-				ns corev1.Namespace,
+				ns *corev1.Namespace,
 			) {
 				t.Logf("verifying that the Gateway %s does not get scheduled by the controller due to missing its GatewayClass", gw.Name)
 				// NOTE: Ideally we wouldn't like to perform a busy wait loop here,
@@ -246,7 +248,7 @@ func TestGatewayWithGatewayClassReconciliation(t *testing.T) {
 				cl client.Client,
 				gwc gatewayapi.GatewayClass,
 				gw gatewayapi.Gateway,
-				ns corev1.Namespace,
+				ns *corev1.Namespace,
 			) {
 				t.Logf("verifying that the Gateway %s does not get scheduled by the controller due to missing its GatewayClass", gw.Name)
 				// NOTE: Ideally we wouldn't like to perform a busy wait loop here,
@@ -349,8 +351,8 @@ func testGatewayWithGatewayClassReconciliation(
 			}
 			defer cancel()
 
-			cl := NewControllerClient(t, scheme, cfg)
-			ns := CreateNamespace(ctx, t, cl)
+			cl := envtest.NewControllerClient(t, scheme, cfg)
+			ns := create.Namespace(ctx, t, cl)
 			clNamespaced := client.NewNamespacedClient(cl, ns.Name)
 
 			svc := corev1.Service{
@@ -379,7 +381,7 @@ func testGatewayWithGatewayClassReconciliation(
 				DataplaneClient:   mocks.Dataplane{},
 				ReferenceIndexers: ctrlref.NewCacheIndexers(logr.Discard()),
 			}
-			StartReconciler(ctx, t, scheme, cfg, gwReconciler, WithWatchNamespace(ns.Name))
+			envtest.StartReconciler(ctx, t, scheme, cfg, gwReconciler, envtest.WithWatchNamespace(ns.Name))
 
 			t.Logf("deploying gateway %s using %s gateway class", tc.Gateway.Name, tc.GatewayClass.Name)
 			tc.Gateway.Namespace = ns.Name

--- a/test/envtest/k8s_objects_status_envtest_test.go
+++ b/test/envtest/k8s_objects_status_envtest_test.go
@@ -15,6 +15,7 @@ import (
 	managercfg "github.com/kong/kong-operator/v2/ingress-controller/pkg/manager/config"
 	"github.com/kong/kong-operator/v2/ingress-controller/test/gatewayapi"
 	"github.com/kong/kong-operator/v2/ingress-controller/test/util/builder"
+	"github.com/kong/kong-operator/v2/test/envtest/create"
 	"github.com/kong/kong-operator/v2/test/helpers/asserts"
 )
 
@@ -27,7 +28,7 @@ func TestHTTPRouteReconciliation_DoesNotBlockSyncLoopWhenStatusQueueBufferIsExce
 	envcfg, _ := Setup(t, ctx, scheme, WithInstallGatewayCRDs(true))
 	ctrlClient := NewControllerClient(t, scheme, envcfg)
 
-	gw, _ := deployGateway(ctx, t, ctrlClient)
+	gw, _ := create.Gateway(ctx, t, ctrlClient)
 	RunManager(ctx, t, envcfg,
 		AdminAPIOptFns(),
 		WithPublishService(gw.Namespace),
@@ -125,7 +126,7 @@ func Test_WatchNamespaces(t *testing.T) {
 	scheme := Scheme(t, WithGatewayAPI)
 	envcfg, _ := Setup(t, ctx, scheme, WithInstallGatewayCRDs(true))
 	ctrlClient := NewControllerClient(t, scheme, envcfg)
-	gw, _ := deployGateway(ctx, t, ctrlClient)
+	gw, _ := create.Gateway(ctx, t, ctrlClient)
 	hidden := CreateNamespace(ctx, t, ctrlClient)
 	RunManager(ctx, t, envcfg,
 		AdminAPIOptFns(),

--- a/test/envtest/kongplugincleanupfinalizer_test.go
+++ b/test/envtest/kongplugincleanupfinalizer_test.go
@@ -55,13 +55,13 @@ func TestKongPluginFinalizer(t *testing.T) {
 			require.NoError(t, clientNamespaced.Delete(ctx, rateLimitingkongPlugin))
 		})
 
-		wKongService := setupWatch[configurationv1alpha1.KongServiceList](t, ctx, clientWithWatch, client.InNamespace(ns.Name))
+		wKongService := SetupWatch[configurationv1alpha1.KongServiceList](t, ctx, clientWithWatch, client.InNamespace(ns.Name))
 		kongService := deploy.KongService(t, ctx, clientNamespaced,
 			deploy.WithKonnectNamespacedRefControlPlaneRef(cp),
 			deploy.WithAnnotation(metadata.AnnotationKeyPlugins, rateLimitingkongPlugin.Name),
 		)
 
-		_ = watchFor(t, ctx, wKongService, apiwatch.Modified,
+		_ = WatchFor(t, ctx, wKongService, apiwatch.Modified,
 			func(svc *configurationv1alpha1.KongService) bool {
 				return svc.Name == kongService.Name &&
 					slices.Contains(svc.GetFinalizers(), consts.CleanupPluginBindingFinalizer)
@@ -72,7 +72,7 @@ func TestKongPluginFinalizer(t *testing.T) {
 		old := kongService.DeepCopy()
 		kongService.Annotations = nil
 		require.NoError(t, clientNamespaced.Patch(ctx, kongService, client.MergeFrom(old)))
-		_ = watchFor(t, ctx, wKongService, apiwatch.Modified,
+		_ = WatchFor(t, ctx, wKongService, apiwatch.Modified,
 			func(svc *configurationv1alpha1.KongService) bool {
 				return svc.Name == kongService.Name &&
 					!slices.Contains(svc.GetFinalizers(), consts.CleanupPluginBindingFinalizer)
@@ -90,14 +90,14 @@ func TestKongPluginFinalizer(t *testing.T) {
 		kongService := deploy.KongService(t, ctx, clientNamespaced,
 			deploy.WithKonnectNamespacedRefControlPlaneRef(cp),
 		)
-		wKongRoute := setupWatch[configurationv1alpha1.KongRouteList](t, ctx, clientWithWatch, client.InNamespace(ns.Name))
+		wKongRoute := SetupWatch[configurationv1alpha1.KongRouteList](t, ctx, clientWithWatch, client.InNamespace(ns.Name))
 		kongRoute := deploy.KongRoute(
 			t, ctx, clientNamespaced,
 			deploy.WithNamespacedKongServiceRef(kongService),
 			deploy.WithAnnotation(metadata.AnnotationKeyPlugins, rateLimitingkongPlugin.Name),
 		)
 
-		_ = watchFor(t, ctx, wKongRoute, apiwatch.Modified,
+		_ = WatchFor(t, ctx, wKongRoute, apiwatch.Modified,
 			func(route *configurationv1alpha1.KongRoute) bool {
 				return route.Name == kongRoute.Name &&
 					slices.Contains(route.GetFinalizers(), consts.CleanupPluginBindingFinalizer)
@@ -108,7 +108,7 @@ func TestKongPluginFinalizer(t *testing.T) {
 		old := kongRoute.DeepCopy()
 		kongRoute.Annotations = nil
 		require.NoError(t, clientNamespaced.Patch(ctx, kongRoute, client.MergeFrom(old)))
-		_ = watchFor(t, ctx, wKongRoute, apiwatch.Modified,
+		_ = WatchFor(t, ctx, wKongRoute, apiwatch.Modified,
 			func(route *configurationv1alpha1.KongRoute) bool {
 				return route.Name == kongRoute.Name &&
 					!slices.Contains(route.GetFinalizers(), consts.CleanupPluginBindingFinalizer)
@@ -123,13 +123,13 @@ func TestKongPluginFinalizer(t *testing.T) {
 			require.NoError(t, clientNamespaced.Delete(ctx, rateLimitingkongPlugin))
 		})
 
-		wKongConsumer := setupWatch[configurationv1.KongConsumerList](t, ctx, clientWithWatch, client.InNamespace(ns.Name))
+		wKongConsumer := SetupWatch[configurationv1.KongConsumerList](t, ctx, clientWithWatch, client.InNamespace(ns.Name))
 		kongConsumer := deploy.KongConsumer(t, ctx, clientNamespaced, "username-1",
 			deploy.WithKonnectNamespacedRefControlPlaneRef(cp),
 			deploy.WithAnnotation(metadata.AnnotationKeyPlugins, rateLimitingkongPlugin.Name),
 		)
 
-		_ = watchFor(t, ctx, wKongConsumer, apiwatch.Modified,
+		_ = WatchFor(t, ctx, wKongConsumer, apiwatch.Modified,
 			func(c *configurationv1.KongConsumer) bool {
 				return c.Name == kongConsumer.Name &&
 					slices.Contains(c.GetFinalizers(), consts.CleanupPluginBindingFinalizer)
@@ -140,7 +140,7 @@ func TestKongPluginFinalizer(t *testing.T) {
 		old := kongConsumer.DeepCopy()
 		kongConsumer.Annotations = nil
 		require.NoError(t, clientNamespaced.Patch(ctx, kongConsumer, client.MergeFrom(old)))
-		_ = watchFor(t, ctx, wKongConsumer, apiwatch.Modified,
+		_ = WatchFor(t, ctx, wKongConsumer, apiwatch.Modified,
 			func(c *configurationv1.KongConsumer) bool {
 				return c.Name == kongConsumer.Name &&
 					!slices.Contains(c.GetFinalizers(), consts.CleanupPluginBindingFinalizer)
@@ -155,13 +155,13 @@ func TestKongPluginFinalizer(t *testing.T) {
 			require.NoError(t, clientNamespaced.Delete(ctx, rateLimitingkongPlugin))
 		})
 
-		wKongConsumerGroup := setupWatch[configurationv1beta1.KongConsumerGroupList](t, ctx, clientWithWatch, client.InNamespace(ns.Name))
+		wKongConsumerGroup := SetupWatch[configurationv1beta1.KongConsumerGroupList](t, ctx, clientWithWatch, client.InNamespace(ns.Name))
 		kongConsumerGroup := deploy.KongConsumerGroupAttachedToCP(t, ctx, clientNamespaced,
 			deploy.WithKonnectNamespacedRefControlPlaneRef(cp),
 			deploy.WithAnnotation(metadata.AnnotationKeyPlugins, rateLimitingkongPlugin.Name),
 		)
 
-		_ = watchFor(t, ctx, wKongConsumerGroup, apiwatch.Modified,
+		_ = WatchFor(t, ctx, wKongConsumerGroup, apiwatch.Modified,
 			func(cg *configurationv1beta1.KongConsumerGroup) bool {
 				return cg.Name == kongConsumerGroup.Name &&
 					slices.Contains(cg.GetFinalizers(), consts.CleanupPluginBindingFinalizer)
@@ -172,7 +172,7 @@ func TestKongPluginFinalizer(t *testing.T) {
 		old := kongConsumerGroup.DeepCopy()
 		kongConsumerGroup.Annotations = nil
 		require.NoError(t, clientNamespaced.Patch(ctx, kongConsumerGroup, client.MergeFrom(old)))
-		_ = watchFor(t, ctx, wKongConsumerGroup, apiwatch.Modified,
+		_ = WatchFor(t, ctx, wKongConsumerGroup, apiwatch.Modified,
 			func(cg *configurationv1beta1.KongConsumerGroup) bool {
 				return cg.Name == kongConsumerGroup.Name &&
 					!slices.Contains(cg.GetFinalizers(), consts.CleanupPluginBindingFinalizer)

--- a/test/envtest/konnect-api-gw/kongconsumercredential_acl_test.go
+++ b/test/envtest/konnect-api-gw/kongconsumercredential_acl_test.go
@@ -24,20 +24,22 @@ import (
 	"github.com/kong/kong-operator/v2/modules/manager/logging"
 	"github.com/kong/kong-operator/v2/modules/manager/scheme"
 	k8sutils "github.com/kong/kong-operator/v2/pkg/utils/kubernetes"
+	"github.com/kong/kong-operator/v2/test/envtest"
+	"github.com/kong/kong-operator/v2/test/envtest/consts"
 	"github.com/kong/kong-operator/v2/test/helpers/deploy"
 	"github.com/kong/kong-operator/v2/test/mocks/metricsmocks"
 	"github.com/kong/kong-operator/v2/test/mocks/sdkmocks"
 )
 
-func TestKongConsumerCredential_APIKey(t *testing.T) {
+func TestKongConsumerCredential_ACL(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := Context(t, t.Context())
+	ctx, cancel := envtest.Context(t, t.Context())
 	defer cancel()
 
 	// Setup up the envtest environment.
-	cfg, ns := Setup(t, ctx, scheme.Get(), WithInstallGatewayCRDs(true))
+	cfg, ns := envtest.Setup(t, ctx, scheme.Get(), envtest.WithInstallGatewayCRDs(true))
 
-	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())
+	mgr, logs := envtest.NewManager(t, ctx, cfg, scheme.Get())
 
 	cl, err := client.NewWithWatch(mgr.GetConfig(), client.Options{
 		Scheme: scheme.Get(),
@@ -70,110 +72,110 @@ func TestKongConsumerCredential_APIKey(t *testing.T) {
 	}
 	require.NoError(t, clientNamespaced.Status().Update(ctx, consumer))
 
-	kongCredentialAPIKey := deploy.KongCredentialAPIKey(t, ctx, clientNamespaced, consumer.Name)
-	keyID := uuid.NewString()
+	aclGroup := "acl-group1"
+	kongCredentialACL := deploy.KongCredentialACL(t, ctx, clientNamespaced, consumer.Name, aclGroup)
+	aclID := uuid.NewString()
 	tags := []string{
 		"k8s-generation:1",
 		"k8s-group:configuration.konghq.com",
-		"k8s-kind:KongCredentialAPIKey",
-		"k8s-name:" + kongCredentialAPIKey.Name,
+		"k8s-kind:KongCredentialACL",
+		"k8s-name:" + kongCredentialACL.Name,
 		"k8s-namespace:" + ns.Name,
-		"k8s-uid:" + string(kongCredentialAPIKey.GetUID()),
+		"k8s-uid:" + string(kongCredentialACL.GetUID()),
 		"k8s-version:v1alpha1",
 		"managed-by:kong-operator",
 	}
 
 	factory := sdkmocks.NewMockSDKFactory(t)
-	sdk := factory.SDK.KongCredentialsAPIKeySDK
-
+	sdk := factory.SDK.KongCredentialsACLSDK
 	sdk.EXPECT().
-		CreateKeyAuthWithConsumer(
+		CreateACLWithConsumer(
 			mock.Anything,
-			sdkkonnectops.CreateKeyAuthWithConsumerRequest{
+			sdkkonnectops.CreateACLWithConsumerRequest{
 				ControlPlaneID:              cp.GetKonnectStatus().GetKonnectID(),
 				ConsumerIDForNestedEntities: consumerID,
-				KeyAuthWithoutParents: &sdkkonnectcomp.KeyAuthWithoutParents{
-					Key:  new("key"),
-					Tags: tags,
+				ACLWithoutParents: sdkkonnectcomp.ACLWithoutParents{
+					Group: aclGroup,
+					Tags:  tags,
 				},
 			},
 		).
 		Return(
-			&sdkkonnectops.CreateKeyAuthWithConsumerResponse{
-				KeyAuth: &sdkkonnectcomp.KeyAuth{
-					ID: new(keyID),
+			&sdkkonnectops.CreateACLWithConsumerResponse{
+				ACL: &sdkkonnectcomp.ACL{
+					ID: new(aclID),
 				},
 			},
 			nil,
 		)
 	sdk.EXPECT().
-		UpsertKeyAuthWithConsumer(mock.Anything, mock.Anything, mock.Anything).Maybe().
+		UpsertACLWithConsumer(mock.Anything, mock.Anything, mock.Anything).Maybe().
 		Return(
-			&sdkkonnectops.UpsertKeyAuthWithConsumerResponse{
-				KeyAuth: &sdkkonnectcomp.KeyAuth{
-					ID: new(keyID),
+			&sdkkonnectops.UpsertACLWithConsumerResponse{
+				ACL: &sdkkonnectcomp.ACL{
+					ID: new(aclID),
 				},
 			},
 			nil,
 		)
 
-	reconcilers := []Reconciler{
+	reconcilers := []envtest.Reconciler{
 		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
-			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialAPIKey](konnectInfiniteSyncTime),
-			konnect.WithMetricRecorder[configurationv1alpha1.KongCredentialAPIKey](&metricsmocks.MockRecorder{}),
+			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialACL](consts.KonnectInfiniteSyncTime),
+			konnect.WithMetricRecorder[configurationv1alpha1.KongCredentialACL](&metricsmocks.MockRecorder{}),
 		),
 	}
 
-	StartReconcilers(ctx, t, mgr, logs, reconcilers...)
+	envtest.StartReconcilers(ctx, t, mgr, logs, reconcilers...)
 
 	assert.EventuallyWithT(t,
-		assertCollectObjectExistsAndHasKonnectID(t, ctx, clientNamespaced, kongCredentialAPIKey, keyID),
-		waitTime, tickTime,
-		"KongCredentialAPIKey wasn't created",
+		envtest.AssertCollectObjectExistsAndHasKonnectID(t, ctx, clientNamespaced, kongCredentialACL, aclID),
+		consts.WaitTime, consts.TickTime,
+		"KongCredentialACL wasn't created",
 	)
 
-	eventuallyAssertSDKExpectations(t, sdk, waitTime, tickTime)
+	envtest.EventuallyAssertSDKExpectations(t, sdk, consts.WaitTime, consts.TickTime)
 
 	sdk.EXPECT().
-		DeleteKeyAuthWithConsumer(
+		DeleteACLWithConsumer(
 			mock.Anything,
-			sdkkonnectops.DeleteKeyAuthWithConsumerRequest{
+			sdkkonnectops.DeleteACLWithConsumerRequest{
 				ControlPlaneID:              cp.GetKonnectStatus().GetKonnectID(),
 				ConsumerIDForNestedEntities: consumerID,
-				KeyAuthID:                   keyID,
+				ACLID:                       aclID,
 			},
 		).
 		Return(
-			&sdkkonnectops.DeleteKeyAuthWithConsumerResponse{
+			&sdkkonnectops.DeleteACLWithConsumerResponse{
 				StatusCode: 200,
 			},
 			nil,
 		)
-
-	require.NoError(t, clientNamespaced.Delete(ctx, kongCredentialAPIKey))
+	require.NoError(t, clientNamespaced.Delete(ctx, kongCredentialACL))
 
 	assert.EventuallyWithT(t,
 		func(c *assert.CollectT) {
 			assert.True(c, apierrors.IsNotFound(
-				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kongCredentialAPIKey), kongCredentialAPIKey),
+				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kongCredentialACL), kongCredentialACL),
 			))
-		}, waitTime, tickTime,
-		"KongCredentialAPIKey wasn't deleted but it should have been",
+		}, consts.WaitTime, consts.TickTime,
+		"KongCredentialACL wasn't deleted but it should have been",
 	)
 
-	eventuallyAssertSDKExpectations(t, sdk, waitTime, tickTime)
+	envtest.EventuallyAssertSDKExpectations(t, sdk, consts.WaitTime, consts.TickTime)
 
 	t.Run("conflict on creation should be handled successfully", func(t *testing.T) {
 		t.Log("Setting up SDK expectations on creation with conflict")
 		sdk.EXPECT().
-			CreateKeyAuthWithConsumer(
+			CreateACLWithConsumer(
 				mock.Anything,
-				mock.MatchedBy(func(r sdkkonnectops.CreateKeyAuthWithConsumerRequest) bool {
+				mock.MatchedBy(func(r sdkkonnectops.CreateACLWithConsumerRequest) bool {
 					return r.ControlPlaneID == cp.GetKonnectID() &&
 						r.ConsumerIDForNestedEntities == consumerID &&
-						r.KeyAuthWithoutParents.Tags != nil &&
+						r.ACLWithoutParents.Group == aclGroup &&
+						r.ACLWithoutParents.Tags != nil &&
 						slices.ContainsFunc(
-							r.KeyAuthWithoutParents.Tags,
+							r.ACLWithoutParents.Tags,
 							func(t string) bool {
 								return strings.HasPrefix(t, "k8s-uid:")
 							},
@@ -185,36 +187,37 @@ func TestKongConsumerCredential_APIKey(t *testing.T) {
 				nil,
 				&sdkkonnecterrs.SDKError{
 					StatusCode: 400,
-					Body:       ErrBodyDataConstraintError,
+					Body:       consts.ErrBodyDataConstraintError,
 				},
 			)
 
 		sdk.EXPECT().
-			ListKeyAuth(
+			ListACL(
 				mock.Anything,
-				mock.MatchedBy(func(r sdkkonnectops.ListKeyAuthRequest) bool {
+				mock.MatchedBy(func(r sdkkonnectops.ListACLRequest) bool {
 					return r.ControlPlaneID == cp.GetKonnectID() &&
 						r.Tags != nil && strings.HasPrefix(*r.Tags, "k8s-uid")
 				}),
 			).
-			Return(&sdkkonnectops.ListKeyAuthResponse{
-				Object: &sdkkonnectops.ListKeyAuthResponseBody{
-					Data: []sdkkonnectcomp.KeyAuth{
+			Return(&sdkkonnectops.ListACLResponse{
+				Object: &sdkkonnectops.ListACLResponseBody{
+					Data: []sdkkonnectcomp.ACL{
 						{
-							ID: new(keyID),
+							ID: new(aclID),
 						},
 					},
 				},
 			}, nil)
 
-		w := setupWatch[configurationv1alpha1.KongCredentialAPIKeyList](t, ctx, cl, client.InNamespace(ns.Name))
-		created := deploy.KongCredentialAPIKey(t, ctx, clientNamespaced, consumer.Name)
+		w := envtest.SetupWatch[configurationv1alpha1.KongCredentialACLList](t, ctx, cl, client.InNamespace(ns.Name))
+		created := deploy.KongCredentialACL(t, ctx, clientNamespaced, consumer.Name, aclGroup)
 
-		t.Log("Waiting for KongCredentialAPIKey to be programmed")
-		watchFor(t, ctx, w, apiwatch.Modified, func(k *configurationv1alpha1.KongCredentialAPIKey) bool {
+		t.Log("Waiting for KongCredentialACL to be programmed")
+		envtest.WatchFor(t, ctx, w, apiwatch.Modified, func(k *configurationv1alpha1.KongCredentialACL) bool {
 			return k.GetName() == created.GetName() && k8sutils.IsProgrammed(k)
-		}, "KongCredentialAPIKey's Programmed condition should be true eventually")
+		}, "KongCredentialACL's Programmed condition should be true eventually")
 
-		eventuallyAssertSDKExpectations(t, sdk, waitTime, tickTime)
+		t.Log("Checking SDK KongCredentialACL operations")
+		envtest.EventuallyAssertSDKExpectations(t, sdk, consts.WaitTime, consts.TickTime)
 	})
 }

--- a/test/envtest/konnect-api-gw/kongconsumercredential_apikey_test.go
+++ b/test/envtest/konnect-api-gw/kongconsumercredential_apikey_test.go
@@ -24,20 +24,22 @@ import (
 	"github.com/kong/kong-operator/v2/modules/manager/logging"
 	"github.com/kong/kong-operator/v2/modules/manager/scheme"
 	k8sutils "github.com/kong/kong-operator/v2/pkg/utils/kubernetes"
+	"github.com/kong/kong-operator/v2/test/envtest"
+	"github.com/kong/kong-operator/v2/test/envtest/consts"
 	"github.com/kong/kong-operator/v2/test/helpers/deploy"
 	"github.com/kong/kong-operator/v2/test/mocks/metricsmocks"
 	"github.com/kong/kong-operator/v2/test/mocks/sdkmocks"
 )
 
-func TestKongConsumerCredential_ACL(t *testing.T) {
+func TestKongConsumerCredential_APIKey(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := Context(t, t.Context())
+	ctx, cancel := envtest.Context(t, t.Context())
 	defer cancel()
 
 	// Setup up the envtest environment.
-	cfg, ns := Setup(t, ctx, scheme.Get(), WithInstallGatewayCRDs(true))
+	cfg, ns := envtest.Setup(t, ctx, scheme.Get(), envtest.WithInstallGatewayCRDs(true))
 
-	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())
+	mgr, logs := envtest.NewManager(t, ctx, cfg, scheme.Get())
 
 	cl, err := client.NewWithWatch(mgr.GetConfig(), client.Options{
 		Scheme: scheme.Get(),
@@ -70,110 +72,110 @@ func TestKongConsumerCredential_ACL(t *testing.T) {
 	}
 	require.NoError(t, clientNamespaced.Status().Update(ctx, consumer))
 
-	aclGroup := "acl-group1"
-	kongCredentialACL := deploy.KongCredentialACL(t, ctx, clientNamespaced, consumer.Name, aclGroup)
-	aclID := uuid.NewString()
+	kongCredentialAPIKey := deploy.KongCredentialAPIKey(t, ctx, clientNamespaced, consumer.Name)
+	keyID := uuid.NewString()
 	tags := []string{
 		"k8s-generation:1",
 		"k8s-group:configuration.konghq.com",
-		"k8s-kind:KongCredentialACL",
-		"k8s-name:" + kongCredentialACL.Name,
+		"k8s-kind:KongCredentialAPIKey",
+		"k8s-name:" + kongCredentialAPIKey.Name,
 		"k8s-namespace:" + ns.Name,
-		"k8s-uid:" + string(kongCredentialACL.GetUID()),
+		"k8s-uid:" + string(kongCredentialAPIKey.GetUID()),
 		"k8s-version:v1alpha1",
 		"managed-by:kong-operator",
 	}
 
 	factory := sdkmocks.NewMockSDKFactory(t)
-	sdk := factory.SDK.KongCredentialsACLSDK
+	sdk := factory.SDK.KongCredentialsAPIKeySDK
+
 	sdk.EXPECT().
-		CreateACLWithConsumer(
+		CreateKeyAuthWithConsumer(
 			mock.Anything,
-			sdkkonnectops.CreateACLWithConsumerRequest{
+			sdkkonnectops.CreateKeyAuthWithConsumerRequest{
 				ControlPlaneID:              cp.GetKonnectStatus().GetKonnectID(),
 				ConsumerIDForNestedEntities: consumerID,
-				ACLWithoutParents: sdkkonnectcomp.ACLWithoutParents{
-					Group: aclGroup,
-					Tags:  tags,
+				KeyAuthWithoutParents: &sdkkonnectcomp.KeyAuthWithoutParents{
+					Key:  new("key"),
+					Tags: tags,
 				},
 			},
 		).
 		Return(
-			&sdkkonnectops.CreateACLWithConsumerResponse{
-				ACL: &sdkkonnectcomp.ACL{
-					ID: new(aclID),
+			&sdkkonnectops.CreateKeyAuthWithConsumerResponse{
+				KeyAuth: &sdkkonnectcomp.KeyAuth{
+					ID: new(keyID),
 				},
 			},
 			nil,
 		)
 	sdk.EXPECT().
-		UpsertACLWithConsumer(mock.Anything, mock.Anything, mock.Anything).Maybe().
+		UpsertKeyAuthWithConsumer(mock.Anything, mock.Anything, mock.Anything).Maybe().
 		Return(
-			&sdkkonnectops.UpsertACLWithConsumerResponse{
-				ACL: &sdkkonnectcomp.ACL{
-					ID: new(aclID),
+			&sdkkonnectops.UpsertKeyAuthWithConsumerResponse{
+				KeyAuth: &sdkkonnectcomp.KeyAuth{
+					ID: new(keyID),
 				},
 			},
 			nil,
 		)
 
-	reconcilers := []Reconciler{
+	reconcilers := []envtest.Reconciler{
 		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
-			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialACL](konnectInfiniteSyncTime),
-			konnect.WithMetricRecorder[configurationv1alpha1.KongCredentialACL](&metricsmocks.MockRecorder{}),
+			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialAPIKey](consts.KonnectInfiniteSyncTime),
+			konnect.WithMetricRecorder[configurationv1alpha1.KongCredentialAPIKey](&metricsmocks.MockRecorder{}),
 		),
 	}
 
-	StartReconcilers(ctx, t, mgr, logs, reconcilers...)
+	envtest.StartReconcilers(ctx, t, mgr, logs, reconcilers...)
 
 	assert.EventuallyWithT(t,
-		assertCollectObjectExistsAndHasKonnectID(t, ctx, clientNamespaced, kongCredentialACL, aclID),
-		waitTime, tickTime,
-		"KongCredentialACL wasn't created",
+		envtest.AssertCollectObjectExistsAndHasKonnectID(t, ctx, clientNamespaced, kongCredentialAPIKey, keyID),
+		consts.WaitTime, consts.TickTime,
+		"KongCredentialAPIKey wasn't created",
 	)
 
-	eventuallyAssertSDKExpectations(t, sdk, waitTime, tickTime)
+	envtest.EventuallyAssertSDKExpectations(t, sdk, consts.WaitTime, consts.TickTime)
 
 	sdk.EXPECT().
-		DeleteACLWithConsumer(
+		DeleteKeyAuthWithConsumer(
 			mock.Anything,
-			sdkkonnectops.DeleteACLWithConsumerRequest{
+			sdkkonnectops.DeleteKeyAuthWithConsumerRequest{
 				ControlPlaneID:              cp.GetKonnectStatus().GetKonnectID(),
 				ConsumerIDForNestedEntities: consumerID,
-				ACLID:                       aclID,
+				KeyAuthID:                   keyID,
 			},
 		).
 		Return(
-			&sdkkonnectops.DeleteACLWithConsumerResponse{
+			&sdkkonnectops.DeleteKeyAuthWithConsumerResponse{
 				StatusCode: 200,
 			},
 			nil,
 		)
-	require.NoError(t, clientNamespaced.Delete(ctx, kongCredentialACL))
+
+	require.NoError(t, clientNamespaced.Delete(ctx, kongCredentialAPIKey))
 
 	assert.EventuallyWithT(t,
 		func(c *assert.CollectT) {
 			assert.True(c, apierrors.IsNotFound(
-				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kongCredentialACL), kongCredentialACL),
+				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kongCredentialAPIKey), kongCredentialAPIKey),
 			))
-		}, waitTime, tickTime,
-		"KongCredentialACL wasn't deleted but it should have been",
+		}, consts.WaitTime, consts.TickTime,
+		"KongCredentialAPIKey wasn't deleted but it should have been",
 	)
 
-	eventuallyAssertSDKExpectations(t, sdk, waitTime, tickTime)
+	envtest.EventuallyAssertSDKExpectations(t, sdk, consts.WaitTime, consts.TickTime)
 
 	t.Run("conflict on creation should be handled successfully", func(t *testing.T) {
 		t.Log("Setting up SDK expectations on creation with conflict")
 		sdk.EXPECT().
-			CreateACLWithConsumer(
+			CreateKeyAuthWithConsumer(
 				mock.Anything,
-				mock.MatchedBy(func(r sdkkonnectops.CreateACLWithConsumerRequest) bool {
+				mock.MatchedBy(func(r sdkkonnectops.CreateKeyAuthWithConsumerRequest) bool {
 					return r.ControlPlaneID == cp.GetKonnectID() &&
 						r.ConsumerIDForNestedEntities == consumerID &&
-						r.ACLWithoutParents.Group == aclGroup &&
-						r.ACLWithoutParents.Tags != nil &&
+						r.KeyAuthWithoutParents.Tags != nil &&
 						slices.ContainsFunc(
-							r.ACLWithoutParents.Tags,
+							r.KeyAuthWithoutParents.Tags,
 							func(t string) bool {
 								return strings.HasPrefix(t, "k8s-uid:")
 							},
@@ -185,37 +187,36 @@ func TestKongConsumerCredential_ACL(t *testing.T) {
 				nil,
 				&sdkkonnecterrs.SDKError{
 					StatusCode: 400,
-					Body:       ErrBodyDataConstraintError,
+					Body:       consts.ErrBodyDataConstraintError,
 				},
 			)
 
 		sdk.EXPECT().
-			ListACL(
+			ListKeyAuth(
 				mock.Anything,
-				mock.MatchedBy(func(r sdkkonnectops.ListACLRequest) bool {
+				mock.MatchedBy(func(r sdkkonnectops.ListKeyAuthRequest) bool {
 					return r.ControlPlaneID == cp.GetKonnectID() &&
 						r.Tags != nil && strings.HasPrefix(*r.Tags, "k8s-uid")
 				}),
 			).
-			Return(&sdkkonnectops.ListACLResponse{
-				Object: &sdkkonnectops.ListACLResponseBody{
-					Data: []sdkkonnectcomp.ACL{
+			Return(&sdkkonnectops.ListKeyAuthResponse{
+				Object: &sdkkonnectops.ListKeyAuthResponseBody{
+					Data: []sdkkonnectcomp.KeyAuth{
 						{
-							ID: new(aclID),
+							ID: new(keyID),
 						},
 					},
 				},
 			}, nil)
 
-		w := setupWatch[configurationv1alpha1.KongCredentialACLList](t, ctx, cl, client.InNamespace(ns.Name))
-		created := deploy.KongCredentialACL(t, ctx, clientNamespaced, consumer.Name, aclGroup)
+		w := envtest.SetupWatch[configurationv1alpha1.KongCredentialAPIKeyList](t, ctx, cl, client.InNamespace(ns.Name))
+		created := deploy.KongCredentialAPIKey(t, ctx, clientNamespaced, consumer.Name)
 
-		t.Log("Waiting for KongCredentialACL to be programmed")
-		watchFor(t, ctx, w, apiwatch.Modified, func(k *configurationv1alpha1.KongCredentialACL) bool {
+		t.Log("Waiting for KongCredentialAPIKey to be programmed")
+		envtest.WatchFor(t, ctx, w, apiwatch.Modified, func(k *configurationv1alpha1.KongCredentialAPIKey) bool {
 			return k.GetName() == created.GetName() && k8sutils.IsProgrammed(k)
-		}, "KongCredentialACL's Programmed condition should be true eventually")
+		}, "KongCredentialAPIKey's Programmed condition should be true eventually")
 
-		t.Log("Checking SDK KongCredentialACL operations")
-		eventuallyAssertSDKExpectations(t, sdk, waitTime, tickTime)
+		envtest.EventuallyAssertSDKExpectations(t, sdk, consts.WaitTime, consts.TickTime)
 	})
 }

--- a/test/envtest/konnect-api-gw/kongconsumercredential_basicauth_test.go
+++ b/test/envtest/konnect-api-gw/kongconsumercredential_basicauth_test.go
@@ -24,20 +24,22 @@ import (
 	"github.com/kong/kong-operator/v2/modules/manager/logging"
 	"github.com/kong/kong-operator/v2/modules/manager/scheme"
 	k8sutils "github.com/kong/kong-operator/v2/pkg/utils/kubernetes"
+	"github.com/kong/kong-operator/v2/test/envtest"
+	"github.com/kong/kong-operator/v2/test/envtest/consts"
 	"github.com/kong/kong-operator/v2/test/helpers/deploy"
 	"github.com/kong/kong-operator/v2/test/mocks/metricsmocks"
 	"github.com/kong/kong-operator/v2/test/mocks/sdkmocks"
 )
 
-func TestKongConsumerCredential_HMAC(t *testing.T) {
+func TestKongConsumerCredential_BasicAuth(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := Context(t, t.Context())
+	ctx, cancel := envtest.Context(t, t.Context())
 	defer cancel()
 
 	// Setup up the envtest environment.
-	cfg, ns := Setup(t, ctx, scheme.Get(), WithInstallGatewayCRDs(true))
+	cfg, ns := envtest.Setup(t, ctx, scheme.Get(), envtest.WithInstallGatewayCRDs(true))
 
-	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())
+	mgr, logs := envtest.NewManager(t, ctx, cfg, scheme.Get())
 
 	cl, err := client.NewWithWatch(mgr.GetConfig(), client.Options{
 		Scheme: scheme.Get(),
@@ -70,108 +72,112 @@ func TestKongConsumerCredential_HMAC(t *testing.T) {
 	}
 	require.NoError(t, clientNamespaced.Status().Update(ctx, consumer))
 
-	kongCredentialHMAC := deploy.KongCredentialHMAC(t, ctx, clientNamespaced, consumer.Name)
-	hmacID := uuid.NewString()
+	password := "password"
+	username := "username"
+	kongCredentialBasicAuth := deploy.KongCredentialBasicAuth(t, ctx, clientNamespaced, consumer.Name, username, password)
+	basicAuthID := uuid.NewString()
 	tags := []string{
 		"k8s-generation:1",
 		"k8s-group:configuration.konghq.com",
-		"k8s-kind:KongCredentialHMAC",
-		"k8s-name:" + kongCredentialHMAC.Name,
+		"k8s-kind:KongCredentialBasicAuth",
+		"k8s-name:" + kongCredentialBasicAuth.Name,
 		"k8s-namespace:" + ns.Name,
-		"k8s-uid:" + string(kongCredentialHMAC.GetUID()),
+		"k8s-uid:" + string(kongCredentialBasicAuth.GetUID()),
 		"k8s-version:v1alpha1",
 		"managed-by:kong-operator",
 	}
 
 	factory := sdkmocks.NewMockSDKFactory(t)
-	sdk := factory.SDK.KongCredentialsHMACSDK
+	sdk := factory.SDK.KongCredentialsBasicAuthSDK
+
 	sdk.EXPECT().
-		CreateHmacAuthWithConsumer(
+		CreateBasicAuthWithConsumer(
 			mock.Anything,
-			sdkkonnectops.CreateHmacAuthWithConsumerRequest{
+			sdkkonnectops.CreateBasicAuthWithConsumerRequest{
 				ControlPlaneID:              cp.GetKonnectStatus().GetKonnectID(),
 				ConsumerIDForNestedEntities: consumerID,
-				HMACAuthWithoutParents: sdkkonnectcomp.HMACAuthWithoutParents{
-					Username: "username",
+				BasicAuthWithoutParents: sdkkonnectcomp.BasicAuthWithoutParents{
+					Password: password,
+					Username: username,
 					Tags:     tags,
 				},
 			},
 		).
 		Return(
-			&sdkkonnectops.CreateHmacAuthWithConsumerResponse{
-				HMACAuth: &sdkkonnectcomp.HMACAuth{
-					ID: new(hmacID),
+			&sdkkonnectops.CreateBasicAuthWithConsumerResponse{
+				BasicAuth: &sdkkonnectcomp.BasicAuth{
+					ID: new(basicAuthID),
 				},
 			},
 			nil,
 		)
 	sdk.EXPECT().
-		UpsertHmacAuthWithConsumer(mock.Anything, mock.Anything, mock.Anything).Maybe().
+		UpsertBasicAuthWithConsumer(mock.Anything, mock.Anything, mock.Anything).Maybe().
 		Return(
-			&sdkkonnectops.UpsertHmacAuthWithConsumerResponse{
-				HMACAuth: &sdkkonnectcomp.HMACAuth{
-					ID: new(hmacID),
+			&sdkkonnectops.UpsertBasicAuthWithConsumerResponse{
+				BasicAuth: &sdkkonnectcomp.BasicAuth{
+					ID: new(basicAuthID),
 				},
 			},
 			nil,
 		)
 
-	reconcilers := []Reconciler{
+	reconcilers := []envtest.Reconciler{
 		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
-			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialHMAC](konnectInfiniteSyncTime),
-			konnect.WithMetricRecorder[configurationv1alpha1.KongCredentialHMAC](&metricsmocks.MockRecorder{}),
+			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialBasicAuth](consts.KonnectInfiniteSyncTime),
+			konnect.WithMetricRecorder[configurationv1alpha1.KongCredentialBasicAuth](&metricsmocks.MockRecorder{}),
 		),
 	}
 
-	StartReconcilers(ctx, t, mgr, logs, reconcilers...)
+	envtest.StartReconcilers(ctx, t, mgr, logs, reconcilers...)
 
 	assert.EventuallyWithT(t,
-		assertCollectObjectExistsAndHasKonnectID(t, ctx, clientNamespaced, kongCredentialHMAC, hmacID),
-		waitTime, tickTime,
-		"KongCredentialHMAC wasn't created",
+		envtest.AssertCollectObjectExistsAndHasKonnectID(t, ctx, clientNamespaced, kongCredentialBasicAuth, basicAuthID),
+		consts.WaitTime, consts.TickTime,
+		"KongCredentialBasicAuth wasn't created",
 	)
 
-	eventuallyAssertSDKExpectations(t, sdk, waitTime, tickTime)
+	envtest.EventuallyAssertSDKExpectations(t, sdk, consts.WaitTime, consts.TickTime)
 
 	sdk.EXPECT().
-		DeleteHmacAuthWithConsumer(
+		DeleteBasicAuthWithConsumer(
 			mock.Anything,
-			sdkkonnectops.DeleteHmacAuthWithConsumerRequest{
+			sdkkonnectops.DeleteBasicAuthWithConsumerRequest{
 				ControlPlaneID:              cp.GetKonnectStatus().GetKonnectID(),
 				ConsumerIDForNestedEntities: consumerID,
-				HMACAuthID:                  hmacID,
+				BasicAuthID:                 basicAuthID,
 			},
 		).
 		Return(
-			&sdkkonnectops.DeleteHmacAuthWithConsumerResponse{
+			&sdkkonnectops.DeleteBasicAuthWithConsumerResponse{
 				StatusCode: 200,
 			},
 			nil,
 		)
-	require.NoError(t, clientNamespaced.Delete(ctx, kongCredentialHMAC))
+	require.NoError(t, clientNamespaced.Delete(ctx, kongCredentialBasicAuth))
 
 	assert.EventuallyWithT(t,
 		func(c *assert.CollectT) {
 			assert.True(c, apierrors.IsNotFound(
-				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kongCredentialHMAC), kongCredentialHMAC),
+				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kongCredentialBasicAuth), kongCredentialBasicAuth),
 			))
-		}, waitTime, tickTime,
-		"KongCredentialHMAC wasn't deleted but it should have been",
+		}, consts.WaitTime, consts.TickTime,
+		"KongCredentialBasicAuth wasn't deleted but it should have been",
 	)
 
-	eventuallyAssertSDKExpectations(t, sdk, waitTime, tickTime)
+	envtest.EventuallyAssertSDKExpectations(t, factory.SDK.KongCredentialsBasicAuthSDK, consts.WaitTime, consts.TickTime)
 
 	t.Run("conflict on creation should be handled successfully", func(t *testing.T) {
 		t.Log("Setting up SDK expectations on creation with conflict")
 		sdk.EXPECT().
-			CreateHmacAuthWithConsumer(
+			CreateBasicAuthWithConsumer(
 				mock.Anything,
-				mock.MatchedBy(func(r sdkkonnectops.CreateHmacAuthWithConsumerRequest) bool {
+				mock.MatchedBy(func(r sdkkonnectops.CreateBasicAuthWithConsumerRequest) bool {
 					return r.ControlPlaneID == cp.GetKonnectID() &&
 						r.ConsumerIDForNestedEntities == consumerID &&
-						r.HMACAuthWithoutParents.Tags != nil &&
+						r.BasicAuthWithoutParents.Tags != nil &&
 						slices.ContainsFunc(
-							r.HMACAuthWithoutParents.Tags,
+							r.BasicAuthWithoutParents.Tags,
 							func(t string) bool {
 								return strings.HasPrefix(t, "k8s-uid:")
 							},
@@ -183,36 +189,36 @@ func TestKongConsumerCredential_HMAC(t *testing.T) {
 				nil,
 				&sdkkonnecterrs.SDKError{
 					StatusCode: 400,
-					Body:       ErrBodyDataConstraintError,
+					Body:       consts.ErrBodyDataConstraintError,
 				},
 			)
 
 		sdk.EXPECT().
-			ListHmacAuth(
+			ListBasicAuth(
 				mock.Anything,
-				mock.MatchedBy(func(r sdkkonnectops.ListHmacAuthRequest) bool {
+				mock.MatchedBy(func(r sdkkonnectops.ListBasicAuthRequest) bool {
 					return r.ControlPlaneID == cp.GetKonnectID() &&
 						r.Tags != nil && strings.HasPrefix(*r.Tags, "k8s-uid")
 				}),
 			).
-			Return(&sdkkonnectops.ListHmacAuthResponse{
-				Object: &sdkkonnectops.ListHmacAuthResponseBody{
-					Data: []sdkkonnectcomp.HMACAuth{
+			Return(&sdkkonnectops.ListBasicAuthResponse{
+				Object: &sdkkonnectops.ListBasicAuthResponseBody{
+					Data: []sdkkonnectcomp.BasicAuth{
 						{
-							ID: new(hmacID),
+							ID: new(basicAuthID),
 						},
 					},
 				},
 			}, nil)
 
-		w := setupWatch[configurationv1alpha1.KongCredentialHMACList](t, ctx, cl, client.InNamespace(ns.Name))
-		created := deploy.KongCredentialHMAC(t, ctx, clientNamespaced, consumer.Name)
+		w := envtest.SetupWatch[configurationv1alpha1.KongCredentialBasicAuthList](t, ctx, cl, client.InNamespace(ns.Name))
+		created := deploy.KongCredentialBasicAuth(t, ctx, clientNamespaced, consumer.Name, "username", "password")
 
-		t.Log("Waiting for KongCredentialHMAC to be programmed")
-		watchFor(t, ctx, w, apiwatch.Modified, func(k *configurationv1alpha1.KongCredentialHMAC) bool {
+		t.Log("Waiting for KongCredentialBasicAuth to be programmed")
+		envtest.WatchFor(t, ctx, w, apiwatch.Modified, func(k *configurationv1alpha1.KongCredentialBasicAuth) bool {
 			return k.GetName() == created.GetName() && k8sutils.IsProgrammed(k)
-		}, "KongCredentialHMAC's Programmed condition should be true eventually")
+		}, "KongCredentialBasicAuth's Programmed condition should be true eventually")
 
-		eventuallyAssertSDKExpectations(t, sdk, waitTime, tickTime)
+		envtest.EventuallyAssertSDKExpectations(t, sdk, consts.WaitTime, consts.TickTime)
 	})
 }

--- a/test/envtest/konnect-api-gw/kongconsumercredential_hmac_test.go
+++ b/test/envtest/konnect-api-gw/kongconsumercredential_hmac_test.go
@@ -24,20 +24,22 @@ import (
 	"github.com/kong/kong-operator/v2/modules/manager/logging"
 	"github.com/kong/kong-operator/v2/modules/manager/scheme"
 	k8sutils "github.com/kong/kong-operator/v2/pkg/utils/kubernetes"
+	"github.com/kong/kong-operator/v2/test/envtest"
+	"github.com/kong/kong-operator/v2/test/envtest/consts"
 	"github.com/kong/kong-operator/v2/test/helpers/deploy"
 	"github.com/kong/kong-operator/v2/test/mocks/metricsmocks"
 	"github.com/kong/kong-operator/v2/test/mocks/sdkmocks"
 )
 
-func TestKongConsumerCredential_BasicAuth(t *testing.T) {
+func TestKongConsumerCredential_HMAC(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := Context(t, t.Context())
+	ctx, cancel := envtest.Context(t, t.Context())
 	defer cancel()
 
 	// Setup up the envtest environment.
-	cfg, ns := Setup(t, ctx, scheme.Get(), WithInstallGatewayCRDs(true))
+	cfg, ns := envtest.Setup(t, ctx, scheme.Get(), envtest.WithInstallGatewayCRDs(true))
 
-	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())
+	mgr, logs := envtest.NewManager(t, ctx, cfg, scheme.Get())
 
 	cl, err := client.NewWithWatch(mgr.GetConfig(), client.Options{
 		Scheme: scheme.Get(),
@@ -70,112 +72,108 @@ func TestKongConsumerCredential_BasicAuth(t *testing.T) {
 	}
 	require.NoError(t, clientNamespaced.Status().Update(ctx, consumer))
 
-	password := "password"
-	username := "username"
-	kongCredentialBasicAuth := deploy.KongCredentialBasicAuth(t, ctx, clientNamespaced, consumer.Name, username, password)
-	basicAuthID := uuid.NewString()
+	kongCredentialHMAC := deploy.KongCredentialHMAC(t, ctx, clientNamespaced, consumer.Name)
+	hmacID := uuid.NewString()
 	tags := []string{
 		"k8s-generation:1",
 		"k8s-group:configuration.konghq.com",
-		"k8s-kind:KongCredentialBasicAuth",
-		"k8s-name:" + kongCredentialBasicAuth.Name,
+		"k8s-kind:KongCredentialHMAC",
+		"k8s-name:" + kongCredentialHMAC.Name,
 		"k8s-namespace:" + ns.Name,
-		"k8s-uid:" + string(kongCredentialBasicAuth.GetUID()),
+		"k8s-uid:" + string(kongCredentialHMAC.GetUID()),
 		"k8s-version:v1alpha1",
 		"managed-by:kong-operator",
 	}
 
 	factory := sdkmocks.NewMockSDKFactory(t)
-	sdk := factory.SDK.KongCredentialsBasicAuthSDK
-
+	sdk := factory.SDK.KongCredentialsHMACSDK
 	sdk.EXPECT().
-		CreateBasicAuthWithConsumer(
+		CreateHmacAuthWithConsumer(
 			mock.Anything,
-			sdkkonnectops.CreateBasicAuthWithConsumerRequest{
+			sdkkonnectops.CreateHmacAuthWithConsumerRequest{
 				ControlPlaneID:              cp.GetKonnectStatus().GetKonnectID(),
 				ConsumerIDForNestedEntities: consumerID,
-				BasicAuthWithoutParents: sdkkonnectcomp.BasicAuthWithoutParents{
-					Password: password,
-					Username: username,
+				HMACAuthWithoutParents: sdkkonnectcomp.HMACAuthWithoutParents{
+					Username: "username",
 					Tags:     tags,
 				},
 			},
 		).
 		Return(
-			&sdkkonnectops.CreateBasicAuthWithConsumerResponse{
-				BasicAuth: &sdkkonnectcomp.BasicAuth{
-					ID: new(basicAuthID),
+			&sdkkonnectops.CreateHmacAuthWithConsumerResponse{
+				HMACAuth: &sdkkonnectcomp.HMACAuth{
+					ID: new(hmacID),
 				},
 			},
 			nil,
 		)
 	sdk.EXPECT().
-		UpsertBasicAuthWithConsumer(mock.Anything, mock.Anything, mock.Anything).Maybe().
+		UpsertHmacAuthWithConsumer(mock.Anything, mock.Anything, mock.Anything).Maybe().
 		Return(
-			&sdkkonnectops.UpsertBasicAuthWithConsumerResponse{
-				BasicAuth: &sdkkonnectcomp.BasicAuth{
-					ID: new(basicAuthID),
+			&sdkkonnectops.UpsertHmacAuthWithConsumerResponse{
+				HMACAuth: &sdkkonnectcomp.HMACAuth{
+					ID: new(hmacID),
 				},
 			},
 			nil,
 		)
 
-	reconcilers := []Reconciler{
+	reconcilers := []envtest.Reconciler{
 		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
-			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialBasicAuth](konnectInfiniteSyncTime),
-			konnect.WithMetricRecorder[configurationv1alpha1.KongCredentialBasicAuth](&metricsmocks.MockRecorder{}),
+			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialHMAC](consts.KonnectInfiniteSyncTime),
+			konnect.WithMetricRecorder[configurationv1alpha1.KongCredentialHMAC](&metricsmocks.MockRecorder{}),
 		),
 	}
 
-	StartReconcilers(ctx, t, mgr, logs, reconcilers...)
+	envtest.StartReconcilers(ctx, t, mgr, logs, reconcilers...)
 
 	assert.EventuallyWithT(t,
-		assertCollectObjectExistsAndHasKonnectID(t, ctx, clientNamespaced, kongCredentialBasicAuth, basicAuthID),
-		waitTime, tickTime,
-		"KongCredentialBasicAuth wasn't created",
+		envtest.AssertCollectObjectExistsAndHasKonnectID(t, ctx, clientNamespaced, kongCredentialHMAC, hmacID),
+		consts.WaitTime, consts.TickTime,
+		"KongCredentialHMAC wasn't created",
 	)
 
-	eventuallyAssertSDKExpectations(t, sdk, waitTime, tickTime)
+	envtest.EventuallyAssertSDKExpectations(t, sdk, consts.WaitTime, consts.TickTime)
 
 	sdk.EXPECT().
-		DeleteBasicAuthWithConsumer(
+		DeleteHmacAuthWithConsumer(
 			mock.Anything,
-			sdkkonnectops.DeleteBasicAuthWithConsumerRequest{
+			sdkkonnectops.DeleteHmacAuthWithConsumerRequest{
 				ControlPlaneID:              cp.GetKonnectStatus().GetKonnectID(),
 				ConsumerIDForNestedEntities: consumerID,
-				BasicAuthID:                 basicAuthID,
+				HMACAuthID:                  hmacID,
 			},
 		).
 		Return(
-			&sdkkonnectops.DeleteBasicAuthWithConsumerResponse{
+			&sdkkonnectops.DeleteHmacAuthWithConsumerResponse{
 				StatusCode: 200,
 			},
 			nil,
 		)
-	require.NoError(t, clientNamespaced.Delete(ctx, kongCredentialBasicAuth))
+	require.NoError(t, clientNamespaced.Delete(ctx, kongCredentialHMAC))
 
 	assert.EventuallyWithT(t,
 		func(c *assert.CollectT) {
 			assert.True(c, apierrors.IsNotFound(
-				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kongCredentialBasicAuth), kongCredentialBasicAuth),
+				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kongCredentialHMAC), kongCredentialHMAC),
 			))
-		}, waitTime, tickTime,
-		"KongCredentialBasicAuth wasn't deleted but it should have been",
+		}, consts.WaitTime, consts.TickTime,
+		"KongCredentialHMAC wasn't deleted but it should have been",
 	)
 
-	eventuallyAssertSDKExpectations(t, factory.SDK.KongCredentialsBasicAuthSDK, waitTime, tickTime)
+	envtest.EventuallyAssertSDKExpectations(t, sdk, consts.WaitTime, consts.TickTime)
 
 	t.Run("conflict on creation should be handled successfully", func(t *testing.T) {
 		t.Log("Setting up SDK expectations on creation with conflict")
 		sdk.EXPECT().
-			CreateBasicAuthWithConsumer(
+			CreateHmacAuthWithConsumer(
 				mock.Anything,
-				mock.MatchedBy(func(r sdkkonnectops.CreateBasicAuthWithConsumerRequest) bool {
+				mock.MatchedBy(func(r sdkkonnectops.CreateHmacAuthWithConsumerRequest) bool {
 					return r.ControlPlaneID == cp.GetKonnectID() &&
 						r.ConsumerIDForNestedEntities == consumerID &&
-						r.BasicAuthWithoutParents.Tags != nil &&
+						r.HMACAuthWithoutParents.Tags != nil &&
 						slices.ContainsFunc(
-							r.BasicAuthWithoutParents.Tags,
+							r.HMACAuthWithoutParents.Tags,
 							func(t string) bool {
 								return strings.HasPrefix(t, "k8s-uid:")
 							},
@@ -187,36 +185,36 @@ func TestKongConsumerCredential_BasicAuth(t *testing.T) {
 				nil,
 				&sdkkonnecterrs.SDKError{
 					StatusCode: 400,
-					Body:       ErrBodyDataConstraintError,
+					Body:       consts.ErrBodyDataConstraintError,
 				},
 			)
 
 		sdk.EXPECT().
-			ListBasicAuth(
+			ListHmacAuth(
 				mock.Anything,
-				mock.MatchedBy(func(r sdkkonnectops.ListBasicAuthRequest) bool {
+				mock.MatchedBy(func(r sdkkonnectops.ListHmacAuthRequest) bool {
 					return r.ControlPlaneID == cp.GetKonnectID() &&
 						r.Tags != nil && strings.HasPrefix(*r.Tags, "k8s-uid")
 				}),
 			).
-			Return(&sdkkonnectops.ListBasicAuthResponse{
-				Object: &sdkkonnectops.ListBasicAuthResponseBody{
-					Data: []sdkkonnectcomp.BasicAuth{
+			Return(&sdkkonnectops.ListHmacAuthResponse{
+				Object: &sdkkonnectops.ListHmacAuthResponseBody{
+					Data: []sdkkonnectcomp.HMACAuth{
 						{
-							ID: new(basicAuthID),
+							ID: new(hmacID),
 						},
 					},
 				},
 			}, nil)
 
-		w := setupWatch[configurationv1alpha1.KongCredentialBasicAuthList](t, ctx, cl, client.InNamespace(ns.Name))
-		created := deploy.KongCredentialBasicAuth(t, ctx, clientNamespaced, consumer.Name, "username", "password")
+		w := envtest.SetupWatch[configurationv1alpha1.KongCredentialHMACList](t, ctx, cl, client.InNamespace(ns.Name))
+		created := deploy.KongCredentialHMAC(t, ctx, clientNamespaced, consumer.Name)
 
-		t.Log("Waiting for KongCredentialBasicAuth to be programmed")
-		watchFor(t, ctx, w, apiwatch.Modified, func(k *configurationv1alpha1.KongCredentialBasicAuth) bool {
+		t.Log("Waiting for KongCredentialHMAC to be programmed")
+		envtest.WatchFor(t, ctx, w, apiwatch.Modified, func(k *configurationv1alpha1.KongCredentialHMAC) bool {
 			return k.GetName() == created.GetName() && k8sutils.IsProgrammed(k)
-		}, "KongCredentialBasicAuth's Programmed condition should be true eventually")
+		}, "KongCredentialHMAC's Programmed condition should be true eventually")
 
-		eventuallyAssertSDKExpectations(t, sdk, waitTime, tickTime)
+		envtest.EventuallyAssertSDKExpectations(t, sdk, consts.WaitTime, consts.TickTime)
 	})
 }

--- a/test/envtest/konnect-api-gw/kongconsumercredential_jwt_test.go
+++ b/test/envtest/konnect-api-gw/kongconsumercredential_jwt_test.go
@@ -24,6 +24,8 @@ import (
 	"github.com/kong/kong-operator/v2/modules/manager/logging"
 	"github.com/kong/kong-operator/v2/modules/manager/scheme"
 	k8sutils "github.com/kong/kong-operator/v2/pkg/utils/kubernetes"
+	"github.com/kong/kong-operator/v2/test/envtest"
+	"github.com/kong/kong-operator/v2/test/envtest/consts"
 	"github.com/kong/kong-operator/v2/test/helpers/deploy"
 	"github.com/kong/kong-operator/v2/test/mocks/metricsmocks"
 	"github.com/kong/kong-operator/v2/test/mocks/sdkmocks"
@@ -31,13 +33,13 @@ import (
 
 func TestKongConsumerCredential_JWT(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := Context(t, t.Context())
+	ctx, cancel := envtest.Context(t, t.Context())
 	defer cancel()
 
 	// Setup up the envtest environment.
-	cfg, ns := Setup(t, ctx, scheme.Get(), WithInstallGatewayCRDs(true))
+	cfg, ns := envtest.Setup(t, ctx, scheme.Get(), envtest.WithInstallGatewayCRDs(true))
 
-	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())
+	mgr, logs := envtest.NewManager(t, ctx, cfg, scheme.Get())
 
 	cl, err := client.NewWithWatch(mgr.GetConfig(), client.Options{
 		Scheme: scheme.Get(),
@@ -118,22 +120,22 @@ func TestKongConsumerCredential_JWT(t *testing.T) {
 			nil,
 		)
 
-	reconcilers := []Reconciler{
+	reconcilers := []envtest.Reconciler{
 		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
-			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialJWT](konnectInfiniteSyncTime),
+			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialJWT](consts.KonnectInfiniteSyncTime),
 			konnect.WithMetricRecorder[configurationv1alpha1.KongCredentialJWT](&metricsmocks.MockRecorder{}),
 		),
 	}
 
-	StartReconcilers(ctx, t, mgr, logs, reconcilers...)
+	envtest.StartReconcilers(ctx, t, mgr, logs, reconcilers...)
 
 	assert.EventuallyWithT(t,
-		assertCollectObjectExistsAndHasKonnectID(t, ctx, clientNamespaced, kongCredentialJWT, jwtID),
-		waitTime, tickTime,
+		envtest.AssertCollectObjectExistsAndHasKonnectID(t, ctx, clientNamespaced, kongCredentialJWT, jwtID),
+		consts.WaitTime, consts.TickTime,
 		"KongCredentialJWT wasn't created",
 	)
 
-	eventuallyAssertSDKExpectations(t, sdk, waitTime, tickTime)
+	envtest.EventuallyAssertSDKExpectations(t, sdk, consts.WaitTime, consts.TickTime)
 
 	sdk.EXPECT().
 		DeleteJwtWithConsumer(
@@ -158,11 +160,11 @@ func TestKongConsumerCredential_JWT(t *testing.T) {
 			assert.True(c, apierrors.IsNotFound(
 				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kongCredentialJWT), kongCredentialJWT),
 			))
-		}, waitTime, tickTime,
+		}, consts.WaitTime, consts.TickTime,
 		"KongCredentialJWT wasn't deleted but it should have been",
 	)
 
-	eventuallyAssertSDKExpectations(t, sdk, waitTime, tickTime)
+	envtest.EventuallyAssertSDKExpectations(t, sdk, consts.WaitTime, consts.TickTime)
 
 	t.Run("conflict on creation should be handled successfully", func(t *testing.T) {
 		t.Log("Setting up SDK expectations on creation with conflict")
@@ -186,7 +188,7 @@ func TestKongConsumerCredential_JWT(t *testing.T) {
 				nil,
 				&sdkkonnecterrs.SDKError{
 					StatusCode: 400,
-					Body:       ErrBodyDataConstraintError,
+					Body:       consts.ErrBodyDataConstraintError,
 				},
 			)
 
@@ -208,14 +210,14 @@ func TestKongConsumerCredential_JWT(t *testing.T) {
 				},
 			}, nil)
 
-		w := setupWatch[configurationv1alpha1.KongCredentialJWTList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := envtest.SetupWatch[configurationv1alpha1.KongCredentialJWTList](t, ctx, cl, client.InNamespace(ns.Name))
 		created := deploy.KongCredentialJWT(t, ctx, clientNamespaced, consumer.Name)
 
 		t.Log("Waiting for KongCredentialJWT to be programmed")
-		watchFor(t, ctx, w, apiwatch.Modified, func(k *configurationv1alpha1.KongCredentialJWT) bool {
+		envtest.WatchFor(t, ctx, w, apiwatch.Modified, func(k *configurationv1alpha1.KongCredentialJWT) bool {
 			return k.GetName() == created.GetName() && k8sutils.IsProgrammed(k)
 		}, "KongCredentialJWT's Programmed condition should be true eventually")
 
-		eventuallyAssertSDKExpectations(t, sdk, waitTime, tickTime)
+		envtest.EventuallyAssertSDKExpectations(t, sdk, consts.WaitTime, consts.TickTime)
 	})
 }

--- a/test/envtest/konnect-api-gw/kongpluginbinding_adoption_test.go
+++ b/test/envtest/konnect-api-gw/kongpluginbinding_adoption_test.go
@@ -18,6 +18,8 @@ import (
 	"github.com/kong/kong-operator/v2/modules/manager/logging"
 	"github.com/kong/kong-operator/v2/modules/manager/scheme"
 	k8sutils "github.com/kong/kong-operator/v2/pkg/utils/kubernetes"
+	"github.com/kong/kong-operator/v2/test/envtest"
+	"github.com/kong/kong-operator/v2/test/envtest/consts"
 	"github.com/kong/kong-operator/v2/test/helpers/deploy"
 	"github.com/kong/kong-operator/v2/test/helpers/eventually"
 	"github.com/kong/kong-operator/v2/test/mocks/metricsmocks"
@@ -26,13 +28,13 @@ import (
 
 func TestKongPluginBindingAdoption(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := Context(t, t.Context())
+	ctx, cancel := envtest.Context(t, t.Context())
 	defer cancel()
 
 	// Set up the envtest environment.
-	cfg, ns := Setup(t, ctx, scheme.Get(), WithInstallGatewayCRDs(true))
+	cfg, ns := envtest.Setup(t, ctx, scheme.Get(), envtest.WithInstallGatewayCRDs(true))
 
-	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())
+	mgr, logs := envtest.NewManager(t, ctx, cfg, scheme.Get())
 
 	t.Log("Setting up clients")
 	cl, err := client.NewWithWatch(mgr.GetConfig(), client.Options{
@@ -47,18 +49,18 @@ func TestKongPluginBindingAdoption(t *testing.T) {
 	factory := sdkmocks.NewMockSDKFactory(t)
 	sdk := factory.SDK
 
-	reconcilers := []Reconciler{
+	reconcilers := []envtest.Reconciler{
 		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
-			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongPluginBinding](konnectInfiniteSyncTime),
+			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongPluginBinding](consts.KonnectInfiniteSyncTime),
 			konnect.WithMetricRecorder[configurationv1alpha1.KongPluginBinding](&metricsmocks.MockRecorder{}),
 		),
 	}
 
-	StartReconcilers(ctx, t, mgr, logs, reconcilers...)
+	envtest.StartReconcilers(ctx, t, mgr, logs, reconcilers...)
 
 	t.Run("Adopting a globally applied plugin", func(t *testing.T) {
 		pluginID := uuid.NewString()
-		w := setupWatch[configurationv1alpha1.KongPluginBindingList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := envtest.SetupWatch[configurationv1alpha1.KongPluginBindingList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations for getting and updating plugins")
 		sdk.PluginSDK.EXPECT().GetPlugin(
@@ -91,7 +93,7 @@ func TestKongPluginBindingAdoption(t *testing.T) {
 		)
 
 		t.Logf("Waiting for KongPluginBinding %s/%s being Programmed and set Konnect ID", ns.Name, kpbGlobal.Name)
-		watchFor(t, ctx, w,
+		envtest.WatchFor(t, ctx, w,
 			apiwatch.Modified,
 			func(kpb *configurationv1alpha1.KongPluginBinding) bool {
 				return kpb.Name == kpbGlobal.Name &&
@@ -104,12 +106,12 @@ func TestKongPluginBindingAdoption(t *testing.T) {
 
 		t.Logf("Deleting the KongPluginBinding %s/%s", ns.Name, kpbGlobal.Name)
 		require.NoError(t, clientNamespaced.Delete(ctx, kpbGlobal))
-		eventually.WaitForObjectToNotExist(t, ctx, cl, kpbGlobal, waitTime, tickTime)
+		eventually.WaitForObjectToNotExist(t, ctx, cl, kpbGlobal, consts.WaitTime, consts.TickTime)
 	})
 
 	t.Run("Adopting a plugin attached to a service", func(t *testing.T) {
 		pluginID := uuid.NewString()
-		w := setupWatch[configurationv1alpha1.KongPluginBindingList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := envtest.SetupWatch[configurationv1alpha1.KongPluginBindingList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Creating a service with ID")
 		kongService := deploy.KongServiceWithID(t, ctx, clientNamespaced, deploy.WithKonnectNamespacedRefControlPlaneRef(cp))
@@ -149,7 +151,7 @@ func TestKongPluginBindingAdoption(t *testing.T) {
 		)
 
 		t.Logf("Waiting for KongPluginBinding %s/%s being Programmed and set Konnect ID", ns.Name, kpbService.Name)
-		watchFor(t, ctx, w,
+		envtest.WatchFor(t, ctx, w,
 			apiwatch.Modified,
 			func(kpb *configurationv1alpha1.KongPluginBinding) bool {
 				return kpb.Name == kpbService.Name &&
@@ -162,11 +164,11 @@ func TestKongPluginBindingAdoption(t *testing.T) {
 
 		t.Logf("Deleting the KongPluginBinding %s/%s", ns.Name, kpbService.Name)
 		require.NoError(t, clientNamespaced.Delete(ctx, kpbService))
-		eventually.WaitForObjectToNotExist(t, ctx, cl, kpbService, waitTime, tickTime)
+		eventually.WaitForObjectToNotExist(t, ctx, cl, kpbService, consts.WaitTime, consts.TickTime)
 	})
 
 	t.Run("Adopting without KongPlugin reference should fail", func(t *testing.T) {
-		w := setupWatch[configurationv1alpha1.KongPluginBindingList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := envtest.SetupWatch[configurationv1alpha1.KongPluginBindingList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Creating a KongPluginBinding without the KongPlugin to adopt the plugin")
 		kpbGlobal := deploy.KongPluginBinding(t, ctx, clientNamespaced, konnect.NewKongPluginBindingBuilder().
@@ -178,11 +180,11 @@ func TestKongPluginBindingAdoption(t *testing.T) {
 		)
 
 		t.Logf("Waiting for the KongPluginBinding %s/%s to be marked as not programmed with PluginRefValid=False", ns.Name, kpbGlobal.Name)
-		watchFor(t, ctx, w,
+		envtest.WatchFor(t, ctx, w,
 			apiwatch.Modified,
 			func(kpb *configurationv1alpha1.KongPluginBinding) bool {
 				return kpb.Name == kpbGlobal.Name &&
-					conditionsContainProgrammedFalse(kpb.GetConditions()) &&
+					envtest.ConditionsContainProgrammedFalse(kpb.GetConditions()) &&
 					k8sutils.HasConditionFalse(konnectv1alpha1.KongPluginRefValidConditionType, kpb)
 			},
 			"Did not see KongPluginBinding marked as not programmed with PluginRefValid=False in its conditions.",

--- a/test/envtest/konnect-api-gw/kongpluginbinding_managed_test.go
+++ b/test/envtest/konnect-api-gw/kongpluginbinding_managed_test.go
@@ -24,8 +24,10 @@ import (
 	"github.com/kong/kong-operator/v2/internal/utils/index"
 	"github.com/kong/kong-operator/v2/modules/manager/logging"
 	"github.com/kong/kong-operator/v2/modules/manager/scheme"
-	"github.com/kong/kong-operator/v2/pkg/consts"
+	pkgconsts "github.com/kong/kong-operator/v2/pkg/consts"
 	"github.com/kong/kong-operator/v2/pkg/metadata"
+	"github.com/kong/kong-operator/v2/test/envtest"
+	"github.com/kong/kong-operator/v2/test/envtest/consts"
 	"github.com/kong/kong-operator/v2/test/helpers/deploy"
 	"github.com/kong/kong-operator/v2/test/helpers/eventually"
 	"github.com/kong/kong-operator/v2/test/mocks/metricsmocks"
@@ -40,13 +42,13 @@ func TestKongPluginBindingManaged(t *testing.T) {
 	// KongPluginBindings.
 
 	t.Parallel()
-	ctx, cancel := Context(t, t.Context())
+	ctx, cancel := envtest.Context(t, t.Context())
 	defer cancel()
 
 	// Setup up the envtest environment.
-	cfg, ns := Setup(t, ctx, scheme.Get(), WithInstallGatewayCRDs(true))
+	cfg, ns := envtest.Setup(t, ctx, scheme.Get(), envtest.WithInstallGatewayCRDs(true))
 
-	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())
+	mgr, logs := envtest.NewManager(t, ctx, cfg, scheme.Get())
 
 	clientWithWatch, err := client.NewWithWatch(mgr.GetConfig(), client.Options{
 		Scheme: scheme.Get(),
@@ -61,15 +63,15 @@ func TestKongPluginBindingManaged(t *testing.T) {
 	factory := sdkmocks.NewMockSDKFactory(t)
 	sdk := factory.SDK
 
-	reconcilers := []Reconciler{
+	reconcilers := []envtest.Reconciler{
 		konnect.NewKongPluginReconciler(controller.Options{}, logging.DevelopmentMode, mgr.GetClient()),
 		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
-			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongPluginBinding](konnectInfiniteSyncTime),
+			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongPluginBinding](consts.KonnectInfiniteSyncTime),
 			konnect.WithMetricRecorder[configurationv1alpha1.KongPluginBinding](&metricsmocks.MockRecorder{}),
 		),
 	}
 
-	StartReconcilers(ctx, t, mgr, logs, reconcilers...)
+	envtest.StartReconcilers(ctx, t, mgr, logs, reconcilers...)
 
 	addPluginDeleteExpectation := func() {
 		sdk.PluginSDK.EXPECT().
@@ -105,7 +107,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 			exists = true
 			assert.NotEmpty(c, kpb.GetKonnectID())
 			assert.True(c, controllerutil.ContainsFinalizer(kpb, konnect.KonnectCleanupFinalizer))
-		}, waitTime, tickTime, "KongPluginBinding %s was not synced before deletion", key)
+		}, consts.WaitTime, consts.TickTime, "KongPluginBinding %s was not synced before deletion", key)
 		if !exists {
 			t.Logf("managed kongPluginBinding %s (bound to %s) was already deleted", key, client.ObjectKeyFromObject(obj))
 			return
@@ -114,7 +116,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		t.Logf("delete managed kongPluginBinding %s (bound to %s), then check it gets recreated", client.ObjectKeyFromObject(kpb), client.ObjectKeyFromObject(obj))
 		addPluginDeleteExpectation()
 		require.NoError(t, client.IgnoreNotFound(cl.Delete(ctx, kpb)))
-		eventually.WaitForObjectToNotExist(t, ctx, cl, kpb, waitTime, tickTime)
+		eventually.WaitForObjectToNotExist(t, ctx, cl, kpb, consts.WaitTime, consts.TickTime)
 	}
 
 	rateLimitingkongPlugin := &configurationv1.KongPlugin{
@@ -146,9 +148,9 @@ func TestKongPluginBindingManaged(t *testing.T) {
 				if !assert.NoError(c, clientNamespacedWithWatch.Get(ctx, client.ObjectKeyFromObject(rateLimitingkongPlugin), &kp)) {
 					return
 				}
-				assert.Equal(c, expected, controllerutil.ContainsFinalizer(&kp, consts.PluginInUseFinalizer))
+				assert.Equal(c, expected, controllerutil.ContainsFinalizer(&kp, pkgconsts.PluginInUseFinalizer))
 			},
-			waitTime, tickTime,
+			consts.WaitTime, consts.TickTime,
 			message,
 		)
 	}
@@ -177,7 +179,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 				}
 				assert.NotNil(c, found)
 			},
-			waitTime, tickTime,
+			consts.WaitTime, consts.TickTime,
 			message,
 		)
 		require.NotNil(t, found)
@@ -214,7 +216,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		t.Cleanup(func() {
 			require.NoError(t, clientNamespaced.Delete(ctx, kongService))
 		})
-		updateKongServiceStatusWithProgrammed(t, ctx, clientNamespaced, kongService, serviceID, cp.GetKonnectStatus().GetKonnectID())
+		envtest.UpdateKongServiceStatusWithProgrammed(t, ctx, clientNamespaced, kongService, serviceID, cp.GetKonnectStatus().GetKonnectID())
 
 		t.Logf("waiting for KongPluginBinding to be created")
 		kongPluginBinding := waitForKongPluginBinding(t, "KongPluginBinding wasn't created",
@@ -242,7 +244,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 			},
 		)
 
-		eventuallyAssertSDKExpectations(t, sdk.PluginSDK, waitTime, tickTime)
+		envtest.EventuallyAssertSDKExpectations(t, sdk.PluginSDK, consts.WaitTime, consts.TickTime)
 
 		t.Logf(
 			"remove annotation from KongService %s and check that managed KongPluginBinding %s gets deleted, "+
@@ -267,11 +269,11 @@ func TestKongPluginBindingManaged(t *testing.T) {
 			client.ObjectKeyFromObject(kongPluginBinding),
 		)
 		eventually.WaitForObjectToNotExist(
-			t, ctx, clientNamespaced, kongPluginBinding, waitTime, tickTime,
+			t, ctx, clientNamespaced, kongPluginBinding, consts.WaitTime, consts.TickTime,
 			"KongPluginBinding wasn't deleted after removing annotation from KongService",
 		)
 
-		eventuallyAssertSDKExpectations(t, sdk.PluginSDK, waitTime, tickTime)
+		envtest.EventuallyAssertSDKExpectations(t, sdk.PluginSDK, consts.WaitTime, consts.TickTime)
 	})
 
 	t.Run("binding to KongRoute", func(t *testing.T) {
@@ -284,7 +286,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		t.Cleanup(func() {
 			require.NoError(t, clientNamespaced.Delete(ctx, kongService))
 		})
-		updateKongServiceStatusWithProgrammed(t, ctx, clientNamespaced, kongService, serviceID, cp.GetKonnectStatus().GetKonnectID())
+		envtest.UpdateKongServiceStatusWithProgrammed(t, ctx, clientNamespaced, kongService, serviceID, cp.GetKonnectStatus().GetKonnectID())
 		kongRoute := deploy.KongRoute(
 			t, ctx, clientNamespaced,
 			deploy.WithAnnotation(metadata.AnnotationKeyPlugins, rateLimitingkongPlugin.Name),
@@ -293,7 +295,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		t.Cleanup(func() {
 			require.NoError(t, clientNamespaced.Delete(ctx, kongRoute))
 		})
-		updateKongRouteStatusWithProgrammed(t, ctx, clientNamespaced, kongRoute, routeID, cp.GetKonnectStatus().GetKonnectID(), serviceID)
+		envtest.UpdateKongRouteStatusWithProgrammed(t, ctx, clientNamespaced, kongRoute, routeID, cp.GetKonnectStatus().GetKonnectID(), serviceID)
 
 		t.Logf("waiting for KongPluginBinding to be created")
 		kongPluginBinding := waitForKongPluginBinding(t, "KongPluginBinding wasn't created",
@@ -321,7 +323,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 			},
 		)
 
-		eventuallyAssertSDKExpectations(t, sdk.PluginSDK, waitTime, tickTime)
+		envtest.EventuallyAssertSDKExpectations(t, sdk.PluginSDK, consts.WaitTime, consts.TickTime)
 
 		t.Logf(
 			"remove annotation from KongRoute %s and check that managed KongPluginBinding %s gets deleted, "+
@@ -346,18 +348,18 @@ func TestKongPluginBindingManaged(t *testing.T) {
 			client.ObjectKeyFromObject(kongPluginBinding),
 		)
 		eventually.WaitForObjectToNotExist(
-			t, ctx, clientNamespaced, kongPluginBinding, waitTime, tickTime,
+			t, ctx, clientNamespaced, kongPluginBinding, consts.WaitTime, consts.TickTime,
 			"KongPluginBinding wasn't deleted after removing annotation from KongRoute",
 		)
 
-		eventuallyAssertSDKExpectations(t, sdk.PluginSDK, waitTime, tickTime)
+		envtest.EventuallyAssertSDKExpectations(t, sdk.PluginSDK, consts.WaitTime, consts.TickTime)
 	})
 
 	t.Run("binding to KongService and KongRoute", func(t *testing.T) {
 		serviceID := uuid.NewString()
 		routeID := uuid.NewString()
 
-		wKongPluginBinding := setupWatch[configurationv1alpha1.KongPluginBindingList](t, ctx, clientWithWatch, client.InNamespace(ns.Name))
+		wKongPluginBinding := envtest.SetupWatch[configurationv1alpha1.KongPluginBindingList](t, ctx, clientWithWatch, client.InNamespace(ns.Name))
 		kongService := deploy.KongService(t, ctx, clientNamespaced,
 			deploy.WithKonnectNamespacedRefControlPlaneRef(cp),
 			deploy.WithAnnotation(metadata.AnnotationKeyPlugins, rateLimitingkongPlugin.Name),
@@ -365,7 +367,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		t.Cleanup(func() {
 			require.NoError(t, clientNamespaced.Delete(ctx, kongService))
 		})
-		updateKongServiceStatusWithProgrammed(t, ctx, clientNamespaced, kongService, serviceID, cp.GetKonnectStatus().GetKonnectID())
+		envtest.UpdateKongServiceStatusWithProgrammed(t, ctx, clientNamespaced, kongService, serviceID, cp.GetKonnectStatus().GetKonnectID())
 		kongRoute := deploy.KongRoute(t, ctx, clientNamespaced,
 			deploy.WithNamespacedKongServiceRef(kongService),
 			deploy.WithAnnotation(metadata.AnnotationKeyPlugins, rateLimitingkongPlugin.Name),
@@ -373,11 +375,11 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		t.Cleanup(func() {
 			require.NoError(t, clientNamespaced.Delete(ctx, kongRoute))
 		})
-		updateKongRouteStatusWithProgrammed(t, ctx, clientNamespaced, kongRoute, routeID, cp.GetKonnectStatus().GetKonnectID(), serviceID)
+		envtest.UpdateKongRouteStatusWithProgrammed(t, ctx, clientNamespaced, kongRoute, routeID, cp.GetKonnectStatus().GetKonnectID(), serviceID)
 
 		t.Logf("waiting for 2 KongPluginBindings to be created")
 		var kpbRoute, kpbService *configurationv1alpha1.KongPluginBinding
-		watchFor(t, ctx, wKongPluginBinding, apiwatch.Added,
+		envtest.WatchFor(t, ctx, wKongPluginBinding, apiwatch.Added,
 			func(kpb *configurationv1alpha1.KongPluginBinding) bool {
 				if kpb.Spec.PluginReference.Name != rateLimitingkongPlugin.Name {
 					return false
@@ -406,7 +408,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		deleteKongPluginBinding(t, ctx, clientNamespaced, kpbRoute, kongRoute)
 		deleteKongPluginBinding(t, ctx, clientNamespaced, kpbService, kongService)
 
-		watchFor(t, ctx, wKongPluginBinding, apiwatch.Added,
+		envtest.WatchFor(t, ctx, wKongPluginBinding, apiwatch.Added,
 			func(kpb *configurationv1alpha1.KongPluginBinding) bool {
 				if kpb.Spec.PluginReference.Name != rateLimitingkongPlugin.Name {
 					return false
@@ -437,7 +439,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		delete(kongRoute.Annotations, metadata.AnnotationKeyPlugins)
 		require.NoError(t, clientNamespaced.Update(ctx, kongRoute))
 		eventually.WaitForObjectToNotExist(
-			t, ctx, clientNamespaced, kpbRoute, waitTime, tickTime,
+			t, ctx, clientNamespaced, kpbRoute, consts.WaitTime, consts.TickTime,
 			"KongPluginBinding bound to Route wasn't deleted after removing annotation from KongRoute",
 		)
 
@@ -451,11 +453,11 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		require.NoError(t, clientNamespaced.Update(ctx, kongService))
 
 		eventually.WaitForObjectToNotExist(
-			t, ctx, clientNamespaced, kpbService, waitTime, tickTime,
+			t, ctx, clientNamespaced, kpbService, consts.WaitTime, consts.TickTime,
 			"KongPluginBinding bound to Service wasn't deleted after removing annotation from KongService",
 		)
 
-		eventuallyAssertSDKExpectations(t, sdk.PluginSDK, waitTime, tickTime)
+		envtest.EventuallyAssertSDKExpectations(t, sdk.PluginSDK, consts.WaitTime, consts.TickTime)
 	})
 
 	t.Run("binding to KongConsumer, KongService and KongRoute", func(t *testing.T) {
@@ -476,7 +478,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 			).
 			Maybe()
 
-		wKongPluginBinding := setupWatch[configurationv1alpha1.KongPluginBindingList](t, ctx, clientWithWatch, client.InNamespace(ns.Name))
+		wKongPluginBinding := envtest.SetupWatch[configurationv1alpha1.KongPluginBindingList](t, ctx, clientWithWatch, client.InNamespace(ns.Name))
 		kongService := deploy.KongService(t, ctx, clientNamespaced,
 			deploy.WithKonnectNamespacedRefControlPlaneRef(cp),
 			deploy.WithAnnotation(metadata.AnnotationKeyPlugins, rateLimitingkongPlugin.Name),
@@ -484,7 +486,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		t.Cleanup(func() {
 			require.NoError(t, clientNamespaced.Delete(ctx, kongService))
 		})
-		updateKongServiceStatusWithProgrammed(t, ctx, clientNamespaced, kongService, serviceID, cp.GetKonnectStatus().GetKonnectID())
+		envtest.UpdateKongServiceStatusWithProgrammed(t, ctx, clientNamespaced, kongService, serviceID, cp.GetKonnectStatus().GetKonnectID())
 		kongRoute := deploy.KongRoute(
 			t, ctx, clientNamespaced,
 			deploy.WithNamespacedKongServiceRef(kongService),
@@ -493,7 +495,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		t.Cleanup(func() {
 			require.NoError(t, clientNamespaced.Delete(ctx, kongRoute))
 		})
-		updateKongRouteStatusWithProgrammed(t, ctx, clientNamespaced, kongRoute, routeID, cp.GetKonnectStatus().GetKonnectID(), serviceID)
+		envtest.UpdateKongRouteStatusWithProgrammed(t, ctx, clientNamespaced, kongRoute, routeID, cp.GetKonnectStatus().GetKonnectID(), serviceID)
 		kongConsumer := deploy.KongConsumer(t, ctx, clientNamespaced, "username-1",
 			deploy.WithKonnectNamespacedRefControlPlaneRef(cp),
 			deploy.WithAnnotation(metadata.AnnotationKeyPlugins, rateLimitingkongPlugin.Name),
@@ -501,11 +503,11 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		t.Cleanup(func() {
 			require.NoError(t, clientNamespaced.Delete(ctx, kongConsumer))
 		})
-		updateKongConsumerStatusWithKonnectID(t, ctx, clientNamespaced, kongConsumer, consumerID, cp.GetKonnectStatus().GetKonnectID())
+		envtest.UpdateKongConsumerStatusWithKonnectID(t, ctx, clientNamespaced, kongConsumer, consumerID, cp.GetKonnectStatus().GetKonnectID())
 
 		t.Logf("waiting for 2 KongPluginBindings to be created")
 		var kpbRoute, kpbService *configurationv1alpha1.KongPluginBinding
-		watchFor(t, ctx, wKongPluginBinding, apiwatch.Added,
+		envtest.WatchFor(t, ctx, wKongPluginBinding, apiwatch.Added,
 			func(kpb *configurationv1alpha1.KongPluginBinding) bool {
 				if kpb.Spec.PluginReference.Name != rateLimitingkongPlugin.Name {
 					return false
@@ -538,7 +540,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		deleteKongPluginBinding(t, ctx, clientNamespaced, kpbRoute, kongRoute)
 		deleteKongPluginBinding(t, ctx, clientNamespaced, kpbService, kongService)
 
-		watchFor(t, ctx, wKongPluginBinding, apiwatch.Added,
+		envtest.WatchFor(t, ctx, wKongPluginBinding, apiwatch.Added,
 			func(kpb *configurationv1alpha1.KongPluginBinding) bool {
 				if kpb.Spec.PluginReference.Name != rateLimitingkongPlugin.Name {
 					return false
@@ -579,7 +581,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 				index.IndexFieldKongPluginBindingKongServiceReference:  kongService.Name,
 				index.IndexFieldKongPluginBindingKongConsumerReference: kongConsumer.Name,
 			},
-			waitTime, tickTime,
+			consts.WaitTime, consts.TickTime,
 			func(c *assert.CollectT, bindings []configurationv1alpha1.KongPluginBinding) {
 				assert.Len(c, bindings, 1)
 			},
@@ -587,7 +589,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		)
 
 		eventually.WaitForObjectToNotExist(
-			t, ctx, clientNamespaced, kpbRoute, waitTime, tickTime,
+			t, ctx, clientNamespaced, kpbRoute, consts.WaitTime, consts.TickTime,
 			"KongPluginBinding bound to Route wasn't deleted after removing annotation from KongRoute",
 		)
 
@@ -605,7 +607,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 				index.IndexFieldKongPluginBindingKongPluginReference:   managedPluginReference,
 				index.IndexFieldKongPluginBindingKongConsumerReference: kongConsumer.Name,
 			},
-			waitTime, tickTime,
+			consts.WaitTime, consts.TickTime,
 			func(c *assert.CollectT, bindings []configurationv1alpha1.KongPluginBinding) {
 				if !assert.Len(c, bindings, 1) {
 					return
@@ -635,14 +637,14 @@ func TestKongPluginBindingManaged(t *testing.T) {
 				index.IndexFieldKongPluginBindingKongPluginReference:   managedPluginReference,
 				index.IndexFieldKongPluginBindingKongConsumerReference: kongConsumer.Name,
 			},
-			waitTime, tickTime,
+			consts.WaitTime, consts.TickTime,
 			func(c *assert.CollectT, bindings []configurationv1alpha1.KongPluginBinding) {
 				assert.Empty(c, bindings)
 			},
 			"KongConsumer bound KongPluginBinding wasn't deleted",
 		)
 
-		eventuallyAssertSDKExpectations(t, sdk.PluginSDK, waitTime, tickTime)
+		envtest.EventuallyAssertSDKExpectations(t, sdk.PluginSDK, consts.WaitTime, consts.TickTime)
 	})
 
 	t.Run("binding to KongConsumerGroup, KongService and KongRoute", func(t *testing.T) {
@@ -663,7 +665,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 			).
 			Maybe()
 
-		wKongPluginBinding := setupWatch[configurationv1alpha1.KongPluginBindingList](t, ctx, clientWithWatch, client.InNamespace(ns.Name))
+		wKongPluginBinding := envtest.SetupWatch[configurationv1alpha1.KongPluginBindingList](t, ctx, clientWithWatch, client.InNamespace(ns.Name))
 		kongService := deploy.KongService(t, ctx, clientNamespaced,
 			deploy.WithKonnectNamespacedRefControlPlaneRef(cp),
 			deploy.WithAnnotation(metadata.AnnotationKeyPlugins, rateLimitingkongPlugin.Name),
@@ -671,7 +673,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		t.Cleanup(func() {
 			require.NoError(t, clientNamespaced.Delete(ctx, kongService))
 		})
-		updateKongServiceStatusWithProgrammed(t, ctx, clientNamespaced, kongService, serviceID, cp.GetKonnectStatus().GetKonnectID())
+		envtest.UpdateKongServiceStatusWithProgrammed(t, ctx, clientNamespaced, kongService, serviceID, cp.GetKonnectStatus().GetKonnectID())
 		kongRoute := deploy.KongRoute(
 			t, ctx, clientNamespaced,
 			deploy.WithNamespacedKongServiceRef(kongService),
@@ -680,7 +682,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		t.Cleanup(func() {
 			require.NoError(t, clientNamespaced.Delete(ctx, kongRoute))
 		})
-		updateKongRouteStatusWithProgrammed(t, ctx, clientNamespaced, kongRoute, routeID, cp.GetKonnectStatus().GetKonnectID(), serviceID)
+		envtest.UpdateKongRouteStatusWithProgrammed(t, ctx, clientNamespaced, kongRoute, routeID, cp.GetKonnectStatus().GetKonnectID(), serviceID)
 		kongConsumerGroup := deploy.KongConsumerGroupAttachedToCP(t, ctx, clientNamespaced,
 			deploy.WithKonnectNamespacedRefControlPlaneRef(cp),
 			deploy.WithAnnotation(metadata.AnnotationKeyPlugins, rateLimitingkongPlugin.Name),
@@ -688,11 +690,11 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		t.Cleanup(func() {
 			require.NoError(t, clientNamespaced.Delete(ctx, kongConsumerGroup))
 		})
-		updateKongConsumerGroupStatusWithKonnectID(t, ctx, clientNamespaced, kongConsumerGroup, consumerGroupID, cp.GetKonnectStatus().GetKonnectID())
+		envtest.UpdateKongConsumerGroupStatusWithKonnectID(t, ctx, clientNamespaced, kongConsumerGroup, consumerGroupID, cp.GetKonnectStatus().GetKonnectID())
 
 		t.Logf("waiting for 2 KongPluginBindings to be created")
 		var kpbRoute, kpbService *configurationv1alpha1.KongPluginBinding
-		watchFor(t, ctx, wKongPluginBinding, apiwatch.Added,
+		envtest.WatchFor(t, ctx, wKongPluginBinding, apiwatch.Added,
 			func(kpb *configurationv1alpha1.KongPluginBinding) bool {
 				if kpb.Spec.PluginReference.Name != rateLimitingkongPlugin.Name {
 					return false
@@ -725,7 +727,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		deleteKongPluginBinding(t, ctx, clientNamespaced, kpbRoute, kongRoute)
 		deleteKongPluginBinding(t, ctx, clientNamespaced, kpbService, kongService)
 
-		watchFor(t, ctx, wKongPluginBinding, apiwatch.Added,
+		envtest.WatchFor(t, ctx, wKongPluginBinding, apiwatch.Added,
 			func(kpb *configurationv1alpha1.KongPluginBinding) bool {
 				if kpb.Spec.PluginReference.Name != rateLimitingkongPlugin.Name {
 					return false
@@ -766,7 +768,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 				index.IndexFieldKongPluginBindingKongServiceReference:       kongService.Name,
 				index.IndexFieldKongPluginBindingKongConsumerGroupReference: kongConsumerGroup.Name,
 			},
-			waitTime, tickTime,
+			consts.WaitTime, consts.TickTime,
 			func(c *assert.CollectT, bindings []configurationv1alpha1.KongPluginBinding) {
 				assert.Len(c, bindings, 1)
 			},
@@ -774,7 +776,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 		)
 
 		eventually.WaitForObjectToNotExist(
-			t, ctx, clientNamespaced, kpbRoute, waitTime, tickTime,
+			t, ctx, clientNamespaced, kpbRoute, consts.WaitTime, consts.TickTime,
 			"KongPluginBinding bound to Route wasn't deleted after removing annotation from KongRoute",
 		)
 
@@ -792,7 +794,7 @@ func TestKongPluginBindingManaged(t *testing.T) {
 				index.IndexFieldKongPluginBindingKongPluginReference:        managedPluginReference,
 				index.IndexFieldKongPluginBindingKongConsumerGroupReference: kongConsumerGroup.Name,
 			},
-			waitTime, tickTime,
+			consts.WaitTime, consts.TickTime,
 			func(c *assert.CollectT, bindings []configurationv1alpha1.KongPluginBinding) {
 				if !assert.Len(c, bindings, 1) {
 					return
@@ -822,13 +824,13 @@ func TestKongPluginBindingManaged(t *testing.T) {
 				index.IndexFieldKongPluginBindingKongPluginReference:        managedPluginReference,
 				index.IndexFieldKongPluginBindingKongConsumerGroupReference: kongConsumerGroup.Name,
 			},
-			waitTime, tickTime,
+			consts.WaitTime, consts.TickTime,
 			func(c *assert.CollectT, bindings []configurationv1alpha1.KongPluginBinding) {
 				assert.Empty(c, bindings)
 			},
 			"KongConsumerGroup bound KongPluginBinding wasn't deleted",
 		)
 
-		eventuallyAssertSDKExpectations(t, sdk.PluginSDK, waitTime, tickTime)
+		envtest.EventuallyAssertSDKExpectations(t, sdk.PluginSDK, consts.WaitTime, consts.TickTime)
 	})
 }

--- a/test/envtest/konnect-api-gw/kongpluginbinding_unmanaged_test.go
+++ b/test/envtest/konnect-api-gw/kongpluginbinding_unmanaged_test.go
@@ -19,6 +19,8 @@ import (
 	"github.com/kong/kong-operator/v2/modules/manager/logging"
 	"github.com/kong/kong-operator/v2/modules/manager/scheme"
 	k8sutils "github.com/kong/kong-operator/v2/pkg/utils/kubernetes"
+	"github.com/kong/kong-operator/v2/test/envtest"
+	"github.com/kong/kong-operator/v2/test/envtest/consts"
 	"github.com/kong/kong-operator/v2/test/helpers/deploy"
 	"github.com/kong/kong-operator/v2/test/mocks/metricsmocks"
 	"github.com/kong/kong-operator/v2/test/mocks/sdkmocks"
@@ -26,13 +28,13 @@ import (
 
 func TestKongPluginBindingUnmanaged(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := Context(t, t.Context())
+	ctx, cancel := envtest.Context(t, t.Context())
 	defer cancel()
 
 	// Setup up the envtest environment.
-	cfg, ns := Setup(t, ctx, scheme.Get(), WithInstallGatewayCRDs(true))
+	cfg, ns := envtest.Setup(t, ctx, scheme.Get(), envtest.WithInstallGatewayCRDs(true))
 
-	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())
+	mgr, logs := envtest.NewManager(t, ctx, cfg, scheme.Get())
 
 	clientOptions := client.Options{
 		Scheme: scheme.Get(),
@@ -50,14 +52,14 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 	factory := sdkmocks.NewMockSDKFactory(t)
 	sdk := factory.SDK
 
-	reconcilers := []Reconciler{
+	reconcilers := []envtest.Reconciler{
 		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
-			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongPluginBinding](konnectInfiniteSyncTime),
+			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongPluginBinding](consts.KonnectInfiniteSyncTime),
 			konnect.WithMetricRecorder[configurationv1alpha1.KongPluginBinding](&metricsmocks.MockRecorder{}),
 		),
 	}
 
-	StartReconcilers(ctx, t, mgr, logs, reconcilers...)
+	envtest.StartReconcilers(ctx, t, mgr, logs, reconcilers...)
 
 	t.Run("binding to KongService", func(t *testing.T) {
 		proxyCacheKongPlugin := deploy.ProxyCachePlugin(t, ctx, clientNamespaced)
@@ -80,7 +82,7 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 		kongService := deploy.KongService(t, ctx, clientNamespaced,
 			deploy.WithKonnectNamespacedRefControlPlaneRef(cp),
 		)
-		updateKongServiceStatusWithProgrammed(t, ctx, clientNamespaced, kongService, serviceID, cp.GetKonnectStatus().GetKonnectID())
+		envtest.UpdateKongServiceStatusWithProgrammed(t, ctx, clientNamespaced, kongService, serviceID, cp.GetKonnectStatus().GetKonnectID())
 
 		kpb := deploy.KongPluginBinding(t, ctx, clientNamespaced,
 			konnect.NewKongPluginBindingBuilder().
@@ -94,8 +96,8 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 			client.ObjectKeyFromObject(kpb),
 		)
 		assert.EventuallyWithT(t,
-			assertCollectObjectExistsAndHasKonnectID(t, ctx, clientNamespaced, kpb, pluginID),
-			waitTime, tickTime,
+			envtest.AssertCollectObjectExistsAndHasKonnectID(t, ctx, clientNamespaced, kpb, pluginID),
+			consts.WaitTime, consts.TickTime,
 			"KongPlugin wasn't created using Konnect API or its KonnectID wasn't set",
 		)
 
@@ -116,7 +118,7 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 			assert.True(c, apierrors.IsNotFound(
 				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kpb), kpb),
 			))
-		}, waitTime, tickTime, "KongPluginBinding did not get deleted but should have")
+		}, consts.WaitTime, consts.TickTime, "KongPluginBinding did not get deleted but should have")
 
 		t.Logf(
 			"delete the KongService %s and check it gets collected, as there should be no finalizer blocking its deletion",
@@ -127,9 +129,9 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 			assert.True(c, apierrors.IsNotFound(
 				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kongService), kongService),
 			))
-		}, waitTime, tickTime)
+		}, consts.WaitTime, consts.TickTime)
 
-		eventuallyAssertSDKExpectations(t, sdk.PluginSDK, waitTime, tickTime)
+		envtest.EventuallyAssertSDKExpectations(t, sdk.PluginSDK, consts.WaitTime, consts.TickTime)
 	})
 	t.Run("binding to KongRoute", func(t *testing.T) {
 		proxyCacheKongPlugin := deploy.ProxyCachePlugin(t, ctx, clientNamespaced)
@@ -154,9 +156,9 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 			deploy.WithKonnectNamespacedRefControlPlaneRef(cp),
 		)
 
-		updateKongServiceStatusWithProgrammed(t, ctx, clientNamespaced, kongService, serviceID, cp.GetKonnectStatus().GetKonnectID())
+		envtest.UpdateKongServiceStatusWithProgrammed(t, ctx, clientNamespaced, kongService, serviceID, cp.GetKonnectStatus().GetKonnectID())
 		kongRoute := deploy.KongRoute(t, ctx, clientNamespaced, deploy.WithNamespacedKongServiceRef(kongService))
-		updateKongRouteStatusWithProgrammed(t, ctx, clientNamespaced, kongRoute, routeID, cp.GetKonnectStatus().GetKonnectID(), serviceID)
+		envtest.UpdateKongRouteStatusWithProgrammed(t, ctx, clientNamespaced, kongRoute, routeID, cp.GetKonnectStatus().GetKonnectID(), serviceID)
 
 		kpb := deploy.KongPluginBinding(t, ctx, clientNamespaced,
 			konnect.NewKongPluginBindingBuilder().
@@ -170,8 +172,8 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 			client.ObjectKeyFromObject(kpb),
 		)
 		assert.EventuallyWithT(t,
-			assertCollectObjectExistsAndHasKonnectID(t, ctx, clientNamespaced, kpb, pluginID),
-			waitTime, tickTime,
+			envtest.AssertCollectObjectExistsAndHasKonnectID(t, ctx, clientNamespaced, kpb, pluginID),
+			consts.WaitTime, consts.TickTime,
 			"KongPlugin wasn't created using Konnect API or its KonnectID wasn't set",
 		)
 
@@ -192,7 +194,7 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 			assert.True(c, apierrors.IsNotFound(
 				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kpb), kpb),
 			))
-		}, waitTime, tickTime, "KongPluginBinding did not get deleted but should have")
+		}, consts.WaitTime, consts.TickTime, "KongPluginBinding did not get deleted but should have")
 
 		t.Logf(
 			"delete the KongRoute %s and check it gets collected, as there should be no finalizer blocking its deletion",
@@ -203,9 +205,9 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 			assert.True(c, apierrors.IsNotFound(
 				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kongRoute), kongRoute),
 			))
-		}, waitTime, tickTime)
+		}, consts.WaitTime, consts.TickTime)
 
-		eventuallyAssertSDKExpectations(t, sdk.PluginSDK, waitTime, tickTime)
+		envtest.EventuallyAssertSDKExpectations(t, sdk.PluginSDK, consts.WaitTime, consts.TickTime)
 	})
 
 	t.Run("binding to KongService and KongRoute", func(t *testing.T) {
@@ -219,9 +221,9 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 			deploy.WithKonnectNamespacedRefControlPlaneRef(cp),
 		)
 
-		updateKongServiceStatusWithProgrammed(t, ctx, clientNamespaced, kongService, serviceID, cp.GetKonnectStatus().GetKonnectID())
+		envtest.UpdateKongServiceStatusWithProgrammed(t, ctx, clientNamespaced, kongService, serviceID, cp.GetKonnectStatus().GetKonnectID())
 		kongRoute := deploy.KongRoute(t, ctx, clientNamespaced, deploy.WithNamespacedKongServiceRef(kongService))
-		updateKongRouteStatusWithProgrammed(t, ctx, clientNamespaced, kongRoute, routeID, cp.GetKonnectStatus().GetKonnectID(), serviceID)
+		envtest.UpdateKongRouteStatusWithProgrammed(t, ctx, clientNamespaced, kongRoute, routeID, cp.GetKonnectStatus().GetKonnectID(), serviceID)
 
 		sdk.PluginSDK.EXPECT().
 			CreatePlugin(
@@ -252,8 +254,8 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 			client.ObjectKeyFromObject(kpb),
 		)
 		assert.EventuallyWithT(t,
-			assertCollectObjectExistsAndHasKonnectID(t, ctx, clientNamespaced, kpb, pluginID),
-			waitTime, tickTime,
+			envtest.AssertCollectObjectExistsAndHasKonnectID(t, ctx, clientNamespaced, kpb, pluginID),
+			consts.WaitTime, consts.TickTime,
 			"KongPlugin wasn't created using Konnect API or its KonnectID wasn't set",
 		)
 
@@ -274,7 +276,7 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 			assert.True(c, apierrors.IsNotFound(
 				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kpb), kpb),
 			))
-		}, waitTime, tickTime, "KongPluginBinding did not get deleted but should have")
+		}, consts.WaitTime, consts.TickTime, "KongPluginBinding did not get deleted but should have")
 
 		t.Logf(
 			"delete the KongRoute %s and check it gets collected, as there should be no finalizer blocking its deletion",
@@ -285,9 +287,9 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 			assert.True(c, apierrors.IsNotFound(
 				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kongRoute), kongRoute),
 			))
-		}, waitTime, tickTime)
+		}, consts.WaitTime, consts.TickTime)
 
-		eventuallyAssertSDKExpectations(t, sdk.PluginSDK, waitTime, tickTime)
+		envtest.EventuallyAssertSDKExpectations(t, sdk.PluginSDK, consts.WaitTime, consts.TickTime)
 	})
 
 	t.Run("binding to KongService and KongConsumer", func(t *testing.T) {
@@ -305,14 +307,14 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 		t.Cleanup(func() {
 			require.NoError(t, client.IgnoreNotFound(clientNamespaced.Delete(ctx, kongService)))
 		})
-		updateKongServiceStatusWithProgrammed(t, ctx, clientNamespaced, kongService, serviceID, cp.GetKonnectStatus().GetKonnectID())
+		envtest.UpdateKongServiceStatusWithProgrammed(t, ctx, clientNamespaced, kongService, serviceID, cp.GetKonnectStatus().GetKonnectID())
 		kongConsumer := deploy.KongConsumer(t, ctx, clientNamespaced, username,
 			deploy.WithKonnectNamespacedRefControlPlaneRef(cp),
 		)
 		t.Cleanup(func() {
 			require.NoError(t, client.IgnoreNotFound(clientNamespaced.Delete(ctx, kongConsumer)))
 		})
-		updateKongConsumerStatusWithKonnectID(t, ctx, clientNamespaced, kongConsumer, consumerID, cp.GetKonnectStatus().GetKonnectID())
+		envtest.UpdateKongConsumerStatusWithKonnectID(t, ctx, clientNamespaced, kongConsumer, consumerID, cp.GetKonnectStatus().GetKonnectID())
 
 		sdk.PluginSDK.EXPECT().
 			CreatePlugin(
@@ -343,8 +345,8 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 			client.ObjectKeyFromObject(kpb),
 		)
 		assert.EventuallyWithT(t,
-			assertCollectObjectExistsAndHasKonnectID(t, ctx, clientNamespaced, kpb, pluginID),
-			waitTime, tickTime,
+			envtest.AssertCollectObjectExistsAndHasKonnectID(t, ctx, clientNamespaced, kpb, pluginID),
+			consts.WaitTime, consts.TickTime,
 			"KongPlugin wasn't created using Konnect API or its KonnectID wasn't set",
 		)
 
@@ -365,7 +367,7 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 			assert.True(c, apierrors.IsNotFound(
 				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kpb), kpb),
 			))
-		}, waitTime, tickTime, "KongPluginBinding did not get deleted but should have")
+		}, consts.WaitTime, consts.TickTime, "KongPluginBinding did not get deleted but should have")
 
 		t.Logf(
 			"delete the KongConsumer %s and check it gets collected, as there should be no finalizer blocking its deletion",
@@ -376,9 +378,9 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 			assert.True(c, apierrors.IsNotFound(
 				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kongConsumer), kongConsumer),
 			))
-		}, waitTime, tickTime)
+		}, consts.WaitTime, consts.TickTime)
 
-		eventuallyAssertSDKExpectations(t, sdk.PluginSDK, waitTime, tickTime)
+		envtest.EventuallyAssertSDKExpectations(t, sdk.PluginSDK, consts.WaitTime, consts.TickTime)
 	})
 
 	t.Run("binding to KongService and KongConsumerGroup", func(t *testing.T) {
@@ -392,11 +394,11 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 			deploy.WithKonnectNamespacedRefControlPlaneRef(cp),
 		)
 
-		updateKongServiceStatusWithProgrammed(t, ctx, clientNamespaced, kongService, serviceID, cp.GetKonnectStatus().GetKonnectID())
+		envtest.UpdateKongServiceStatusWithProgrammed(t, ctx, clientNamespaced, kongService, serviceID, cp.GetKonnectStatus().GetKonnectID())
 		kongConsumerGroup := deploy.KongConsumerGroupAttachedToCP(t, ctx, clientNamespaced,
 			deploy.WithKonnectNamespacedRefControlPlaneRef(cp),
 		)
-		updateKongConsumerGroupStatusWithKonnectID(t, ctx, clientNamespaced, kongConsumerGroup, consumerGroupID, cp.GetKonnectStatus().GetKonnectID())
+		envtest.UpdateKongConsumerGroupStatusWithKonnectID(t, ctx, clientNamespaced, kongConsumerGroup, consumerGroupID, cp.GetKonnectStatus().GetKonnectID())
 
 		sdk.PluginSDK.EXPECT().
 			CreatePlugin(
@@ -427,8 +429,8 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 			client.ObjectKeyFromObject(kpb),
 		)
 		assert.EventuallyWithT(t,
-			assertCollectObjectExistsAndHasKonnectID(t, ctx, clientNamespaced, kpb, pluginID),
-			waitTime, tickTime,
+			envtest.AssertCollectObjectExistsAndHasKonnectID(t, ctx, clientNamespaced, kpb, pluginID),
+			consts.WaitTime, consts.TickTime,
 			"KongPlugin wasn't created using Konnect API or its KonnectID wasn't set",
 		)
 
@@ -449,7 +451,7 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 			assert.True(c, apierrors.IsNotFound(
 				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kpb), kpb),
 			))
-		}, waitTime, tickTime, "KongPluginBinding did not get deleted but should have")
+		}, consts.WaitTime, consts.TickTime, "KongPluginBinding did not get deleted but should have")
 
 		t.Logf(
 			"delete the KongConsumerGroup %s and check it gets collected, as there should be no finalizer blocking its deletion",
@@ -460,9 +462,9 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 			assert.True(c, apierrors.IsNotFound(
 				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kongConsumerGroup), kongConsumerGroup),
 			))
-		}, waitTime, tickTime)
+		}, consts.WaitTime, consts.TickTime)
 
-		eventuallyAssertSDKExpectations(t, sdk.PluginSDK, waitTime, tickTime)
+		envtest.EventuallyAssertSDKExpectations(t, sdk.PluginSDK, consts.WaitTime, consts.TickTime)
 	})
 
 	t.Run("binding globally", func(t *testing.T) {
@@ -496,8 +498,8 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 			client.ObjectKeyFromObject(kpb),
 		)
 		assert.EventuallyWithT(t,
-			assertCollectObjectExistsAndHasKonnectID(t, ctx, clientNamespaced, kpb, pluginID),
-			waitTime, tickTime,
+			envtest.AssertCollectObjectExistsAndHasKonnectID(t, ctx, clientNamespaced, kpb, pluginID),
+			consts.WaitTime, consts.TickTime,
 			"KongPluginBinding wasn't created using Konnect API or its KonnectID wasn't set",
 		)
 
@@ -518,13 +520,13 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 			assert.True(c, apierrors.IsNotFound(
 				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kpb), kpb),
 			))
-		}, waitTime, tickTime, "KongPluginBinding did not get deleted but should have")
+		}, consts.WaitTime, consts.TickTime, "KongPluginBinding did not get deleted but should have")
 
-		eventuallyAssertSDKExpectations(t, sdk.PluginSDK, waitTime, tickTime)
+		envtest.EventuallyAssertSDKExpectations(t, sdk.PluginSDK, consts.WaitTime, consts.TickTime)
 	})
 
 	t.Run("binding to KongService with KongPlugin from another namespace with valid KongReferenceGrant", func(t *testing.T) {
-		w := setupWatch[configurationv1alpha1.KongPluginBindingList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := envtest.SetupWatch[configurationv1alpha1.KongPluginBindingList](t, ctx, cl, client.InNamespace(ns.Name))
 		proxyCacheKongPlugin := deploy.ProxyCachePlugin(t, ctx, clientNamespaced2)
 
 		serviceID := uuid.NewString()
@@ -545,7 +547,7 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 		kongService := deploy.KongService(t, ctx, clientNamespaced,
 			deploy.WithKonnectNamespacedRefControlPlaneRef(cp),
 		)
-		updateKongServiceStatusWithProgrammed(t, ctx, clientNamespaced, kongService, serviceID, cp.GetKonnectStatus().GetKonnectID())
+		envtest.UpdateKongServiceStatusWithProgrammed(t, ctx, clientNamespaced, kongService, serviceID, cp.GetKonnectStatus().GetKonnectID())
 
 		krg := deploy.KongReferenceGrant(t, ctx, clientNamespaced2,
 			deploy.KongReferenceGrantFroms(configurationv1alpha1.ReferenceGrantFrom{
@@ -576,13 +578,13 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 			client.ObjectKeyFromObject(kpb),
 		)
 		assert.EventuallyWithT(t,
-			assertCollectObjectExistsAndHasKonnectID(t, ctx, clientNamespaced, kpb, pluginID),
-			waitTime, tickTime,
+			envtest.AssertCollectObjectExistsAndHasKonnectID(t, ctx, clientNamespaced, kpb, pluginID),
+			consts.WaitTime, consts.TickTime,
 			"KongPlugin wasn't created using Konnect API or its KonnectID wasn't set",
 		)
 
 		t.Log("Waiting for KongPluginBinding to get PluginRefValid condition with status=True")
-		watchFor(t, ctx, w, apiwatch.Modified, func(k *configurationv1alpha1.KongPluginBinding) bool {
+		envtest.WatchFor(t, ctx, w, apiwatch.Modified, func(k *configurationv1alpha1.KongPluginBinding) bool {
 			if k.GetName() != kpb.GetName() || k.GetNamespace() != kpb.GetNamespace() {
 				return false
 			}
@@ -608,7 +610,7 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 			assert.True(c, apierrors.IsNotFound(
 				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kpb), kpb),
 			))
-		}, waitTime, tickTime, "KongPluginBinding did not get deleted but should have")
+		}, consts.WaitTime, consts.TickTime, "KongPluginBinding did not get deleted but should have")
 
 		t.Logf(
 			"delete the KongService %s and check it gets collected, as there should be no finalizer blocking its deletion",
@@ -619,13 +621,13 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 			assert.True(c, apierrors.IsNotFound(
 				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kongService), kongService),
 			))
-		}, waitTime, tickTime)
+		}, consts.WaitTime, consts.TickTime)
 
-		eventuallyAssertSDKExpectations(t, sdk.PluginSDK, waitTime, tickTime)
+		envtest.EventuallyAssertSDKExpectations(t, sdk.PluginSDK, consts.WaitTime, consts.TickTime)
 	})
 
 	t.Run("binding to KongService with KongPlugin from another namespace without valid KongReferenceGrant", func(t *testing.T) {
-		w := setupWatch[configurationv1alpha1.KongPluginBindingList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := envtest.SetupWatch[configurationv1alpha1.KongPluginBindingList](t, ctx, cl, client.InNamespace(ns.Name))
 		proxyCacheKongPlugin := deploy.ProxyCachePlugin(t, ctx, clientNamespaced2)
 
 		serviceID := uuid.NewString()
@@ -633,7 +635,7 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 		kongService := deploy.KongService(t, ctx, clientNamespaced,
 			deploy.WithKonnectNamespacedRefControlPlaneRef(cp),
 		)
-		updateKongServiceStatusWithProgrammed(t, ctx, clientNamespaced, kongService, serviceID, cp.GetKonnectStatus().GetKonnectID())
+		envtest.UpdateKongServiceStatusWithProgrammed(t, ctx, clientNamespaced, kongService, serviceID, cp.GetKonnectStatus().GetKonnectID())
 
 		kpb := deploy.KongPluginBinding(t, ctx, clientNamespaced,
 			konnect.NewKongPluginBindingBuilder().
@@ -649,7 +651,7 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 		)
 
 		t.Log("Waiting for KongPluginBinding to get PluginRefValid condition with status=False")
-		watchFor(t, ctx, w, apiwatch.Modified, func(k *configurationv1alpha1.KongPluginBinding) bool {
+		envtest.WatchFor(t, ctx, w, apiwatch.Modified, func(k *configurationv1alpha1.KongPluginBinding) bool {
 			if k.GetName() != kpb.GetName() || k.GetNamespace() != kpb.GetNamespace() {
 				return false
 			}
@@ -665,7 +667,7 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 			assert.True(c, apierrors.IsNotFound(
 				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kpb), kpb),
 			))
-		}, waitTime, tickTime, "KongPluginBinding did not get deleted but should have")
+		}, consts.WaitTime, consts.TickTime, "KongPluginBinding did not get deleted but should have")
 
 		t.Logf(
 			"delete the KongService %s and check it gets collected, as there should be no finalizer blocking its deletion",
@@ -676,20 +678,20 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 			assert.True(c, apierrors.IsNotFound(
 				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kongService), kongService),
 			))
-		}, waitTime, tickTime)
+		}, consts.WaitTime, consts.TickTime)
 
-		eventuallyAssertSDKExpectations(t, sdk.PluginSDK, waitTime, tickTime)
+		envtest.EventuallyAssertSDKExpectations(t, sdk.PluginSDK, consts.WaitTime, consts.TickTime)
 	})
 
 	t.Run("binding to KongService with same-namespace KongPlugin not found gets PluginRefValid=False/Invalid", func(t *testing.T) {
-		w := setupWatch[configurationv1alpha1.KongPluginBindingList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := envtest.SetupWatch[configurationv1alpha1.KongPluginBindingList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		serviceID := uuid.NewString()
 
 		kongService := deploy.KongService(t, ctx, clientNamespaced,
 			deploy.WithKonnectNamespacedRefControlPlaneRef(cp),
 		)
-		updateKongServiceStatusWithProgrammed(t, ctx, clientNamespaced, kongService, serviceID, cp.GetKonnectStatus().GetKonnectID())
+		envtest.UpdateKongServiceStatusWithProgrammed(t, ctx, clientNamespaced, kongService, serviceID, cp.GetKonnectStatus().GetKonnectID())
 
 		// Create a binding that references a KongPlugin that does not exist.
 		kpb := deploy.KongPluginBinding(t, ctx, clientNamespaced,
@@ -705,7 +707,7 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 		)
 
 		t.Log("Waiting for KongPluginBinding to get PluginRefValid=False/Invalid condition")
-		watchFor(t, ctx, w, apiwatch.Modified, func(k *configurationv1alpha1.KongPluginBinding) bool {
+		envtest.WatchFor(t, ctx, w, apiwatch.Modified, func(k *configurationv1alpha1.KongPluginBinding) bool {
 			if k.GetName() != kpb.GetName() || k.GetNamespace() != kpb.GetNamespace() {
 				return false
 			}
@@ -718,20 +720,20 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 			assert.True(c, apierrors.IsNotFound(
 				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kpb), kpb),
 			))
-		}, waitTime, tickTime, "KongPluginBinding did not get deleted but should have")
+		}, consts.WaitTime, consts.TickTime, "KongPluginBinding did not get deleted but should have")
 
 		require.NoError(t, clientNamespaced.Delete(ctx, kongService))
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
 			assert.True(c, apierrors.IsNotFound(
 				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kongService), kongService),
 			))
-		}, waitTime, tickTime)
+		}, consts.WaitTime, consts.TickTime)
 
-		eventuallyAssertSDKExpectations(t, sdk.PluginSDK, waitTime, tickTime)
+		envtest.EventuallyAssertSDKExpectations(t, sdk.PluginSDK, consts.WaitTime, consts.TickTime)
 	})
 
 	t.Run("binding to KongService with cross-namespace KongPlugin not found (grant present) gets PluginRefValid=False/Invalid", func(t *testing.T) {
-		w := setupWatch[configurationv1alpha1.KongPluginBindingList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := envtest.SetupWatch[configurationv1alpha1.KongPluginBindingList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		serviceID := uuid.NewString()
 
@@ -754,7 +756,7 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 		kongService := deploy.KongService(t, ctx, clientNamespaced,
 			deploy.WithKonnectNamespacedRefControlPlaneRef(cp),
 		)
-		updateKongServiceStatusWithProgrammed(t, ctx, clientNamespaced, kongService, serviceID, cp.GetKonnectStatus().GetKonnectID())
+		envtest.UpdateKongServiceStatusWithProgrammed(t, ctx, clientNamespaced, kongService, serviceID, cp.GetKonnectStatus().GetKonnectID())
 
 		kpb := deploy.KongPluginBinding(t, ctx, clientNamespaced,
 			konnect.NewKongPluginBindingBuilder().
@@ -770,7 +772,7 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 		)
 
 		t.Log("Waiting for KongPluginBinding to get PluginRefValid=False/Invalid condition")
-		watchFor(t, ctx, w, apiwatch.Modified, func(k *configurationv1alpha1.KongPluginBinding) bool {
+		envtest.WatchFor(t, ctx, w, apiwatch.Modified, func(k *configurationv1alpha1.KongPluginBinding) bool {
 			if k.GetName() != kpb.GetName() || k.GetNamespace() != kpb.GetNamespace() {
 				return false
 			}
@@ -783,15 +785,15 @@ func TestKongPluginBindingUnmanaged(t *testing.T) {
 			assert.True(c, apierrors.IsNotFound(
 				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kpb), kpb),
 			))
-		}, waitTime, tickTime, "KongPluginBinding did not get deleted but should have")
+		}, consts.WaitTime, consts.TickTime, "KongPluginBinding did not get deleted but should have")
 
 		require.NoError(t, clientNamespaced.Delete(ctx, kongService))
 		assert.EventuallyWithT(t, func(c *assert.CollectT) {
 			assert.True(c, apierrors.IsNotFound(
 				clientNamespaced.Get(ctx, client.ObjectKeyFromObject(kongService), kongService),
 			))
-		}, waitTime, tickTime)
+		}, consts.WaitTime, consts.TickTime)
 
-		eventuallyAssertSDKExpectations(t, sdk.PluginSDK, waitTime, tickTime)
+		envtest.EventuallyAssertSDKExpectations(t, sdk.PluginSDK, consts.WaitTime, consts.TickTime)
 	})
 }

--- a/test/envtest/konnect-api-gw/konnect_entities_kongconsumer_test.go
+++ b/test/envtest/konnect-api-gw/konnect_entities_kongconsumer_test.go
@@ -31,6 +31,8 @@ import (
 	"github.com/kong/kong-operator/v2/modules/manager/logging"
 	"github.com/kong/kong-operator/v2/modules/manager/scheme"
 	k8sutils "github.com/kong/kong-operator/v2/pkg/utils/kubernetes"
+	"github.com/kong/kong-operator/v2/test/envtest"
+	"github.com/kong/kong-operator/v2/test/envtest/consts"
 	"github.com/kong/kong-operator/v2/test/helpers/deploy"
 	"github.com/kong/kong-operator/v2/test/mocks/metricsmocks"
 	"github.com/kong/kong-operator/v2/test/mocks/sdkmocks"
@@ -38,26 +40,26 @@ import (
 
 func TestKongConsumer(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := Context(t, t.Context())
+	ctx, cancel := envtest.Context(t, t.Context())
 	defer cancel()
-	cfg, ns := Setup(t, ctx, scheme.Get(), WithInstallGatewayCRDs(true))
+	cfg, ns := envtest.Setup(t, ctx, scheme.Get(), envtest.WithInstallGatewayCRDs(true))
 
 	t.Log("Setting up the manager with reconcilers")
-	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())
+	mgr, logs := envtest.NewManager(t, ctx, cfg, scheme.Get())
 	factory := sdkmocks.NewMockSDKFactory(t)
 	sdk := factory.SDK
-	reconcilers := []Reconciler{
+	reconcilers := []envtest.Reconciler{
 		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
-			konnect.WithKonnectEntitySyncPeriod[configurationv1.KongConsumer](konnectInfiniteSyncTime),
+			konnect.WithKonnectEntitySyncPeriod[configurationv1.KongConsumer](consts.KonnectInfiniteSyncTime),
 			konnect.WithMetricRecorder[configurationv1.KongConsumer](&metricsmocks.MockRecorder{}),
 		),
 		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
-			konnect.WithKonnectEntitySyncPeriod[configurationv1beta1.KongConsumerGroup](konnectInfiniteSyncTime),
+			konnect.WithKonnectEntitySyncPeriod[configurationv1beta1.KongConsumerGroup](consts.KonnectInfiniteSyncTime),
 			konnect.WithMetricRecorder[configurationv1beta1.KongConsumerGroup](&metricsmocks.MockRecorder{}),
 		),
 		konnect.NewKongCredentialSecretReconciler(controller.Options{}, logging.DevelopmentMode, mgr.GetClient(), mgr.GetScheme()),
 	}
-	StartReconcilers(ctx, t, mgr, logs, reconcilers...)
+	envtest.StartReconcilers(ctx, t, mgr, logs, reconcilers...)
 
 	t.Log("Setting up clients")
 	cl, err := client.NewWithWatch(mgr.GetConfig(), client.Options{
@@ -70,7 +72,7 @@ func TestKongConsumer(t *testing.T) {
 	apiAuth := deploy.KonnectAPIAuthConfigurationWithProgrammed(t, ctx, clientNamespaced)
 	cp := deploy.KonnectGatewayControlPlaneWithID(t, ctx, clientNamespaced, apiAuth)
 
-	wConsumer := setupWatch[configurationv1.KongConsumerList](t, ctx, cl, client.InNamespace(ns.Name))
+	wConsumer := envtest.SetupWatch[configurationv1.KongConsumerList](t, ctx, cl, client.InNamespace(ns.Name))
 
 	t.Run("should create, update and delete Consumer without ConsumerGroups successfully", func(t *testing.T) {
 		const (
@@ -111,15 +113,15 @@ func TestKongConsumer(t *testing.T) {
 		)
 
 		t.Log("Waiting for KongConsumer to be programmed")
-		watchFor(t, ctx, wConsumer, apiwatch.Modified,
-			assertsAnd(
-				objectMatchesName(createdConsumer),
-				objectHasConditionProgrammedSetToTrue[*configurationv1.KongConsumer](),
+		envtest.WatchFor(t, ctx, wConsumer, apiwatch.Modified,
+			envtest.AssertsAnd(
+				envtest.ObjectMatchesName(createdConsumer),
+				envtest.ObjectHasConditionProgrammedSetToTrue[*configurationv1.KongConsumer](),
 			),
 			"KongConsumer's Programmed condition should be true eventually",
 		)
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.ConsumersSDK, waitTime, tickTime)
+		envtest.EventuallyAssertSDKExpectations(t, factory.SDK.ConsumersSDK, consts.WaitTime, consts.TickTime)
 
 		t.Log("Setting up SDK expectations on KongConsumer update")
 		sdk.ConsumersSDK.EXPECT().
@@ -136,17 +138,17 @@ func TestKongConsumer(t *testing.T) {
 		require.NoError(t, clientNamespaced.Patch(ctx, consumerToPatch, client.MergeFrom(createdConsumer)))
 
 		t.Log("Waiting for KongConsumer to be patched")
-		watchFor(t, ctx, wConsumer, apiwatch.Modified,
-			assertsAnd(
-				objectMatchesName(createdConsumer),
-				objectMatchesKonnectID[*configurationv1.KongConsumer](consumerID),
+		envtest.WatchFor(t, ctx, wConsumer, apiwatch.Modified,
+			envtest.AssertsAnd(
+				envtest.ObjectMatchesName(createdConsumer),
+				envtest.ObjectMatchesKonnectID[*configurationv1.KongConsumer](consumerID),
 				func(c *configurationv1.KongConsumer) bool {
 					return c.Username == updatedUsername
 				},
 			),
 			"KongConsumer should get patched with new username",
 		)
-		eventuallyAssertSDKExpectations(t, factory.SDK.ConsumersSDK, waitTime, tickTime)
+		envtest.EventuallyAssertSDKExpectations(t, factory.SDK.ConsumersSDK, consts.WaitTime, consts.TickTime)
 
 		t.Log("Setting up SDK expectations on KongConsumer deletion")
 		sdk.ConsumersSDK.EXPECT().
@@ -161,13 +163,13 @@ func TestKongConsumer(t *testing.T) {
 				assert.True(c, apierrors.IsNotFound(
 					clientNamespaced.Get(ctx, client.ObjectKeyFromObject(createdConsumer), createdConsumer),
 				))
-			}, waitTime, tickTime,
+			}, consts.WaitTime, consts.TickTime,
 		)
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.ConsumersSDK, waitTime, tickTime)
+		envtest.EventuallyAssertSDKExpectations(t, factory.SDK.ConsumersSDK, consts.WaitTime, consts.TickTime)
 	})
 
-	cgWatch := setupWatch[configurationv1beta1.KongConsumerGroupList](t, ctx, cl, client.InNamespace(ns.Name))
+	cgWatch := envtest.SetupWatch[configurationv1beta1.KongConsumerGroupList](t, ctx, cl, client.InNamespace(ns.Name))
 
 	t.Run("should create, update and delete Consumer with ConsumerGroups successfully", func(t *testing.T) {
 		const (
@@ -245,16 +247,16 @@ func TestKongConsumer(t *testing.T) {
 		require.NoError(t, clientNamespaced.Patch(ctx, consumer, client.MergeFrom(createdConsumer)))
 
 		t.Log("Waiting for KongConsumer to be programmed")
-		watchFor(t, ctx, wConsumer, apiwatch.Modified,
-			assertsAnd(
-				objectMatchesName(createdConsumer),
-				objectHasConditionProgrammedSetToTrue[*configurationv1.KongConsumer](),
+		envtest.WatchFor(t, ctx, wConsumer, apiwatch.Modified,
+			envtest.AssertsAnd(
+				envtest.ObjectMatchesName(createdConsumer),
+				envtest.ObjectHasConditionProgrammedSetToTrue[*configurationv1.KongConsumer](),
 			),
 			"KongConsumer's Programmed condition should be true eventually",
 		)
 
 		t.Log("Waiting for KongConsumerGroup to be programmed")
-		watchFor(t, ctx, cgWatch, apiwatch.Modified, func(c *configurationv1beta1.KongConsumerGroup) bool {
+		envtest.WatchFor(t, ctx, cgWatch, apiwatch.Modified, func(c *configurationv1beta1.KongConsumerGroup) bool {
 			if c.GetName() != createdConsumerGroup.GetName() {
 				return false
 			}
@@ -264,7 +266,7 @@ func TestKongConsumer(t *testing.T) {
 			})
 		}, "KongConsumerGroup's Programmed condition should be true eventually")
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.ConsumersSDK, waitTime, tickTime)
+		envtest.EventuallyAssertSDKExpectations(t, factory.SDK.ConsumersSDK, consts.WaitTime, consts.TickTime)
 
 		t.Log("Setting up SDK expectations on KongConsumer update with ConsumerGroup")
 		sdk.ConsumersSDK.EXPECT().
@@ -308,8 +310,8 @@ func TestKongConsumer(t *testing.T) {
 		consumerToPatch.Username = "user-2-updated"
 		require.NoError(t, clientNamespaced.Patch(ctx, consumerToPatch, client.MergeFrom(createdConsumer)))
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.ConsumersSDK, waitTime, tickTime)
-		eventuallyAssertSDKExpectations(t, factory.SDK.ConsumerGroupSDK, waitTime, tickTime)
+		envtest.EventuallyAssertSDKExpectations(t, factory.SDK.ConsumersSDK, consts.WaitTime, consts.TickTime)
+		envtest.EventuallyAssertSDKExpectations(t, factory.SDK.ConsumerGroupSDK, consts.WaitTime, consts.TickTime)
 	})
 
 	t.Run("should handle conflict in creation correctly", func(t *testing.T) {
@@ -349,7 +351,7 @@ func TestKongConsumer(t *testing.T) {
 		)
 
 		t.Log("Watching for KongConsumers to verify the created KongConsumer programmed")
-		watchFor(t, ctx, wConsumer, apiwatch.Modified, func(c *configurationv1.KongConsumer) bool {
+		envtest.WatchFor(t, ctx, wConsumer, apiwatch.Modified, func(c *configurationv1.KongConsumer) bool {
 			return c.GetKonnectID() == consumerID && k8sutils.IsProgrammed(c)
 		}, "KongConsumer should be programmed and have ID in status after handling conflict")
 	})
@@ -364,7 +366,7 @@ func TestKongConsumer(t *testing.T) {
 		apiAuth := deploy.KonnectAPIAuthConfigurationWithProgrammed(t, ctx, clientNamespaced)
 		cp := deploy.KonnectGatewayControlPlaneWithID(t, ctx, clientNamespaced, apiAuth)
 
-		w := setupWatch[configurationv1.KongConsumerList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := envtest.SetupWatch[configurationv1.KongConsumerList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations on KongConsumer creation")
 		sdk.ConsumersSDK.EXPECT().
@@ -401,17 +403,17 @@ func TestKongConsumer(t *testing.T) {
 		)
 
 		t.Log("Waiting for object to be programmed and get Konnect ID")
-		watchFor(t, ctx, w, apiwatch.Modified, conditionProgrammedIsSetToTrueAndCPRefIsKonnectNamespacedRef(created, id),
+		envtest.WatchFor(t, ctx, w, apiwatch.Modified, envtest.ConditionProgrammedIsSetToTrueAndCPRefIsKonnectNamespacedRef(created, id),
 			fmt.Sprintf("Consumer didn't get Programmed status condition or didn't get the correct %s Konnect ID assigned", id))
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.ConsumersSDK, waitTime, tickTime)
+		envtest.EventuallyAssertSDKExpectations(t, factory.SDK.ConsumersSDK, consts.WaitTime, consts.TickTime)
 
 		t.Log("Deleting KonnectGatewayControlPlane")
 		require.NoError(t, clientNamespaced.Delete(ctx, cp))
 
 		t.Log("Waiting for KongConsumer to be get Programmed and ControlPlaneRefValid conditions with status=False")
-		watchFor(t, ctx, w, apiwatch.Modified,
-			conditionsAreSetWhenReferencedControlPlaneIsMissing(created),
+		envtest.WatchFor(t, ctx, w, apiwatch.Modified,
+			envtest.ConditionsAreSetWhenReferencedControlPlaneIsMissing(created),
 			"KongConsumer didn't get Programmed and/or ControlPlaneRefValid status condition set to False",
 		)
 	})
@@ -426,7 +428,7 @@ func TestKongConsumer(t *testing.T) {
 		apiAuth := deploy.KonnectAPIAuthConfigurationWithProgrammed(t, ctx, clientNamespaced)
 		cp := deploy.KonnectGatewayControlPlaneWithID(t, ctx, clientNamespaced, apiAuth)
 
-		w := setupWatch[configurationv1.KongConsumerList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := envtest.SetupWatch[configurationv1.KongConsumerList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations on KongConsumer creation")
 		sdk.ConsumersSDK.EXPECT().
@@ -463,19 +465,19 @@ func TestKongConsumer(t *testing.T) {
 		)
 
 		t.Log("Waiting for object to be programmed and get Konnect ID")
-		watchFor(t, ctx, w, apiwatch.Modified, conditionProgrammedIsSetToTrueAndCPRefIsKonnectNamespacedRef(created, id),
+		envtest.WatchFor(t, ctx, w, apiwatch.Modified, envtest.ConditionProgrammedIsSetToTrueAndCPRefIsKonnectNamespacedRef(created, id),
 			fmt.Sprintf("Consumer didn't get Programmed status condition or didn't get the correct %s Konnect ID assigned", id))
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.ConsumersSDK, waitTime, tickTime)
+		envtest.EventuallyAssertSDKExpectations(t, factory.SDK.ConsumersSDK, consts.WaitTime, consts.TickTime)
 
 		t.Log("Deleting KonnectGatewayControlPlane")
 		require.NoError(t, clientNamespaced.Delete(ctx, cp))
 
 		t.Log("Waiting for object to be get Programmed and ControlPlaneRefValid conditions with status=False and konnect cleanup finalizer removed")
-		watchFor(t, ctx, w, apiwatch.Modified,
-			assertsAnd(
-				assertNot(objectHasFinalizer[*configurationv1.KongConsumer](konnect.KonnectCleanupFinalizer)),
-				conditionsAreSetWhenReferencedControlPlaneIsMissing(created),
+		envtest.WatchFor(t, ctx, w, apiwatch.Modified,
+			envtest.AssertsAnd(
+				envtest.AssertNot(envtest.ObjectHasFinalizer[*configurationv1.KongConsumer](konnect.KonnectCleanupFinalizer)),
+				envtest.ConditionsAreSetWhenReferencedControlPlaneIsMissing(created),
 			),
 			"Object didn't get Programmed and/or ControlPlaneRefValid status condition set to False",
 		)
@@ -512,57 +514,57 @@ func TestKongConsumer(t *testing.T) {
 		require.NoError(t, clientNamespaced.Patch(ctx, consumerToPatch, client.MergeFrom(created)))
 
 		t.Log("Waiting for object to be get Programmed with status=True and konnect cleanup finalizer re added")
-		watchFor(t, ctx, w, apiwatch.Modified,
-			assertsAnd(
-				objectMatchesName(created),
-				objectHasConditionProgrammedSetToTrue[*configurationv1.KongConsumer](),
-				objectHasFinalizer[*configurationv1.KongConsumer](konnect.KonnectCleanupFinalizer),
+		envtest.WatchFor(t, ctx, w, apiwatch.Modified,
+			envtest.AssertsAnd(
+				envtest.ObjectMatchesName(created),
+				envtest.ObjectHasConditionProgrammedSetToTrue[*configurationv1.KongConsumer](),
+				envtest.ObjectHasFinalizer[*configurationv1.KongConsumer](konnect.KonnectCleanupFinalizer),
 			),
 			"Object didn't get Programmed set to True",
 		)
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.ConsumersSDK, waitTime, tickTime)
+		envtest.EventuallyAssertSDKExpectations(t, factory.SDK.ConsumersSDK, consts.WaitTime, consts.TickTime)
 	})
 }
 
 func TestKongConsumerSecretCredentials(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := Context(t, t.Context())
+	ctx, cancel := envtest.Context(t, t.Context())
 	defer cancel()
-	cfg, ns := Setup(t, ctx, scheme.Get(), WithInstallGatewayCRDs(true))
+	cfg, ns := envtest.Setup(t, ctx, scheme.Get(), envtest.WithInstallGatewayCRDs(true))
 
 	t.Log("Setting up the manager with reconcilers")
-	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())
+	mgr, logs := envtest.NewManager(t, ctx, cfg, scheme.Get())
 	factory := sdkmocks.NewMockSDKFactory(t)
 	sdk := factory.SDK
-	reconcilers := []Reconciler{
+	reconcilers := []envtest.Reconciler{
 		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
-			konnect.WithKonnectEntitySyncPeriod[configurationv1.KongConsumer](konnectInfiniteSyncTime),
+			konnect.WithKonnectEntitySyncPeriod[configurationv1.KongConsumer](consts.KonnectInfiniteSyncTime),
 			konnect.WithMetricRecorder[configurationv1.KongConsumer](&metricsmocks.MockRecorder{}),
 		),
 		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
-			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialBasicAuth](konnectInfiniteSyncTime),
+			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialBasicAuth](consts.KonnectInfiniteSyncTime),
 			konnect.WithMetricRecorder[configurationv1alpha1.KongCredentialBasicAuth](&metricsmocks.MockRecorder{}),
 		),
 		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
-			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialAPIKey](konnectInfiniteSyncTime),
+			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialAPIKey](consts.KonnectInfiniteSyncTime),
 			konnect.WithMetricRecorder[configurationv1alpha1.KongCredentialAPIKey](&metricsmocks.MockRecorder{}),
 		),
 		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
-			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialACL](konnectInfiniteSyncTime),
+			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialACL](consts.KonnectInfiniteSyncTime),
 			konnect.WithMetricRecorder[configurationv1alpha1.KongCredentialACL](&metricsmocks.MockRecorder{}),
 		),
 		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
-			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialJWT](konnectInfiniteSyncTime),
+			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialJWT](consts.KonnectInfiniteSyncTime),
 			konnect.WithMetricRecorder[configurationv1alpha1.KongCredentialJWT](&metricsmocks.MockRecorder{}),
 		),
 		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
-			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialHMAC](konnectInfiniteSyncTime),
+			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialHMAC](consts.KonnectInfiniteSyncTime),
 			konnect.WithMetricRecorder[configurationv1alpha1.KongCredentialHMAC](&metricsmocks.MockRecorder{}),
 		),
 		konnect.NewKongCredentialSecretReconciler(controller.Options{}, logging.DevelopmentMode, mgr.GetClient(), mgr.GetScheme()),
 	}
-	StartReconcilers(ctx, t, mgr, logs, reconcilers...)
+	envtest.StartReconcilers(ctx, t, mgr, logs, reconcilers...)
 
 	t.Log("Setting up clients")
 	cl, err := client.NewWithWatch(mgr.GetConfig(), client.Options{
@@ -636,8 +638,8 @@ func TestKongConsumerSecretCredentials(t *testing.T) {
 			)
 
 		t.Log("Creating KongConsumerf")
-		wConsumer := setupWatch[configurationv1.KongConsumerList](t, ctx, cl, client.InNamespace(ns.Name))
-		wBasicAuth := setupWatch[configurationv1alpha1.KongCredentialBasicAuthList](t, ctx, cl, client.InNamespace(ns.Name))
+		wConsumer := envtest.SetupWatch[configurationv1.KongConsumerList](t, ctx, cl, client.InNamespace(ns.Name))
+		wBasicAuth := envtest.SetupWatch[configurationv1alpha1.KongCredentialBasicAuthList](t, ctx, cl, client.InNamespace(ns.Name))
 		createdConsumer := deploy.KongConsumer(t, ctx, clientNamespaced, username,
 			deploy.WithKonnectNamespacedRefControlPlaneRef(cp),
 			func(obj client.Object) {
@@ -649,17 +651,17 @@ func TestKongConsumerSecretCredentials(t *testing.T) {
 		)
 
 		t.Log("Waiting for KongConsumer to be programmed")
-		watchFor(t, ctx, wConsumer, apiwatch.Modified,
-			assertsAnd(
-				objectMatchesName(createdConsumer),
-				objectHasConditionProgrammedSetToTrue[*configurationv1.KongConsumer](),
+		envtest.WatchFor(t, ctx, wConsumer, apiwatch.Modified,
+			envtest.AssertsAnd(
+				envtest.ObjectMatchesName(createdConsumer),
+				envtest.ObjectHasConditionProgrammedSetToTrue[*configurationv1.KongConsumer](),
 			),
 			"KongConsumer's Programmed condition should be true eventually",
 		)
 
 		t.Log("Waiting for KongCredentialBasicAuth to be programmed")
-		watchFor(t, ctx, wBasicAuth, apiwatch.Modified,
-			objectHasConditionProgrammedSetToTrue[*configurationv1alpha1.KongCredentialBasicAuth](),
+		envtest.WatchFor(t, ctx, wBasicAuth, apiwatch.Modified,
+			envtest.ObjectHasConditionProgrammedSetToTrue[*configurationv1alpha1.KongCredentialBasicAuth](),
 			"BasicAuth credential should get the Programmed condition",
 		)
 	})
@@ -735,19 +737,19 @@ func TestKongConsumerSecretCredentials(t *testing.T) {
 		)
 
 		t.Log("Waiting for KongConsumer to be programmed")
-		wConsumer := setupWatch[configurationv1.KongConsumerList](t, ctx, cl, client.InNamespace(ns.Name))
-		wKeyCredential := setupWatch[configurationv1alpha1.KongCredentialAPIKeyList](t, ctx, cl, client.InNamespace(ns.Name))
-		watchFor(t, ctx, wConsumer, apiwatch.Modified,
-			assertsAnd(
-				objectMatchesName(createdConsumer),
-				objectHasConditionProgrammedSetToTrue[*configurationv1.KongConsumer](),
+		wConsumer := envtest.SetupWatch[configurationv1.KongConsumerList](t, ctx, cl, client.InNamespace(ns.Name))
+		wKeyCredential := envtest.SetupWatch[configurationv1alpha1.KongCredentialAPIKeyList](t, ctx, cl, client.InNamespace(ns.Name))
+		envtest.WatchFor(t, ctx, wConsumer, apiwatch.Modified,
+			envtest.AssertsAnd(
+				envtest.ObjectMatchesName(createdConsumer),
+				envtest.ObjectHasConditionProgrammedSetToTrue[*configurationv1.KongConsumer](),
 			),
 			"KongConsumer's Programmed condition should be true eventually",
 		)
 
 		t.Log("Waiting for KongCredentialAPIKey to be programmed")
-		watchFor(t, ctx, wKeyCredential, apiwatch.Modified,
-			objectHasConditionProgrammedSetToTrue[*configurationv1alpha1.KongCredentialAPIKey](),
+		envtest.WatchFor(t, ctx, wKeyCredential, apiwatch.Modified,
+			envtest.ObjectHasConditionProgrammedSetToTrue[*configurationv1alpha1.KongCredentialAPIKey](),
 			"APIKey credential should get the Programmed condition",
 		)
 	})
@@ -825,20 +827,20 @@ func TestKongConsumerSecretCredentials(t *testing.T) {
 		l.GetItems()
 
 		t.Log("Waiting for KongConsumer to be programmed")
-		wConsumer := setupWatch[configurationv1.KongConsumerList](t, ctx, cl, client.InNamespace(ns.Name))
-		wACL := setupWatch[configurationv1alpha1.KongCredentialACLList](t, ctx, cl, client.InNamespace(ns.Name))
+		wConsumer := envtest.SetupWatch[configurationv1.KongConsumerList](t, ctx, cl, client.InNamespace(ns.Name))
+		wACL := envtest.SetupWatch[configurationv1alpha1.KongCredentialACLList](t, ctx, cl, client.InNamespace(ns.Name))
 
-		watchFor(t, ctx, wConsumer, apiwatch.Modified,
-			assertsAnd(
-				objectMatchesName(createdConsumer),
-				objectHasConditionProgrammedSetToTrue[*configurationv1.KongConsumer](),
+		envtest.WatchFor(t, ctx, wConsumer, apiwatch.Modified,
+			envtest.AssertsAnd(
+				envtest.ObjectMatchesName(createdConsumer),
+				envtest.ObjectHasConditionProgrammedSetToTrue[*configurationv1.KongConsumer](),
 			),
 			"KongConsumer's Programmed condition should be true eventually",
 		)
 
 		t.Log("Waiting for KongCredentialACL to be programmed")
-		watchFor(t, ctx, wACL, apiwatch.Modified,
-			objectHasConditionProgrammedSetToTrue[*configurationv1alpha1.KongCredentialACL](),
+		envtest.WatchFor(t, ctx, wACL, apiwatch.Modified,
+			envtest.ObjectHasConditionProgrammedSetToTrue[*configurationv1alpha1.KongCredentialACL](),
 			"ACL credential should get the Programmed condition",
 		)
 	})
@@ -917,19 +919,19 @@ func TestKongConsumerSecretCredentials(t *testing.T) {
 		)
 
 		t.Log("Waiting for KongConsumer to be programmed")
-		wConsumer := setupWatch[configurationv1.KongConsumerList](t, ctx, cl, client.InNamespace(ns.Name))
-		wJWT := setupWatch[configurationv1alpha1.KongCredentialJWTList](t, ctx, cl, client.InNamespace(ns.Name))
-		watchFor(t, ctx, wConsumer, apiwatch.Modified,
-			assertsAnd(
-				objectMatchesName(createdConsumer),
-				objectHasConditionProgrammedSetToTrue[*configurationv1.KongConsumer](),
+		wConsumer := envtest.SetupWatch[configurationv1.KongConsumerList](t, ctx, cl, client.InNamespace(ns.Name))
+		wJWT := envtest.SetupWatch[configurationv1alpha1.KongCredentialJWTList](t, ctx, cl, client.InNamespace(ns.Name))
+		envtest.WatchFor(t, ctx, wConsumer, apiwatch.Modified,
+			envtest.AssertsAnd(
+				envtest.ObjectMatchesName(createdConsumer),
+				envtest.ObjectHasConditionProgrammedSetToTrue[*configurationv1.KongConsumer](),
 			),
 			"KongConsumer's Programmed condition should be true eventually",
 		)
 
 		t.Log("Waiting for KongCredentialJWT to be programmed")
-		watchFor(t, ctx, wJWT, apiwatch.Modified,
-			objectHasConditionProgrammedSetToTrue[*configurationv1alpha1.KongCredentialJWT](),
+		envtest.WatchFor(t, ctx, wJWT, apiwatch.Modified,
+			envtest.ObjectHasConditionProgrammedSetToTrue[*configurationv1alpha1.KongCredentialJWT](),
 			"JWT credential should get the Programmed condition",
 		)
 	})
@@ -995,8 +997,8 @@ func TestKongConsumerSecretCredentials(t *testing.T) {
 				nil,
 			)
 		t.Log("Creating KongConsumer")
-		wConsumer := setupWatch[configurationv1.KongConsumerList](t, ctx, cl, client.InNamespace(ns.Name))
-		wHMAC := setupWatch[configurationv1alpha1.KongCredentialHMACList](t, ctx, cl, client.InNamespace(ns.Name))
+		wConsumer := envtest.SetupWatch[configurationv1.KongConsumerList](t, ctx, cl, client.InNamespace(ns.Name))
+		wHMAC := envtest.SetupWatch[configurationv1alpha1.KongCredentialHMACList](t, ctx, cl, client.InNamespace(ns.Name))
 		createdConsumer := deploy.KongConsumer(t, ctx, clientNamespaced, username,
 			deploy.WithKonnectNamespacedRefControlPlaneRef(cp),
 			func(obj client.Object) {
@@ -1008,17 +1010,17 @@ func TestKongConsumerSecretCredentials(t *testing.T) {
 		)
 		t.Log("Waiting for KongConsumer to be programmed")
 
-		watchFor(t, ctx, wConsumer, apiwatch.Modified,
-			assertsAnd(
-				objectMatchesName(createdConsumer),
-				objectHasConditionProgrammedSetToTrue[*configurationv1.KongConsumer](),
+		envtest.WatchFor(t, ctx, wConsumer, apiwatch.Modified,
+			envtest.AssertsAnd(
+				envtest.ObjectMatchesName(createdConsumer),
+				envtest.ObjectHasConditionProgrammedSetToTrue[*configurationv1.KongConsumer](),
 			),
 			"KongConsumer's Programmed condition should be true eventually",
 		)
 
 		t.Log("Waiting for KongCredentialHMAC to be programmed")
-		watchFor(t, ctx, wHMAC, apiwatch.Modified,
-			objectHasConditionProgrammedSetToTrue[*configurationv1alpha1.KongCredentialHMAC](),
+		envtest.WatchFor(t, ctx, wHMAC, apiwatch.Modified,
+			envtest.ObjectHasConditionProgrammedSetToTrue[*configurationv1alpha1.KongCredentialHMAC](),
 			"HMAC credential should get the Programmed condition",
 		)
 	})
@@ -1026,42 +1028,42 @@ func TestKongConsumerSecretCredentials(t *testing.T) {
 
 func TestAdoptingConsumerAndCredentials(t *testing.T) {
 	t.Parallel()
-	ctx, cancel := Context(t, t.Context())
+	ctx, cancel := envtest.Context(t, t.Context())
 	defer cancel()
-	cfg, ns := Setup(t, ctx, scheme.Get(), WithInstallGatewayCRDs(true))
+	cfg, ns := envtest.Setup(t, ctx, scheme.Get(), envtest.WithInstallGatewayCRDs(true))
 
 	t.Log("Setting up the manager with reconcilers")
-	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())
+	mgr, logs := envtest.NewManager(t, ctx, cfg, scheme.Get())
 	factory := sdkmocks.NewMockSDKFactory(t)
 	sdk := factory.SDK
-	reconcilers := []Reconciler{
+	reconcilers := []envtest.Reconciler{
 		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
-			konnect.WithKonnectEntitySyncPeriod[configurationv1.KongConsumer](konnectInfiniteSyncTime),
+			konnect.WithKonnectEntitySyncPeriod[configurationv1.KongConsumer](consts.KonnectInfiniteSyncTime),
 			konnect.WithMetricRecorder[configurationv1.KongConsumer](&metricsmocks.MockRecorder{}),
 		),
 		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
-			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialBasicAuth](konnectInfiniteSyncTime),
+			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialBasicAuth](consts.KonnectInfiniteSyncTime),
 			konnect.WithMetricRecorder[configurationv1alpha1.KongCredentialBasicAuth](&metricsmocks.MockRecorder{}),
 		),
 		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
-			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialAPIKey](konnectInfiniteSyncTime),
+			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialAPIKey](consts.KonnectInfiniteSyncTime),
 			konnect.WithMetricRecorder[configurationv1alpha1.KongCredentialAPIKey](&metricsmocks.MockRecorder{}),
 		),
 		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
-			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialACL](konnectInfiniteSyncTime),
+			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialACL](consts.KonnectInfiniteSyncTime),
 			konnect.WithMetricRecorder[configurationv1alpha1.KongCredentialACL](&metricsmocks.MockRecorder{}),
 		),
 		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
-			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialJWT](konnectInfiniteSyncTime),
+			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialJWT](consts.KonnectInfiniteSyncTime),
 			konnect.WithMetricRecorder[configurationv1alpha1.KongCredentialJWT](&metricsmocks.MockRecorder{}),
 		),
 		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, mgr.GetClient(),
-			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialHMAC](konnectInfiniteSyncTime),
+			konnect.WithKonnectEntitySyncPeriod[configurationv1alpha1.KongCredentialHMAC](consts.KonnectInfiniteSyncTime),
 			konnect.WithMetricRecorder[configurationv1alpha1.KongCredentialHMAC](&metricsmocks.MockRecorder{}),
 		),
 		konnect.NewKongCredentialSecretReconciler(controller.Options{}, logging.DevelopmentMode, mgr.GetClient(), mgr.GetScheme()),
 	}
-	StartReconcilers(ctx, t, mgr, logs, reconcilers...)
+	envtest.StartReconcilers(ctx, t, mgr, logs, reconcilers...)
 
 	t.Log("Setting up clients")
 	cl, err := client.NewWithWatch(mgr.GetConfig(), client.Options{
@@ -1076,7 +1078,7 @@ func TestAdoptingConsumerAndCredentials(t *testing.T) {
 
 	consumerID := uuid.NewString()
 	userName := "user-1"
-	wConsumer := setupWatch[configurationv1.KongConsumerList](t, ctx, cl, client.InNamespace(ns.Name))
+	wConsumer := envtest.SetupWatch[configurationv1.KongConsumerList](t, ctx, cl, client.InNamespace(ns.Name))
 
 	t.Log("Setting up SDK expectations for getting and updating consumers")
 	sdk.ConsumersSDK.EXPECT().ListConsumerGroupsForConsumer(
@@ -1112,7 +1114,7 @@ func TestAdoptingConsumerAndCredentials(t *testing.T) {
 	)
 
 	t.Log("Waiting for KongConsumer to be programmed and set Konnect ID")
-	watchFor(t, ctx, wConsumer, apiwatch.Modified, func(kc *configurationv1.KongConsumer) bool {
+	envtest.WatchFor(t, ctx, wConsumer, apiwatch.Modified, func(kc *configurationv1.KongConsumer) bool {
 		return kc.Name == createdConsumer.Name && k8sutils.IsProgrammed(kc) && kc.GetKonnectID() == consumerID
 	},
 		"KongConsumer did not get programmed or set Konnect ID")
@@ -1120,7 +1122,7 @@ func TestAdoptingConsumerAndCredentials(t *testing.T) {
 	// Adopting a KeyAuth credential
 	t.Run("APIKey", func(t *testing.T) {
 		keyAuthID := uuid.NewString()
-		wAPIKey := setupWatch[configurationv1alpha1.KongCredentialAPIKeyList](t, ctx, cl, client.InNamespace(ns.Name))
+		wAPIKey := envtest.SetupWatch[configurationv1alpha1.KongCredentialAPIKeyList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations for getting and updating KeyAuth credentials")
 		sdk.KongCredentialsAPIKeySDK.EXPECT().GetKeyAuthWithConsumer(
@@ -1168,7 +1170,7 @@ func TestAdoptingConsumerAndCredentials(t *testing.T) {
 		require.NoError(t, clientNamespaced.Create(ctx, createdAPIKey))
 
 		t.Log("Waiting for the KongCredentialAPIKey to be programmed and set Konnect ID")
-		watchFor(t, ctx, wAPIKey, apiwatch.Modified, func(apikey *configurationv1alpha1.KongCredentialAPIKey) bool {
+		envtest.WatchFor(t, ctx, wAPIKey, apiwatch.Modified, func(apikey *configurationv1alpha1.KongCredentialAPIKey) bool {
 			return apikey.Name == createdAPIKey.Name && k8sutils.IsProgrammed(apikey) && apikey.GetKonnectID() == keyAuthID
 		},
 			"KongCredentialAPIKey did not get programmed or set Konnect ID")
@@ -1177,7 +1179,7 @@ func TestAdoptingConsumerAndCredentials(t *testing.T) {
 	// Adopting a basic auth credential
 	t.Run("BasicAuth", func(t *testing.T) {
 		basicAuthID := uuid.NewString()
-		wBasicAuth := setupWatch[configurationv1alpha1.KongCredentialBasicAuthList](t, ctx, cl, client.InNamespace(ns.Name))
+		wBasicAuth := envtest.SetupWatch[configurationv1alpha1.KongCredentialBasicAuthList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations for getting and updating BasicAuth credentials")
 		sdk.KongCredentialsBasicAuthSDK.EXPECT().GetBasicAuthWithConsumer(
@@ -1226,7 +1228,7 @@ func TestAdoptingConsumerAndCredentials(t *testing.T) {
 		require.NoError(t, clientNamespaced.Create(ctx, createdBasicAuth))
 
 		t.Log("Waiting for the KongCredentialBasicAuth to be programmed and set Konnect ID")
-		watchFor(t, ctx, wBasicAuth, apiwatch.Modified, func(auth *configurationv1alpha1.KongCredentialBasicAuth) bool {
+		envtest.WatchFor(t, ctx, wBasicAuth, apiwatch.Modified, func(auth *configurationv1alpha1.KongCredentialBasicAuth) bool {
 			return auth.Name == createdBasicAuth.Name && k8sutils.IsProgrammed(auth) && auth.GetKonnectID() == basicAuthID
 		},
 			"KongCredentialBasicAuth did not get programmed or set Konnect ID")
@@ -1235,7 +1237,7 @@ func TestAdoptingConsumerAndCredentials(t *testing.T) {
 	// Adopting an ACL
 	t.Run("ACL", func(t *testing.T) {
 		aclID := uuid.NewString()
-		wACL := setupWatch[configurationv1alpha1.KongCredentialACLList](t, ctx, cl, client.InNamespace(ns.Name))
+		wACL := envtest.SetupWatch[configurationv1alpha1.KongCredentialACLList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations for getting and updating ACL credentials")
 		sdk.KongCredentialsACLSDK.EXPECT().GetACLWithConsumer(
@@ -1283,7 +1285,7 @@ func TestAdoptingConsumerAndCredentials(t *testing.T) {
 		require.NoError(t, clientNamespaced.Create(ctx, createdACL))
 
 		t.Log("Waiting for the KongCredentialACL to be programmed and set Konnect ID")
-		watchFor(t, ctx, wACL, apiwatch.Modified, func(acl *configurationv1alpha1.KongCredentialACL) bool {
+		envtest.WatchFor(t, ctx, wACL, apiwatch.Modified, func(acl *configurationv1alpha1.KongCredentialACL) bool {
 			return acl.Name == createdACL.Name && k8sutils.IsProgrammed(acl) && acl.GetKonnectID() == aclID
 		},
 			"KongCredentialACL did not get programmed or set Konnect ID",
@@ -1293,7 +1295,7 @@ func TestAdoptingConsumerAndCredentials(t *testing.T) {
 	// Adopting an HMAC auth credential
 	t.Run("HMAC", func(t *testing.T) {
 		hmacID := uuid.NewString()
-		wHMAC := setupWatch[configurationv1alpha1.KongCredentialHMACList](t, ctx, cl, client.InNamespace(ns.Name))
+		wHMAC := envtest.SetupWatch[configurationv1alpha1.KongCredentialHMACList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations for getting and updating HMACs")
 		sdk.KongCredentialsHMACSDK.EXPECT().GetHmacAuthWithConsumer(
@@ -1343,7 +1345,7 @@ func TestAdoptingConsumerAndCredentials(t *testing.T) {
 		require.NoError(t, clientNamespaced.Create(ctx, createdHMACAuth))
 
 		t.Log("Waiting for the KongCredentialHMAC to be programmed and set Konnect ID")
-		watchFor(t, ctx, wHMAC, apiwatch.Modified, func(hmac *configurationv1alpha1.KongCredentialHMAC) bool {
+		envtest.WatchFor(t, ctx, wHMAC, apiwatch.Modified, func(hmac *configurationv1alpha1.KongCredentialHMAC) bool {
 			return hmac.Name == createdHMACAuth.Name && k8sutils.IsProgrammed(hmac) && hmac.GetKonnectID() == hmacID
 		},
 			"KongCredentialHMAC did not get programmed or set Konnect ID",
@@ -1353,7 +1355,7 @@ func TestAdoptingConsumerAndCredentials(t *testing.T) {
 	// Adopting a JWT
 	t.Run("JWT", func(t *testing.T) {
 		jwtID := uuid.NewString()
-		wJWT := setupWatch[configurationv1alpha1.KongCredentialJWTList](t, ctx, cl, client.InNamespace(ns.Name))
+		wJWT := envtest.SetupWatch[configurationv1alpha1.KongCredentialJWTList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations for getting and updating JWTAuths")
 		sdk.KongCredentialsJWTSDK.EXPECT().GetJwtWithConsumer(
@@ -1405,7 +1407,7 @@ func TestAdoptingConsumerAndCredentials(t *testing.T) {
 		require.NoError(t, clientNamespaced.Create(ctx, createdJWT))
 
 		t.Log("Waiting for the KongCredentialJWT to be programmed and set Konnect ID")
-		watchFor(t, ctx, wJWT, apiwatch.Modified, func(jwt *configurationv1alpha1.KongCredentialJWT) bool {
+		envtest.WatchFor(t, ctx, wJWT, apiwatch.Modified, func(jwt *configurationv1alpha1.KongCredentialJWT) bool {
 			return jwt.Name == createdJWT.Name && k8sutils.IsProgrammed(jwt) && jwt.GetKonnectID() == jwtID
 		},
 			"KongCredentialJWT did not get programmed or set Konnect ID",

--- a/test/envtest/konnect_entities_aigatewayagent_test.go
+++ b/test/envtest/konnect_entities_aigatewayagent_test.go
@@ -63,7 +63,7 @@ func TestAIGatewayAgent(t *testing.T) {
 			agentURL           = "https://upstream.example.com"
 		)
 
-		w := setupWatch[konnectv1alpha1.AIGatewayAgentList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[konnectv1alpha1.AIGatewayAgentList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations on AIGatewayAgent creation")
 		sdk.AIGatewayAgentsSDK.EXPECT().
@@ -90,11 +90,11 @@ func TestAIGatewayAgent(t *testing.T) {
 		})
 
 		t.Log("Waiting for AIGatewayAgent to be programmed")
-		watchFor(t, ctx, w, apiwatch.Modified,
-			assertsAnd(
-				objectMatchesName(agent),
-				objectMatchesKonnectID[*konnectv1alpha1.AIGatewayAgent](agentID),
-				objectHasConditionProgrammedSetToTrue[*konnectv1alpha1.AIGatewayAgent](),
+		WatchFor(t, ctx, w, apiwatch.Modified,
+			AssertsAnd(
+				ObjectMatchesName(agent),
+				ObjectMatchesKonnectID[*konnectv1alpha1.AIGatewayAgent](agentID),
+				ObjectHasConditionProgrammedSetToTrue[*konnectv1alpha1.AIGatewayAgent](),
 				func(a *konnectv1alpha1.AIGatewayAgent) bool {
 					return a.GetGatewayID() == konnectAIGatewayID &&
 						controllerutil.ContainsFinalizer(a, konnect.KonnectCleanupFinalizer)
@@ -103,7 +103,7 @@ func TestAIGatewayAgent(t *testing.T) {
 			"AIGatewayAgent didn't get Programmed status condition, Konnect ID, parent ID, or cleanup finalizer",
 		)
 
-		eventuallyAssertSDKExpectations(t, sdk.AIGatewayAgentsSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, sdk.AIGatewayAgentsSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on AIGatewayAgent update")
 		sdk.AIGatewayAgentsSDK.EXPECT().
@@ -123,11 +123,11 @@ func TestAIGatewayAgent(t *testing.T) {
 		agent = agentToPatch
 
 		t.Log("Waiting for AIGatewayAgent to be patched")
-		watchFor(t, ctx, w, apiwatch.Modified,
-			assertsAnd(
-				objectMatchesName(agent),
-				objectMatchesKonnectID[*konnectv1alpha1.AIGatewayAgent](agentID),
-				objectHasConditionProgrammedSetToTrue[*konnectv1alpha1.AIGatewayAgent](),
+		WatchFor(t, ctx, w, apiwatch.Modified,
+			AssertsAnd(
+				ObjectMatchesName(agent),
+				ObjectMatchesKonnectID[*konnectv1alpha1.AIGatewayAgent](agentID),
+				ObjectHasConditionProgrammedSetToTrue[*konnectv1alpha1.AIGatewayAgent](),
 				func(a *konnectv1alpha1.AIGatewayAgent) bool {
 					return a.Spec.APISpec.DisplayName == updatedDisplayName
 				},
@@ -135,7 +135,7 @@ func TestAIGatewayAgent(t *testing.T) {
 			"AIGatewayAgent didn't get patched",
 		)
 
-		eventuallyAssertSDKExpectations(t, sdk.AIGatewayAgentsSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, sdk.AIGatewayAgentsSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on AIGatewayAgent deletion")
 		sdk.AIGatewayAgentsSDK.EXPECT().
@@ -145,13 +145,13 @@ func TestAIGatewayAgent(t *testing.T) {
 		t.Log("Deleting AIGatewayAgent")
 		require.NoError(t, clientNamespaced.Delete(ctx, agent))
 		eventually.WaitForObjectToNotExist(t, ctx, clientNamespaced, agent, waitTime, tickTime)
-		eventuallyAssertSDKExpectations(t, sdk.AIGatewayAgentsSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, sdk.AIGatewayAgentsSDK, waitTime, tickTime)
 	})
 
 	t.Run("should create AIGatewayAgent successfully on conflict when agent with matching uid label exists", func(t *testing.T) {
 		const agentID = "ai-agent-conflict-id"
 
-		w := setupWatch[konnectv1alpha1.AIGatewayAgentList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[konnectv1alpha1.AIGatewayAgentList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		var agent *konnectv1alpha1.AIGatewayAgent
 
@@ -185,11 +185,11 @@ func TestAIGatewayAgent(t *testing.T) {
 		agent = deploy.AIGatewayAgent(t, ctx, clientNamespaced, gateway)
 
 		t.Log("Waiting for AIGatewayAgent to be programmed after UID conflict lookup")
-		watchFor(t, ctx, w, apiwatch.Modified,
-			assertsAnd(
-				objectMatchesName(agent),
-				objectMatchesKonnectID[*konnectv1alpha1.AIGatewayAgent](agentID),
-				objectHasConditionProgrammedSetToTrue[*konnectv1alpha1.AIGatewayAgent](),
+		WatchFor(t, ctx, w, apiwatch.Modified,
+			AssertsAnd(
+				ObjectMatchesName(agent),
+				ObjectMatchesKonnectID[*konnectv1alpha1.AIGatewayAgent](agentID),
+				ObjectHasConditionProgrammedSetToTrue[*konnectv1alpha1.AIGatewayAgent](),
 				func(a *konnectv1alpha1.AIGatewayAgent) bool {
 					return a.GetGatewayID() == konnectAIGatewayID &&
 						controllerutil.ContainsFinalizer(a, konnect.KonnectCleanupFinalizer)
@@ -198,6 +198,6 @@ func TestAIGatewayAgent(t *testing.T) {
 			"AIGatewayAgent didn't get Programmed status condition or Konnect ID after conflict resolution",
 		)
 
-		eventuallyAssertSDKExpectations(t, sdk.AIGatewayAgentsSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, sdk.AIGatewayAgentsSDK, waitTime, tickTime)
 	})
 }

--- a/test/envtest/konnect_entities_eventgatewaybackendcluster_test.go
+++ b/test/envtest/konnect_entities_eventgatewaybackendcluster_test.go
@@ -63,7 +63,7 @@ func TestEventGatewayBackendCluster(t *testing.T) {
 			updatedDescription = "Updated backend cluster description"
 		)
 
-		w := setupWatch[configurationv1alpha1.EventGatewayBackendClusterList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[configurationv1alpha1.EventGatewayBackendClusterList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations on EventGatewayBackendCluster creation")
 		sdk.EventGatewayBackendClustersSDK.EXPECT().
@@ -104,11 +104,11 @@ func TestEventGatewayBackendCluster(t *testing.T) {
 		})
 
 		t.Log("Waiting for EventGatewayBackendCluster to be programmed")
-		watchFor(t, ctx, w, apiwatch.Modified,
-			assertsAnd(
-				objectMatchesName(backendCluster),
-				objectMatchesKonnectID[*configurationv1alpha1.EventGatewayBackendCluster](backendClusterID),
-				objectHasConditionProgrammedSetToTrue[*configurationv1alpha1.EventGatewayBackendCluster](),
+		WatchFor(t, ctx, w, apiwatch.Modified,
+			AssertsAnd(
+				ObjectMatchesName(backendCluster),
+				ObjectMatchesKonnectID[*configurationv1alpha1.EventGatewayBackendCluster](backendClusterID),
+				ObjectHasConditionProgrammedSetToTrue[*configurationv1alpha1.EventGatewayBackendCluster](),
 				func(bc *configurationv1alpha1.EventGatewayBackendCluster) bool {
 					return bc.GetGatewayID() == eventGatewayID &&
 						controllerutil.ContainsFinalizer(bc, konnect.KonnectCleanupFinalizer)
@@ -117,7 +117,7 @@ func TestEventGatewayBackendCluster(t *testing.T) {
 			"EventGatewayBackendCluster didn't get Programmed status condition, Konnect ID, parent ID, or cleanup finalizer",
 		)
 
-		eventuallyAssertSDKExpectations(t, sdk.EventGatewayBackendClustersSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, sdk.EventGatewayBackendClustersSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on EventGatewayBackendCluster update")
 		sdk.EventGatewayBackendClustersSDK.EXPECT().
@@ -140,11 +140,11 @@ func TestEventGatewayBackendCluster(t *testing.T) {
 		backendCluster = backendClusterToPatch
 
 		t.Log("Waiting for EventGatewayBackendCluster to be patched")
-		watchFor(t, ctx, w, apiwatch.Modified,
-			assertsAnd(
-				objectMatchesName(backendCluster),
-				objectMatchesKonnectID[*configurationv1alpha1.EventGatewayBackendCluster](backendClusterID),
-				objectHasConditionProgrammedSetToTrue[*configurationv1alpha1.EventGatewayBackendCluster](),
+		WatchFor(t, ctx, w, apiwatch.Modified,
+			AssertsAnd(
+				ObjectMatchesName(backendCluster),
+				ObjectMatchesKonnectID[*configurationv1alpha1.EventGatewayBackendCluster](backendClusterID),
+				ObjectHasConditionProgrammedSetToTrue[*configurationv1alpha1.EventGatewayBackendCluster](),
 				func(bc *configurationv1alpha1.EventGatewayBackendCluster) bool {
 					return bc.Spec.APISpec.Description == updatedDescription
 				},
@@ -152,7 +152,7 @@ func TestEventGatewayBackendCluster(t *testing.T) {
 			"EventGatewayBackendCluster didn't get patched",
 		)
 
-		eventuallyAssertSDKExpectations(t, sdk.EventGatewayBackendClustersSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, sdk.EventGatewayBackendClustersSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on EventGatewayBackendCluster deletion")
 		sdk.EventGatewayBackendClustersSDK.EXPECT().
@@ -162,13 +162,13 @@ func TestEventGatewayBackendCluster(t *testing.T) {
 		t.Log("Deleting EventGatewayBackendCluster")
 		require.NoError(t, clientNamespaced.Delete(ctx, backendCluster))
 		eventually.WaitForObjectToNotExist(t, ctx, clientNamespaced, backendCluster, waitTime, tickTime)
-		eventuallyAssertSDKExpectations(t, sdk.EventGatewayBackendClustersSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, sdk.EventGatewayBackendClustersSDK, waitTime, tickTime)
 	})
 
 	t.Run("should create EventGatewayBackendCluster successfully on conflict when backend cluster with matching uid label exists", func(t *testing.T) {
 		const backendClusterID = "backend-cluster-conflict-id"
 
-		w := setupWatch[configurationv1alpha1.EventGatewayBackendClusterList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[configurationv1alpha1.EventGatewayBackendClusterList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		var backendCluster *configurationv1alpha1.EventGatewayBackendCluster
 
@@ -202,11 +202,11 @@ func TestEventGatewayBackendCluster(t *testing.T) {
 		backendCluster = deploy.EventGatewayBackendCluster(t, ctx, clientNamespaced, gateway)
 
 		t.Log("Waiting for EventGatewayBackendCluster to be programmed after UID conflict lookup")
-		watchFor(t, ctx, w, apiwatch.Modified,
-			assertsAnd(
-				objectMatchesName(backendCluster),
-				objectMatchesKonnectID[*configurationv1alpha1.EventGatewayBackendCluster](backendClusterID),
-				objectHasConditionProgrammedSetToTrue[*configurationv1alpha1.EventGatewayBackendCluster](),
+		WatchFor(t, ctx, w, apiwatch.Modified,
+			AssertsAnd(
+				ObjectMatchesName(backendCluster),
+				ObjectMatchesKonnectID[*configurationv1alpha1.EventGatewayBackendCluster](backendClusterID),
+				ObjectHasConditionProgrammedSetToTrue[*configurationv1alpha1.EventGatewayBackendCluster](),
 				func(bc *configurationv1alpha1.EventGatewayBackendCluster) bool {
 					return bc.GetGatewayID() == eventGatewayID &&
 						controllerutil.ContainsFinalizer(bc, konnect.KonnectCleanupFinalizer)
@@ -215,6 +215,6 @@ func TestEventGatewayBackendCluster(t *testing.T) {
 			"EventGatewayBackendCluster didn't get Programmed status condition or Konnect ID after conflict resolution",
 		)
 
-		eventuallyAssertSDKExpectations(t, sdk.EventGatewayBackendClustersSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, sdk.EventGatewayBackendClustersSDK, waitTime, tickTime)
 	})
 }

--- a/test/envtest/konnect_entities_eventgatewayvirtualcluster_test.go
+++ b/test/envtest/konnect_entities_eventgatewayvirtualcluster_test.go
@@ -70,7 +70,7 @@ func TestEventGatewayVirtualCluster(t *testing.T) {
 			initialDNSLabel         = "payments"
 		)
 
-		w := setupWatch[configurationv1alpha1.EventGatewayVirtualClusterList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[configurationv1alpha1.EventGatewayVirtualClusterList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Creating EventGatewayBackendCluster and setting its status to programmed")
 		backendCluster := deploy.EventGatewayBackendCluster(t, ctx, clientNamespaced, eventGateway, deploy.WithName(backendClusterName))
@@ -123,11 +123,11 @@ func TestEventGatewayVirtualCluster(t *testing.T) {
 		})
 
 		t.Log("Waiting for EventGatewayVirtualCluster to be programmed")
-		watchFor(t, ctx, w, apiwatch.Modified,
-			assertsAnd(
-				objectMatchesName(virtualCluster),
-				objectMatchesKonnectID[*configurationv1alpha1.EventGatewayVirtualCluster](virtualClusterID),
-				objectHasConditionProgrammedSetToTrue[*configurationv1alpha1.EventGatewayVirtualCluster](),
+		WatchFor(t, ctx, w, apiwatch.Modified,
+			AssertsAnd(
+				ObjectMatchesName(virtualCluster),
+				ObjectMatchesKonnectID[*configurationv1alpha1.EventGatewayVirtualCluster](virtualClusterID),
+				ObjectHasConditionProgrammedSetToTrue[*configurationv1alpha1.EventGatewayVirtualCluster](),
 				func(vc *configurationv1alpha1.EventGatewayVirtualCluster) bool {
 					return vc.GetGatewayID() == expectedParentGateway &&
 						controllerutil.ContainsFinalizer(vc, konnect.KonnectCleanupFinalizer)
@@ -136,7 +136,7 @@ func TestEventGatewayVirtualCluster(t *testing.T) {
 			"EventGatewayVirtualCluster didn't get Programmed status condition, parent Gateway ID, Konnect ID, or cleanup finalizer",
 		)
 
-		eventuallyAssertSDKExpectations(t, sdk.EventGatewayVirtualClustersSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, sdk.EventGatewayVirtualClustersSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on EventGatewayVirtualCluster update")
 		sdk.EventGatewayVirtualClustersSDK.EXPECT().
@@ -160,11 +160,11 @@ func TestEventGatewayVirtualCluster(t *testing.T) {
 		require.NoError(t, clientNamespaced.Patch(ctx, virtualClusterToPatch, client.MergeFrom(virtualCluster)))
 
 		t.Log("Waiting for EventGatewayVirtualCluster to be patched")
-		watchFor(t, ctx, w, apiwatch.Modified,
-			assertsAnd(
-				objectMatchesName(virtualCluster),
-				objectMatchesKonnectID[*configurationv1alpha1.EventGatewayVirtualCluster](virtualClusterID),
-				objectHasConditionProgrammedSetToTrue[*configurationv1alpha1.EventGatewayVirtualCluster](),
+		WatchFor(t, ctx, w, apiwatch.Modified,
+			AssertsAnd(
+				ObjectMatchesName(virtualCluster),
+				ObjectMatchesKonnectID[*configurationv1alpha1.EventGatewayVirtualCluster](virtualClusterID),
+				ObjectHasConditionProgrammedSetToTrue[*configurationv1alpha1.EventGatewayVirtualCluster](),
 				func(vc *configurationv1alpha1.EventGatewayVirtualCluster) bool {
 					return vc.GetGatewayID() == expectedParentGateway &&
 						vc.Spec.APISpec.Name == updatedVirtualName &&
@@ -174,7 +174,7 @@ func TestEventGatewayVirtualCluster(t *testing.T) {
 			"EventGatewayVirtualCluster didn't get patched",
 		)
 
-		eventuallyAssertSDKExpectations(t, sdk.EventGatewayVirtualClustersSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, sdk.EventGatewayVirtualClustersSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on EventGatewayVirtualCluster deletion")
 		sdk.EventGatewayVirtualClustersSDK.EXPECT().
@@ -184,7 +184,7 @@ func TestEventGatewayVirtualCluster(t *testing.T) {
 		t.Log("Deleting EventGatewayVirtualCluster")
 		require.NoError(t, clientNamespaced.Delete(ctx, virtualCluster))
 		eventually.WaitForObjectToNotExist(t, ctx, clientNamespaced, virtualCluster, waitTime, tickTime)
-		eventuallyAssertSDKExpectations(t, sdk.EventGatewayVirtualClustersSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, sdk.EventGatewayVirtualClustersSDK, waitTime, tickTime)
 	})
 
 	t.Run("should create EventGatewayVirtualCluster successfully on conflict when virtual cluster with matching uid tag exists", func(t *testing.T) {
@@ -193,7 +193,7 @@ func TestEventGatewayVirtualCluster(t *testing.T) {
 			conflictBackendClusterKonnectID = "backend-cluster-conflict-konnect-id"
 		)
 
-		w := setupWatch[configurationv1alpha1.EventGatewayVirtualClusterList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[configurationv1alpha1.EventGatewayVirtualClusterList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Creating EventGatewayBackendCluster 'backend-cluster' and setting its status to programmed")
 		conflictBackendCluster := deploy.EventGatewayBackendCluster(t, ctx, clientNamespaced, eventGateway, deploy.WithName("backend-cluster"))
@@ -243,11 +243,11 @@ func TestEventGatewayVirtualCluster(t *testing.T) {
 		virtualCluster = deploy.EventGatewayVirtualCluster(t, ctx, clientNamespaced, conflictBackendCluster)
 
 		t.Log("Waiting for EventGatewayVirtualCluster to be programmed after UID conflict lookup")
-		watchFor(t, ctx, w, apiwatch.Modified,
-			assertsAnd(
-				objectMatchesName(virtualCluster),
-				objectMatchesKonnectID[*configurationv1alpha1.EventGatewayVirtualCluster](virtualClusterID),
-				objectHasConditionProgrammedSetToTrue[*configurationv1alpha1.EventGatewayVirtualCluster](),
+		WatchFor(t, ctx, w, apiwatch.Modified,
+			AssertsAnd(
+				ObjectMatchesName(virtualCluster),
+				ObjectMatchesKonnectID[*configurationv1alpha1.EventGatewayVirtualCluster](virtualClusterID),
+				ObjectHasConditionProgrammedSetToTrue[*configurationv1alpha1.EventGatewayVirtualCluster](),
 				func(vc *configurationv1alpha1.EventGatewayVirtualCluster) bool {
 					return vc.GetGatewayID() == expectedParentGateway
 				},
@@ -255,6 +255,6 @@ func TestEventGatewayVirtualCluster(t *testing.T) {
 			"EventGatewayVirtualCluster didn't get Programmed status condition, parent Gateway ID, or Konnect ID after conflict resolution",
 		)
 
-		eventuallyAssertSDKExpectations(t, sdk.EventGatewayVirtualClustersSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, sdk.EventGatewayVirtualClustersSDK, waitTime, tickTime)
 	})
 }

--- a/test/envtest/konnect_entities_eventgatewayvirtualclusterconsumepolicy_test.go
+++ b/test/envtest/konnect_entities_eventgatewayvirtualclusterconsumepolicy_test.go
@@ -69,7 +69,7 @@ func TestEventGatewayVirtualClusterConsumePolicy(t *testing.T) {
 			updatedHeaderValue = "updated-value"
 		)
 
-		w := setupWatch[configurationv1alpha1.EventGatewayVirtualClusterConsumePolicyList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[configurationv1alpha1.EventGatewayVirtualClusterConsumePolicyList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Creating EventGatewayBackendCluster and setting its status to programmed")
 		backendCluster := deploy.EventGatewayBackendCluster(t, ctx, clientNamespaced, eventGateway, deploy.WithName("backend-cluster-a"))
@@ -132,11 +132,11 @@ func TestEventGatewayVirtualClusterConsumePolicy(t *testing.T) {
 		require.NoError(t, clientNamespaced.Create(ctx, policy))
 
 		t.Log("Waiting for EventGatewayVirtualClusterConsumePolicy to be programmed")
-		watchFor(t, ctx, w, apiwatch.Modified,
-			assertsAnd(
-				objectMatchesName(policy),
-				objectMatchesKonnectID[*configurationv1alpha1.EventGatewayVirtualClusterConsumePolicy](consumePolicyID),
-				objectHasConditionProgrammedSetToTrue[*configurationv1alpha1.EventGatewayVirtualClusterConsumePolicy](),
+		WatchFor(t, ctx, w, apiwatch.Modified,
+			AssertsAnd(
+				ObjectMatchesName(policy),
+				ObjectMatchesKonnectID[*configurationv1alpha1.EventGatewayVirtualClusterConsumePolicy](consumePolicyID),
+				ObjectHasConditionProgrammedSetToTrue[*configurationv1alpha1.EventGatewayVirtualClusterConsumePolicy](),
 				func(p *configurationv1alpha1.EventGatewayVirtualClusterConsumePolicy) bool {
 					cfg := p.Spec.APISpec.EventGatewayVirtualClusterConsumePolicyConfig
 					return p.GetGatewayID() == gatewayID &&
@@ -152,7 +152,7 @@ func TestEventGatewayVirtualClusterConsumePolicy(t *testing.T) {
 			),
 			"EventGatewayVirtualClusterConsumePolicy didn't get Programmed status condition, parent IDs, Konnect ID, or cleanup finalizer",
 		)
-		eventuallyAssertSDKExpectations(t, sdk.EventGatewayVirtualClusterConsumePoliciesSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, sdk.EventGatewayVirtualClusterConsumePoliciesSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on EventGatewayVirtualClusterConsumePolicy update")
 		policyToPatch := policy.DeepCopy()
@@ -178,11 +178,11 @@ func TestEventGatewayVirtualClusterConsumePolicy(t *testing.T) {
 		policy = policyToPatch
 
 		t.Log("Waiting for EventGatewayVirtualClusterConsumePolicy to be patched")
-		watchFor(t, ctx, w, apiwatch.Modified,
-			assertsAnd(
-				objectMatchesName(policy),
-				objectMatchesKonnectID[*configurationv1alpha1.EventGatewayVirtualClusterConsumePolicy](consumePolicyID),
-				objectHasConditionProgrammedSetToTrue[*configurationv1alpha1.EventGatewayVirtualClusterConsumePolicy](),
+		WatchFor(t, ctx, w, apiwatch.Modified,
+			AssertsAnd(
+				ObjectMatchesName(policy),
+				ObjectMatchesKonnectID[*configurationv1alpha1.EventGatewayVirtualClusterConsumePolicy](consumePolicyID),
+				ObjectHasConditionProgrammedSetToTrue[*configurationv1alpha1.EventGatewayVirtualClusterConsumePolicy](),
 				func(p *configurationv1alpha1.EventGatewayVirtualClusterConsumePolicy) bool {
 					cfg := p.Spec.APISpec.EventGatewayVirtualClusterConsumePolicyConfig
 					return p.GetGatewayID() == gatewayID &&
@@ -196,7 +196,7 @@ func TestEventGatewayVirtualClusterConsumePolicy(t *testing.T) {
 			),
 			"EventGatewayVirtualClusterConsumePolicy didn't get patched",
 		)
-		eventuallyAssertSDKExpectations(t, sdk.EventGatewayVirtualClusterConsumePoliciesSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, sdk.EventGatewayVirtualClusterConsumePoliciesSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on EventGatewayVirtualClusterConsumePolicy deletion")
 		sdk.EventGatewayVirtualClusterConsumePoliciesSDK.EXPECT().
@@ -213,7 +213,7 @@ func TestEventGatewayVirtualClusterConsumePolicy(t *testing.T) {
 		t.Log("Deleting EventGatewayVirtualClusterConsumePolicy")
 		require.NoError(t, clientNamespaced.Delete(ctx, policy))
 		eventually.WaitForObjectToNotExist(t, ctx, clientNamespaced, policy, waitTime, tickTime)
-		eventuallyAssertSDKExpectations(t, sdk.EventGatewayVirtualClusterConsumePoliciesSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, sdk.EventGatewayVirtualClusterConsumePoliciesSDK, waitTime, tickTime)
 	})
 }
 

--- a/test/envtest/konnect_entities_eventgatewayvirtualclusterproducepolicy_test.go
+++ b/test/envtest/konnect_entities_eventgatewayvirtualclusterproducepolicy_test.go
@@ -69,7 +69,7 @@ func TestEventGatewayVirtualClusterProducePolicy(t *testing.T) {
 			updatedHeaderValue = "updated-value"
 		)
 
-		w := setupWatch[configurationv1alpha1.EventGatewayVirtualClusterProducePolicyList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[configurationv1alpha1.EventGatewayVirtualClusterProducePolicyList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Creating EventGatewayBackendCluster and setting its status to programmed")
 		backendCluster := deploy.EventGatewayBackendCluster(t, ctx, clientNamespaced, eventGateway, deploy.WithName("backend-cluster-a"))
@@ -132,11 +132,11 @@ func TestEventGatewayVirtualClusterProducePolicy(t *testing.T) {
 		require.NoError(t, clientNamespaced.Create(ctx, policy))
 
 		t.Log("Waiting for EventGatewayVirtualClusterProducePolicy to be programmed")
-		watchFor(t, ctx, w, apiwatch.Modified,
-			assertsAnd(
-				objectMatchesName(policy),
-				objectMatchesKonnectID[*configurationv1alpha1.EventGatewayVirtualClusterProducePolicy](producePolicyID),
-				objectHasConditionProgrammedSetToTrue[*configurationv1alpha1.EventGatewayVirtualClusterProducePolicy](),
+		WatchFor(t, ctx, w, apiwatch.Modified,
+			AssertsAnd(
+				ObjectMatchesName(policy),
+				ObjectMatchesKonnectID[*configurationv1alpha1.EventGatewayVirtualClusterProducePolicy](producePolicyID),
+				ObjectHasConditionProgrammedSetToTrue[*configurationv1alpha1.EventGatewayVirtualClusterProducePolicy](),
 				func(p *configurationv1alpha1.EventGatewayVirtualClusterProducePolicy) bool {
 					cfg := p.Spec.APISpec.EventGatewayVirtualClusterProducePolicyConfig
 					return p.GetGatewayID() == gatewayID &&
@@ -152,7 +152,7 @@ func TestEventGatewayVirtualClusterProducePolicy(t *testing.T) {
 			),
 			"EventGatewayVirtualClusterProducePolicy didn't get Programmed status condition, parent IDs, Konnect ID, or cleanup finalizer",
 		)
-		eventuallyAssertSDKExpectations(t, sdk.EventGatewayVirtualClusterProducePoliciesSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, sdk.EventGatewayVirtualClusterProducePoliciesSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on EventGatewayVirtualClusterProducePolicy update")
 		policyToPatch := policy.DeepCopy()
@@ -178,11 +178,11 @@ func TestEventGatewayVirtualClusterProducePolicy(t *testing.T) {
 		policy = policyToPatch
 
 		t.Log("Waiting for EventGatewayVirtualClusterProducePolicy to be patched")
-		watchFor(t, ctx, w, apiwatch.Modified,
-			assertsAnd(
-				objectMatchesName(policy),
-				objectMatchesKonnectID[*configurationv1alpha1.EventGatewayVirtualClusterProducePolicy](producePolicyID),
-				objectHasConditionProgrammedSetToTrue[*configurationv1alpha1.EventGatewayVirtualClusterProducePolicy](),
+		WatchFor(t, ctx, w, apiwatch.Modified,
+			AssertsAnd(
+				ObjectMatchesName(policy),
+				ObjectMatchesKonnectID[*configurationv1alpha1.EventGatewayVirtualClusterProducePolicy](producePolicyID),
+				ObjectHasConditionProgrammedSetToTrue[*configurationv1alpha1.EventGatewayVirtualClusterProducePolicy](),
 				func(p *configurationv1alpha1.EventGatewayVirtualClusterProducePolicy) bool {
 					cfg := p.Spec.APISpec.EventGatewayVirtualClusterProducePolicyConfig
 					return p.GetGatewayID() == gatewayID &&
@@ -196,7 +196,7 @@ func TestEventGatewayVirtualClusterProducePolicy(t *testing.T) {
 			),
 			"EventGatewayVirtualClusterProducePolicy didn't get patched",
 		)
-		eventuallyAssertSDKExpectations(t, sdk.EventGatewayVirtualClusterProducePoliciesSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, sdk.EventGatewayVirtualClusterProducePoliciesSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on EventGatewayVirtualClusterProducePolicy deletion")
 		sdk.EventGatewayVirtualClusterProducePoliciesSDK.EXPECT().
@@ -213,7 +213,7 @@ func TestEventGatewayVirtualClusterProducePolicy(t *testing.T) {
 		t.Log("Deleting EventGatewayVirtualClusterProducePolicy")
 		require.NoError(t, clientNamespaced.Delete(ctx, policy))
 		eventually.WaitForObjectToNotExist(t, ctx, clientNamespaced, policy, waitTime, tickTime)
-		eventuallyAssertSDKExpectations(t, sdk.EventGatewayVirtualClusterProducePoliciesSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, sdk.EventGatewayVirtualClusterProducePoliciesSDK, waitTime, tickTime)
 	})
 }
 

--- a/test/envtest/konnect_entities_gatewaycontrolplane_test.go
+++ b/test/envtest/konnect_entities_gatewaycontrolplane_test.go
@@ -101,7 +101,7 @@ var konnectGatewayControlPlaneTestCases = []konnectEntityReconcilerTestCase{
 			)
 
 			assert.Equal(t, "12345", cp.Status.ID)
-			assert.True(t, conditionsContainProgrammedTrue(cp.Status.Conditions),
+			assert.True(t, ConditionsContainProgrammedTrue(cp.Status.Conditions),
 				"Programmed condition should be set and it status should be true",
 			)
 			assert.True(t, controllerutil.ContainsFinalizer(cp, konnect.KonnectCleanupFinalizer),
@@ -243,7 +243,7 @@ var konnectGatewayControlPlaneTestCases = []konnectEntityReconcilerTestCase{
 			)
 
 			assert.Equal(t, "12345", cp.Status.ID)
-			assert.True(t, conditionsContainProgrammedTrue(cp.Status.Conditions),
+			assert.True(t, ConditionsContainProgrammedTrue(cp.Status.Conditions),
 				"Programmed condition should be set and it status should be true",
 			)
 			assert.True(t, controllerutil.ContainsFinalizer(cp, konnect.KonnectCleanupFinalizer),
@@ -265,7 +265,7 @@ var konnectGatewayControlPlaneTestCases = []konnectEntityReconcilerTestCase{
 			)
 
 			assert.Equal(t, "12346", cpGroup.Status.ID)
-			assert.True(t, conditionsContainProgrammedTrue(cpGroup.Status.Conditions),
+			assert.True(t, ConditionsContainProgrammedTrue(cpGroup.Status.Conditions),
 				"Programmed condition should be set and it status should be true",
 			)
 			assert.True(t, conditionsContainMembersRefResolvedTrue(cpGroup.Status.Conditions),
@@ -413,7 +413,7 @@ var konnectGatewayControlPlaneTestCases = []konnectEntityReconcilerTestCase{
 				),
 			)
 
-			assert.True(t, conditionsContainProgrammedTrue(cp.Status.Conditions),
+			assert.True(t, ConditionsContainProgrammedTrue(cp.Status.Conditions),
 				"Programmed condition should be set and its status should be true",
 			)
 			assert.True(t, controllerutil.ContainsFinalizer(cp, konnect.KonnectCleanupFinalizer),
@@ -432,7 +432,7 @@ var konnectGatewayControlPlaneTestCases = []konnectEntityReconcilerTestCase{
 			)
 
 			assert.Equal(t, "123467", cpGroup.Status.ID)
-			assert.True(t, conditionsContainProgrammedFalse(cpGroup.Status.Conditions),
+			assert.True(t, ConditionsContainProgrammedFalse(cpGroup.Status.Conditions),
 				"Programmed condition should be set and its status should be false because of an error returned by Konnect API when setting group members",
 			)
 			assert.True(t, conditionsContainMembersRefResolvedFalse(cpGroup.Status.Conditions),
@@ -533,7 +533,7 @@ var konnectGatewayControlPlaneTestCases = []konnectEntityReconcilerTestCase{
 			)
 
 			assert.Equal(t, "123456", cp.Status.ID, "ID should be set")
-			assert.True(t, conditionsContainProgrammedTrue(cp.Status.Conditions),
+			assert.True(t, ConditionsContainProgrammedTrue(cp.Status.Conditions),
 				"Programmed condition should be set and its status should be true",
 			)
 			assert.True(t, controllerutil.ContainsFinalizer(cp, konnect.KonnectCleanupFinalizer),
@@ -720,7 +720,7 @@ var konnectGatewayControlPlaneTestCases = []konnectEntityReconcilerTestCase{
 			)
 
 			assert.Equal(t, "group-123456", cpGroup.Status.ID, "ID should be set")
-			assert.True(t, conditionsContainProgrammedTrue(cpGroup.Status.Conditions),
+			assert.True(t, ConditionsContainProgrammedTrue(cpGroup.Status.Conditions),
 				"Programmed condition should be set and its status should be true",
 			)
 			assert.True(t, conditionsContainMembersRefResolvedTrue(cpGroup.Status.Conditions),
@@ -809,7 +809,7 @@ var konnectGatewayControlPlaneTestCases = []konnectEntityReconcilerTestCase{
 			)
 
 			assert.Equal(t, "cpg-id", cpGroup.Status.ID, "ID should be set")
-			assert.True(t, conditionsContainProgrammedTrue(cpGroup.Status.Conditions),
+			assert.True(t, ConditionsContainProgrammedTrue(cpGroup.Status.Conditions),
 				"Programmed condition should be set and its status should be true",
 			)
 			assert.True(t, conditionsContainMembersRefResolvedTrue(cpGroup.Status.Conditions),
@@ -860,7 +860,7 @@ var konnectGatewayControlPlaneTestCases = []konnectEntityReconcilerTestCase{
 				),
 			)
 
-			assert.True(t, conditionsContainProgrammedFalse(cp.Status.Conditions),
+			assert.True(t, ConditionsContainProgrammedFalse(cp.Status.Conditions),
 				"Programmed condition should be set to False due to network error",
 			)
 			assert.True(t,
@@ -909,7 +909,7 @@ var konnectGatewayControlPlaneTestCases = []konnectEntityReconcilerTestCase{
 					c.Reason == konnectv1alpha1.KonnectEntityAPIAuthConfigurationResolvedRefReasonRefNotFound
 			}), "APIAuthResolvedRef condition should be False with RefNotFound reason")
 
-			assert.True(t, conditionsContainProgrammedFalse(cp.Status.Conditions),
+			assert.True(t, ConditionsContainProgrammedFalse(cp.Status.Conditions),
 				"Programmed condition should be set to False when APIAuth ref is not found",
 			)
 			assert.True(t,
@@ -921,23 +921,6 @@ var konnectGatewayControlPlaneTestCases = []konnectEntityReconcilerTestCase{
 			)
 		},
 	},
-}
-
-func conditionsContainProgrammed(conds []metav1.Condition, status metav1.ConditionStatus) bool {
-	return lo.ContainsBy(conds,
-		func(condition metav1.Condition) bool {
-			return condition.Type == konnectv1alpha1.KonnectEntityProgrammedConditionType &&
-				condition.Status == status
-		},
-	)
-}
-
-func conditionsContainProgrammedFalse(conds []metav1.Condition) bool {
-	return conditionsContainProgrammed(conds, metav1.ConditionFalse)
-}
-
-func conditionsContainProgrammedTrue(conds []metav1.Condition) bool {
-	return conditionsContainProgrammed(conds, metav1.ConditionTrue)
 }
 
 func conditionsContainProgrammedWithReason(
@@ -1027,7 +1010,7 @@ func TestKonnectGatewayControlPlane_CrossNamespaceRefNotPermitted(t *testing.T) 
 				c.Reason == konnectv1alpha1.KonnectEntityAPIAuthConfigurationResolvedRefReasonRefNotPermitted
 		}), "APIAuthResolvedRef condition should be False with RefNotPermitted reason")
 
-		assert.True(collect, conditionsContainProgrammedFalse(cp.Status.Conditions),
+		assert.True(collect, ConditionsContainProgrammedFalse(cp.Status.Conditions),
 			"Programmed condition should be set to False when cross-namespace ref is not permitted",
 		)
 		assert.True(collect,

--- a/test/envtest/konnect_entities_kongcacertificate_test.go
+++ b/test/envtest/konnect_entities_kongcacertificate_test.go
@@ -73,7 +73,7 @@ func TestKongCACertificate(t *testing.T) {
 		},
 	}, nil)
 
-	w := setupWatch[configurationv1alpha1.KongCACertificateList](t, ctx, cl, client.InNamespace(ns.Name))
+	w := SetupWatch[configurationv1alpha1.KongCACertificateList](t, ctx, cl, client.InNamespace(ns.Name))
 
 	t.Log("Creating KongCACertificate")
 	createdCert := deploy.KongCACertificateAttachedToCP(t, ctx, clientNamespaced, cp,
@@ -84,7 +84,7 @@ func TestKongCACertificate(t *testing.T) {
 	)
 
 	t.Log("Waiting for KongCACertificate to be programmed")
-	watchFor(t, ctx, w, apiwatch.Modified, func(c *configurationv1alpha1.KongCACertificate) bool {
+	WatchFor(t, ctx, w, apiwatch.Modified, func(c *configurationv1alpha1.KongCACertificate) bool {
 		if c.GetName() != createdCert.GetName() {
 			return false
 		}
@@ -95,7 +95,7 @@ func TestKongCACertificate(t *testing.T) {
 	}, "KongCACertificate's Programmed condition should be true eventually")
 
 	t.Log("Waiting for KongCACertificate to be created in the SDK")
-	eventuallyAssertSDKExpectations(t, factory.SDK.CACertificatesSDK, waitTime, tickTime)
+	EventuallyAssertSDKExpectations(t, factory.SDK.CACertificatesSDK, waitTime, tickTime)
 
 	t.Log("Setting up SDK expectations on KongCACertificate update")
 	sdk.CACertificatesSDK.EXPECT().UpsertCaCertificate(mock.Anything, mock.MatchedBy(func(r sdkkonnectops.UpsertCaCertificateRequest) bool {
@@ -109,7 +109,7 @@ func TestKongCACertificate(t *testing.T) {
 	require.NoError(t, clientNamespaced.Patch(ctx, certToPatch, client.MergeFrom(createdCert)))
 
 	t.Log("Waiting for KongCACertificate to be updated in the SDK")
-	eventuallyAssertSDKExpectations(t, factory.SDK.CACertificatesSDK, waitTime, tickTime)
+	EventuallyAssertSDKExpectations(t, factory.SDK.CACertificatesSDK, waitTime, tickTime)
 
 	t.Log("Setting up SDK expectations on KongCACertificate deletion")
 	sdk.CACertificatesSDK.EXPECT().DeleteCaCertificate(mock.Anything, cp.GetKonnectStatus().GetKonnectID(), "12345").
@@ -119,7 +119,7 @@ func TestKongCACertificate(t *testing.T) {
 	require.NoError(t, cl.Delete(ctx, createdCert))
 
 	t.Log("Waiting for KongCACertificate to be deleted in the SDK")
-	eventuallyAssertSDKExpectations(t, factory.SDK.CACertificatesSDK, waitTime, tickTime)
+	EventuallyAssertSDKExpectations(t, factory.SDK.CACertificatesSDK, waitTime, tickTime)
 
 	t.Run("should handle conflict in creation correctly", func(t *testing.T) {
 		const (
@@ -169,11 +169,11 @@ func TestKongCACertificate(t *testing.T) {
 		)
 
 		t.Log("Watching for KongCACertificates to verify the created KongCACertificate gets programmed")
-		watchFor(t, ctx, w, apiwatch.Modified, func(c *configurationv1alpha1.KongCACertificate) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(c *configurationv1alpha1.KongCACertificate) bool {
 			return c.GetKonnectID() == certID && k8sutils.IsProgrammed(c)
 		}, "KongCACertificate should be programmed and have ID in status after handling conflict")
 
-		eventuallyAssertSDKExpectations(t, sdk.CACertificatesSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, sdk.CACertificatesSDK, waitTime, tickTime)
 	})
 
 	t.Run("removing referenced CP sets the status conditions properly", func(t *testing.T) {
@@ -187,7 +187,7 @@ func TestKongCACertificate(t *testing.T) {
 		apiAuth := deploy.KonnectAPIAuthConfigurationWithProgrammed(t, ctx, clientNamespaced)
 		cp := deploy.KonnectGatewayControlPlaneWithID(t, ctx, clientNamespaced, apiAuth)
 
-		w := setupWatch[configurationv1alpha1.KongCACertificateList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[configurationv1alpha1.KongCACertificateList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations on KongCACertifcate creation")
 		sdk.CACertificatesSDK.EXPECT().
@@ -214,18 +214,18 @@ func TestKongCACertificate(t *testing.T) {
 				cert.Spec.Tags = tags
 			},
 		)
-		eventuallyAssertSDKExpectations(t, factory.SDK.CACertificatesSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.CACertificatesSDK, waitTime, tickTime)
 
 		t.Log("Waiting for object to be programmed and get Konnect ID")
-		watchFor(t, ctx, w, apiwatch.Modified, conditionProgrammedIsSetToTrueAndCPRefIsKonnectNamespacedRef(created, id),
+		WatchFor(t, ctx, w, apiwatch.Modified, ConditionProgrammedIsSetToTrueAndCPRefIsKonnectNamespacedRef(created, id),
 			fmt.Sprintf("CACertificate didn't get Programmed status condition or didn't get the correct %s Konnect ID assigned", id))
 
 		t.Log("Deleting KonnectGatewayControlPlane")
 		require.NoError(t, clientNamespaced.Delete(ctx, cp))
 
 		t.Log("Waiting for CACert to be get Programmed and ControlPlaneRefValid conditions with status=False")
-		watchFor(t, ctx, w, apiwatch.Modified,
-			conditionsAreSetWhenReferencedControlPlaneIsMissing(created),
+		WatchFor(t, ctx, w, apiwatch.Modified,
+			ConditionsAreSetWhenReferencedControlPlaneIsMissing(created),
 			"KongCACertificate didn't get Programmed and/or ControlPlaneRefValid status condition set to False",
 		)
 	})
@@ -233,7 +233,7 @@ func TestKongCACertificate(t *testing.T) {
 	t.Run("Adopting an existing CA certificate", func(t *testing.T) {
 		caCertID := uuid.NewString()
 
-		w := setupWatch[configurationv1alpha1.KongCACertificateList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[configurationv1alpha1.KongCACertificateList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations on getting and updating CA certificates")
 		sdk.CACertificatesSDK.EXPECT().GetCaCertificate(
@@ -259,7 +259,7 @@ func TestKongCACertificate(t *testing.T) {
 		)
 
 		t.Logf("Waiting for KongCACertificate %s to be programmed and set Konnect ID", client.ObjectKeyFromObject(createdCACert))
-		watchFor(t, ctx, w, apiwatch.Modified,
+		WatchFor(t, ctx, w, apiwatch.Modified,
 			func(caCert *configurationv1alpha1.KongCACertificate) bool {
 				return caCert.Name == createdCACert.Name &&
 					k8sutils.IsProgrammed(caCert) &&

--- a/test/envtest/konnect_entities_kongcertificate_test.go
+++ b/test/envtest/konnect_entities_kongcertificate_test.go
@@ -86,7 +86,7 @@ func TestKongCertificate(t *testing.T) {
 				Object: &sdkkonnectops.ListCertificateResponseBody{},
 			}, nil)
 
-		w := setupWatch[configurationv1alpha1.KongCertificateList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[configurationv1alpha1.KongCertificateList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Creating KongCertificate")
 		createdCert := deploy.KongCertificateAttachedToCP(t, ctx, clientNamespaced, cp,
@@ -98,7 +98,7 @@ func TestKongCertificate(t *testing.T) {
 		)
 
 		t.Log("Waiting for KongCertificate to be programmed")
-		watchFor(t, ctx, w, apiwatch.Modified, func(c *configurationv1alpha1.KongCertificate) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(c *configurationv1alpha1.KongCertificate) bool {
 			if c.GetName() != createdCert.GetName() {
 				return false
 			}
@@ -108,7 +108,7 @@ func TestKongCertificate(t *testing.T) {
 			})
 		}, "KongCertificate's Programmed condition should be true eventually")
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.CertificatesSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.CertificatesSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on KongCertificate update")
 		sdk.CertificatesSDK.EXPECT().UpsertCertificate(mock.Anything, mock.MatchedBy(func(r sdkkonnectops.UpsertCertificateRequest) bool {
@@ -122,7 +122,7 @@ func TestKongCertificate(t *testing.T) {
 		require.NoError(t, clientNamespaced.Patch(ctx, certToPatch, client.MergeFrom(createdCert)))
 
 		t.Log("Waiting for KongCertificate to be updated in the SDK")
-		eventuallyAssertSDKExpectations(t, factory.SDK.CertificatesSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.CertificatesSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on KongCertificate deletion")
 		sdk.CertificatesSDK.EXPECT().DeleteCertificate(mock.Anything, cpID, "cert-12345").
@@ -131,7 +131,7 @@ func TestKongCertificate(t *testing.T) {
 		t.Log("Deleting KongCertificate")
 		require.NoError(t, cl.Delete(ctx, createdCert))
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.CertificatesSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.CertificatesSDK, waitTime, tickTime)
 	})
 
 	t.Run("should handle conflict in creation correctly", func(t *testing.T) {
@@ -141,7 +141,7 @@ func TestKongCertificate(t *testing.T) {
 		cp := deploy.KonnectGatewayControlPlaneWithID(t, ctx, clientNamespaced, apiAuth)
 		cpID := cp.GetKonnectStatus().GetKonnectID()
 
-		w := setupWatch[configurationv1alpha1.KongCertificateList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[configurationv1alpha1.KongCertificateList](t, ctx, cl, client.InNamespace(ns.Name))
 		t.Log("Creating a KongCertificate")
 		createdCert := deploy.KongCertificateAttachedToCP(t, ctx, clientNamespaced, cp,
 			func(obj client.Object) {
@@ -171,7 +171,7 @@ func TestKongCertificate(t *testing.T) {
 			)
 
 		t.Log("Watching for KongCertificates to verify the created KongCertificate gets programmed")
-		watchFor(t, ctx, w, apiwatch.Modified, func(c *configurationv1alpha1.KongCertificate) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(c *configurationv1alpha1.KongCertificate) bool {
 			if c.GetName() != createdCert.GetName() {
 				return false
 			}
@@ -182,7 +182,7 @@ func TestKongCertificate(t *testing.T) {
 		}, "KongCertificate should be programmed and have ID in status after handling conflict")
 
 		t.Log("Ensuring that the SDK's create and list methods are called")
-		eventuallyAssertSDKExpectations(t, sdk.CertificatesSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, sdk.CertificatesSDK, waitTime, tickTime)
 	})
 
 	t.Run("removing referenced CP sets the status conditions properly", func(t *testing.T) {
@@ -193,7 +193,7 @@ func TestKongCertificate(t *testing.T) {
 		cp := deploy.KonnectGatewayControlPlaneWithID(t, ctx, clientNamespaced, apiAuth)
 		cpID := cp.GetKonnectStatus().GetKonnectID()
 
-		w := setupWatch[configurationv1alpha1.KongCertificateList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[configurationv1alpha1.KongCertificateList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations on KongCertifcate creation")
 		sdk.CertificatesSDK.EXPECT().
@@ -232,18 +232,18 @@ func TestKongCertificate(t *testing.T) {
 				cert.Spec.Tags = []string{"tag3"}
 			},
 		)
-		eventuallyAssertSDKExpectations(t, factory.SDK.CACertificatesSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.CACertificatesSDK, waitTime, tickTime)
 
 		t.Log("Waiting for object to be programmed and get Konnect ID")
-		watchFor(t, ctx, w, apiwatch.Modified, conditionProgrammedIsSetToTrueAndCPRefIsKonnectNamespacedRef(created, id),
+		WatchFor(t, ctx, w, apiwatch.Modified, ConditionProgrammedIsSetToTrueAndCPRefIsKonnectNamespacedRef(created, id),
 			fmt.Sprintf("Certificate didn't get Programmed status condition or didn't get the correct %s Konnect ID assigned", id))
 
 		t.Log("Deleting KonnectGatewayControlPlane")
 		require.NoError(t, clientNamespaced.Delete(ctx, cp))
 
 		t.Log("Waiting for CACert to be get Programmed and ControlPlaneRefValid conditions with status=False")
-		watchFor(t, ctx, w, apiwatch.Modified,
-			conditionsAreSetWhenReferencedControlPlaneIsMissing(created),
+		WatchFor(t, ctx, w, apiwatch.Modified,
+			ConditionsAreSetWhenReferencedControlPlaneIsMissing(created),
 			"KongCACertificate didn't get Programmed and/or ControlPlaneRefValid status condition set to False",
 		)
 	})
@@ -254,7 +254,7 @@ func TestKongCertificate(t *testing.T) {
 		cp := deploy.KonnectGatewayControlPlaneWithID(t, ctx, clientNamespaced, apiAuth)
 		cpID := cp.GetKonnectStatus().GetKonnectID()
 
-		w := setupWatch[configurationv1alpha1.KongCertificateList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[configurationv1alpha1.KongCertificateList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations for getting and updating certificates")
 		sdk.CertificatesSDK.EXPECT().GetCertificate(
@@ -282,7 +282,7 @@ func TestKongCertificate(t *testing.T) {
 		)
 
 		t.Logf("Waiting for KongCertificate %s to be programmed and set Konnect ID", client.ObjectKeyFromObject(createdCert))
-		watchFor(t, ctx, w, apiwatch.Modified,
+		WatchFor(t, ctx, w, apiwatch.Modified,
 			func(cert *configurationv1alpha1.KongCertificate) bool {
 				return cert.Name == createdCert.Name &&
 					k8sutils.IsProgrammed(cert) &&
@@ -316,7 +316,7 @@ func TestKongCertificate(t *testing.T) {
 			},
 		)
 
-		w := setupWatch[configurationv1alpha1.KongCertificateList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[configurationv1alpha1.KongCertificateList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Creating KongCertificate with cross-namespace SecretRef (no grant yet)")
 		certType := configurationv1alpha1.KongCertificateSourceTypeSecretRef
@@ -342,7 +342,7 @@ func TestKongCertificate(t *testing.T) {
 		require.NoError(t, clientNamespaced.Create(ctx, createdCert))
 
 		t.Log("Waiting for KongCertificate to have RefNotPermitted condition (no grant)")
-		watchFor(t, ctx, w, apiwatch.Modified, func(c *configurationv1alpha1.KongCertificate) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(c *configurationv1alpha1.KongCertificate) bool {
 			if c.GetName() != createdCert.GetName() {
 				return false
 			}
@@ -395,7 +395,7 @@ func TestKongCertificate(t *testing.T) {
 			}, nil)
 
 		t.Log("Waiting for KongCertificate to be programmed after grant is created")
-		watchFor(t, ctx, w, apiwatch.Modified, func(c *configurationv1alpha1.KongCertificate) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(c *configurationv1alpha1.KongCertificate) bool {
 			if c.GetName() != createdCert.GetName() {
 				return false
 			}
@@ -411,7 +411,7 @@ func TestKongCertificate(t *testing.T) {
 			return hasResolvedRefs && hasProgrammed
 		}, "KongCertificate should have ResolvedRefs=True and be Programmed after KongReferenceGrant is created")
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.CertificatesSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.CertificatesSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations for certificate deletion")
 		sdk.CertificatesSDK.EXPECT().DeleteCertificate(mock.Anything, cpID, certID).Return(nil, nil)
@@ -465,7 +465,7 @@ func TestKongCertificate(t *testing.T) {
 		)
 		_ = grant
 
-		w := setupWatch[configurationv1alpha1.KongCertificateList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[configurationv1alpha1.KongCertificateList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations for certificate creation")
 		sdk.CertificatesSDK.EXPECT().
@@ -519,7 +519,7 @@ func TestKongCertificate(t *testing.T) {
 		require.NoError(t, clientNamespaced.Create(ctx, createdCert))
 
 		t.Log("Waiting for KongCertificate to be programmed with ResolvedRefs=True")
-		watchFor(t, ctx, w, apiwatch.Modified, func(c *configurationv1alpha1.KongCertificate) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(c *configurationv1alpha1.KongCertificate) bool {
 			if c.GetName() != createdCert.GetName() {
 				return false
 			}
@@ -535,7 +535,7 @@ func TestKongCertificate(t *testing.T) {
 			return hasResolvedRefs && hasProgrammed
 		}, "KongCertificate should have ResolvedRefs=True and be Programmed with both SecretRef and SecretRefAlt")
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.CertificatesSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.CertificatesSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations for certificate deletion")
 		sdk.CertificatesSDK.EXPECT().DeleteCertificate(mock.Anything, cpID, certID).Return(nil, nil)

--- a/test/envtest/konnect_entities_kongconsumergroup_test.go
+++ b/test/envtest/konnect_entities_kongconsumergroup_test.go
@@ -61,7 +61,7 @@ func TestKongConsumerGroup(t *testing.T) {
 	apiAuth := deploy.KonnectAPIAuthConfigurationWithProgrammed(t, ctx, clientNamespaced)
 	cp := deploy.KonnectGatewayControlPlaneWithID(t, ctx, clientNamespaced, apiAuth)
 
-	cWatch := setupWatch[configurationv1beta1.KongConsumerGroupList](t, ctx, cl, client.InNamespace(ns.Name))
+	cWatch := SetupWatch[configurationv1beta1.KongConsumerGroupList](t, ctx, cl, client.InNamespace(ns.Name))
 
 	t.Run("should create, update and delete ConsumerGroup successfully", func(t *testing.T) {
 		const (
@@ -92,7 +92,7 @@ func TestKongConsumerGroup(t *testing.T) {
 		)
 
 		t.Log("Waiting for KongConsumerGroup to be programmed")
-		watchFor(t, ctx, cWatch, apiwatch.Modified, func(c *configurationv1beta1.KongConsumerGroup) bool {
+		WatchFor(t, ctx, cWatch, apiwatch.Modified, func(c *configurationv1beta1.KongConsumerGroup) bool {
 			if c.GetName() != cg.GetName() {
 				return false
 			}
@@ -102,7 +102,7 @@ func TestKongConsumerGroup(t *testing.T) {
 			})
 		}, "KongConsumerGroup's Programmed condition should be true eventually")
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.ConsumerGroupSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.ConsumerGroupSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on KongConsumerGroup update")
 		sdk.ConsumerGroupSDK.EXPECT().
@@ -116,7 +116,7 @@ func TestKongConsumerGroup(t *testing.T) {
 		cgToPatch.Spec.Name = updatedCGName
 		require.NoError(t, clientNamespaced.Patch(ctx, cgToPatch, client.MergeFrom(cg)))
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.ConsumerGroupSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.ConsumerGroupSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on KongConsumerGroup deletion")
 		sdk.ConsumerGroupSDK.EXPECT().
@@ -134,7 +134,7 @@ func TestKongConsumerGroup(t *testing.T) {
 			}, waitTime, tickTime,
 		)
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.ConsumerGroupSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.ConsumerGroupSDK, waitTime, tickTime)
 	})
 
 	t.Run("should create ConsumerGroup successfully on conflict when ConsumerGroup with matching uid tag exists", func(t *testing.T) {
@@ -186,11 +186,11 @@ func TestKongConsumerGroup(t *testing.T) {
 		)
 
 		t.Log("Waiting for KongConsumerGroup to be programmed")
-		watchFor(t, ctx, cWatch, apiwatch.Modified, func(c *configurationv1beta1.KongConsumerGroup) bool {
+		WatchFor(t, ctx, cWatch, apiwatch.Modified, func(c *configurationv1beta1.KongConsumerGroup) bool {
 			return c.GetKonnectID() == cgID && k8sutils.IsProgrammed(c)
 		}, "KongConsumerGroup's Programmed condition should be true eventually")
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.ConsumerGroupSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.ConsumerGroupSDK, waitTime, tickTime)
 	})
 
 	t.Run("removing referenced CP sets the status conditions properly", func(t *testing.T) {
@@ -203,7 +203,7 @@ func TestKongConsumerGroup(t *testing.T) {
 		apiAuth := deploy.KonnectAPIAuthConfigurationWithProgrammed(t, ctx, clientNamespaced)
 		cp := deploy.KonnectGatewayControlPlaneWithID(t, ctx, clientNamespaced, apiAuth)
 
-		w := setupWatch[configurationv1beta1.KongConsumerGroupList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[configurationv1beta1.KongConsumerGroupList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations on KongConsumerGroup creation")
 		sdk.ConsumerGroupSDK.EXPECT().
@@ -231,18 +231,18 @@ func TestKongConsumerGroup(t *testing.T) {
 				cg.Spec.Name = name
 			},
 		)
-		eventuallyAssertSDKExpectations(t, factory.SDK.ConsumerGroupSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.ConsumerGroupSDK, waitTime, tickTime)
 
 		t.Log("Waiting for object to be programmed and get Konnect ID")
-		watchFor(t, ctx, w, apiwatch.Modified, conditionProgrammedIsSetToTrueAndCPRefIsKonnectNamespacedRef(created, id),
+		WatchFor(t, ctx, w, apiwatch.Modified, ConditionProgrammedIsSetToTrueAndCPRefIsKonnectNamespacedRef(created, id),
 			fmt.Sprintf("ConsumerGroup didn't get Programmed status condition or didn't get the correct %s Konnect ID assigned", id))
 
 		t.Log("Deleting KonnectGatewayControlPlane")
 		require.NoError(t, clientNamespaced.Delete(ctx, cp))
 
 		t.Log("Waiting for KongConsumerGroup to be get Programmed and ControlPlaneRefValid conditions with status=False")
-		watchFor(t, ctx, w, apiwatch.Modified,
-			conditionsAreSetWhenReferencedControlPlaneIsMissing(created),
+		WatchFor(t, ctx, w, apiwatch.Modified,
+			ConditionsAreSetWhenReferencedControlPlaneIsMissing(created),
 			"KongConsumerGroup didn't get Programmed and/or ControlPlaneRefValid status condition set to False",
 		)
 	})
@@ -251,7 +251,7 @@ func TestKongConsumerGroup(t *testing.T) {
 		cgID := uuid.NewString()
 		cgName := "adopted-consumer-group"
 
-		w := setupWatch[configurationv1beta1.KongConsumerGroupList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[configurationv1beta1.KongConsumerGroupList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations for getting and updating consumer groups")
 		sdk.ConsumerGroupSDK.EXPECT().GetConsumerGroup(
@@ -283,7 +283,7 @@ func TestKongConsumerGroup(t *testing.T) {
 		)
 
 		t.Logf("Waiting for KongConsumerGroup %s to be programmed and set Konnect ID", client.ObjectKeyFromObject(createdConsumerGroup))
-		watchFor(t, ctx, w, apiwatch.Modified, func(cg *configurationv1beta1.KongConsumerGroup) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(cg *configurationv1beta1.KongConsumerGroup) bool {
 			return cg.Name == createdConsumerGroup.Name &&
 				k8sutils.IsProgrammed(cg) &&
 				cg.GetKonnectID() == cgID

--- a/test/envtest/konnect_entities_kongdataplaneclientcertificate_test.go
+++ b/test/envtest/konnect_entities_kongdataplaneclientcertificate_test.go
@@ -75,7 +75,7 @@ func TestKongDataPlaneClientCertificate(t *testing.T) {
 		},
 	}, nil)
 
-	w := setupWatch[configurationv1alpha1.KongDataPlaneClientCertificateList](t, ctx, cl, client.InNamespace(ns.Name))
+	w := SetupWatch[configurationv1alpha1.KongDataPlaneClientCertificateList](t, ctx, cl, client.InNamespace(ns.Name))
 
 	t.Log("Creating KongDataPlaneClientCertificate")
 	createdCert := deploy.KongDataPlaneClientCertificateAttachedToCP(t, ctx, clientNamespaced,
@@ -83,7 +83,7 @@ func TestKongDataPlaneClientCertificate(t *testing.T) {
 	)
 
 	t.Log("Waiting for KongDataPlaneClientCertificate to be programmed")
-	watchFor(t, ctx, w, apiwatch.Modified, func(c *configurationv1alpha1.KongDataPlaneClientCertificate) bool {
+	WatchFor(t, ctx, w, apiwatch.Modified, func(c *configurationv1alpha1.KongDataPlaneClientCertificate) bool {
 		if c.GetName() != createdCert.GetName() {
 			return false
 		}
@@ -94,7 +94,7 @@ func TestKongDataPlaneClientCertificate(t *testing.T) {
 	}, "KongDataPlaneClientCertificate's Programmed condition should be true eventually")
 
 	t.Log("Waiting for KongDataPlaneClientCertificate to be created in the SDK")
-	eventuallyAssertSDKExpectations(t, factory.SDK.DataPlaneCertificatesSDK, waitTime, tickTime)
+	EventuallyAssertSDKExpectations(t, factory.SDK.DataPlaneCertificatesSDK, waitTime, tickTime)
 
 	t.Log("Setting up SDK expectations on KongDataPlaneClientCertificate deletion")
 	sdk.DataPlaneCertificatesSDK.EXPECT().DeleteDataplaneCertificate(mock.Anything, cp.GetKonnectStatus().GetKonnectID(), dpCertID).
@@ -104,7 +104,7 @@ func TestKongDataPlaneClientCertificate(t *testing.T) {
 	require.NoError(t, cl.Delete(ctx, createdCert))
 
 	t.Log("Waiting for KongDataPlaneClientCertificate to be deleted in the SDK")
-	eventuallyAssertSDKExpectations(t, factory.SDK.DataPlaneCertificatesSDK, waitTime, tickTime)
+	EventuallyAssertSDKExpectations(t, factory.SDK.DataPlaneCertificatesSDK, waitTime, tickTime)
 
 	t.Run("removing referenced CP sets the status conditions properly", func(t *testing.T) {
 		const (
@@ -115,7 +115,7 @@ func TestKongDataPlaneClientCertificate(t *testing.T) {
 		apiAuth := deploy.KonnectAPIAuthConfigurationWithProgrammed(t, ctx, clientNamespaced)
 		cp := deploy.KonnectGatewayControlPlaneWithID(t, ctx, clientNamespaced, apiAuth)
 
-		w := setupWatch[configurationv1alpha1.KongDataPlaneClientCertificateList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[configurationv1alpha1.KongDataPlaneClientCertificateList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations on KongDataPlaneClientCertificate creation")
 		sdk.DataPlaneCertificatesSDK.EXPECT().
@@ -138,25 +138,25 @@ func TestKongDataPlaneClientCertificate(t *testing.T) {
 		created := deploy.KongDataPlaneClientCertificateAttachedToCP(t, ctx, clientNamespaced,
 			deploy.WithKonnectNamespacedRefControlPlaneRef(cp),
 		)
-		eventuallyAssertSDKExpectations(t, factory.SDK.DataPlaneCertificatesSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.DataPlaneCertificatesSDK, waitTime, tickTime)
 
 		t.Log("Waiting for object to be programmed and get Konnect ID")
-		watchFor(t, ctx, w, apiwatch.Modified, conditionProgrammedIsSetToTrueAndCPRefIsKonnectNamespacedRef(created, id),
+		WatchFor(t, ctx, w, apiwatch.Modified, ConditionProgrammedIsSetToTrueAndCPRefIsKonnectNamespacedRef(created, id),
 			fmt.Sprintf("DataPlaneClientCertificate didn't get Programmed status condition or didn't get the correct %s Konnect ID assigned", id))
 
 		t.Log("Deleting KonnectGatewayControlPlane")
 		require.NoError(t, clientNamespaced.Delete(ctx, cp))
 
 		t.Log("Waiting for DataPlaneClientCertificate to be get Programmed and ControlPlaneRefValid conditions with status=False")
-		watchFor(t, ctx, w, apiwatch.Modified,
-			conditionsAreSetWhenReferencedControlPlaneIsMissing(created),
+		WatchFor(t, ctx, w, apiwatch.Modified,
+			ConditionsAreSetWhenReferencedControlPlaneIsMissing(created),
 			"KongDataPlaneClientCertificate didn't get Programmed and/or ControlPlaneRefValid status condition set to False",
 		)
 	})
 
 	t.Run("Adopting existing dataplane certificate", func(t *testing.T) {
 		dpCertID := uuid.NewString()
-		w := setupWatch[configurationv1alpha1.KongDataPlaneClientCertificateList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[configurationv1alpha1.KongDataPlaneClientCertificateList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations for getting DataPlane certificates")
 		sdk.DataPlaneCertificatesSDK.EXPECT().GetDataplaneCertificate(
@@ -179,7 +179,7 @@ func TestKongDataPlaneClientCertificate(t *testing.T) {
 		)
 
 		t.Logf("Waiting for KongDataPlaneClientCertificate %s/%s to be programmed and set Konnect ID", ns.Name, createdDPCert.Name)
-		watchFor(t, ctx, w, apiwatch.Modified, func(dpCert *configurationv1alpha1.KongDataPlaneClientCertificate) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(dpCert *configurationv1alpha1.KongDataPlaneClientCertificate) bool {
 			return dpCert.Name == createdDPCert.Name &&
 				k8sutils.IsProgrammed(dpCert) &&
 				dpCert.GetKonnectID() == dpCertID
@@ -189,7 +189,7 @@ func TestKongDataPlaneClientCertificate(t *testing.T) {
 	})
 
 	t.Run("Cross namespace ref KongDataPlaneClientCertificate -> KonnectNamespacedRefControlPlane yields ResolvedRefs=False without KongReferenceGrant", func(t *testing.T) {
-		w := setupWatch[configurationv1alpha1.KongDataPlaneClientCertificateList](t, ctx, cl2, client.InNamespace(ns2.Name))
+		w := SetupWatch[configurationv1alpha1.KongDataPlaneClientCertificateList](t, ctx, cl2, client.InNamespace(ns2.Name))
 
 		t.Log("Don't setting SDK expectations on DataPlaneClientCertificate creation as we do not expect any operations to be made upstream")
 
@@ -199,7 +199,7 @@ func TestKongDataPlaneClientCertificate(t *testing.T) {
 		)
 
 		t.Log("Waiting for KongDataPlaneClientCertificate to get ResolvedRefs condition with status=False")
-		watchFor(t, ctx, w, apiwatch.Modified, func(c *configurationv1alpha1.KongDataPlaneClientCertificate) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(c *configurationv1alpha1.KongDataPlaneClientCertificate) bool {
 			if c.GetName() != createdCert.GetName() {
 				return false
 			}
@@ -222,7 +222,7 @@ func TestKongDataPlaneClientCertificate(t *testing.T) {
 	t.Run("Cross namespace ref KongDataPlaneClientCertificate -> KonnectNamespacedRefControlPlane yields ResolvedRefs=True with valid KongReferenceGrant", func(t *testing.T) {
 		const id = "dp-cert-cross-ns-1234"
 
-		w := setupWatch[configurationv1alpha1.KongDataPlaneClientCertificateList](t, ctx, cl2, client.InNamespace(ns2.Name))
+		w := SetupWatch[configurationv1alpha1.KongDataPlaneClientCertificateList](t, ctx, cl2, client.InNamespace(ns2.Name))
 
 		t.Log("Setting up SDK expectations on DataPlaneClientCertificate creation")
 		sdk.DataPlaneCertificatesSDK.EXPECT().
@@ -262,7 +262,7 @@ func TestKongDataPlaneClientCertificate(t *testing.T) {
 		)
 
 		t.Log("Waiting for KongDataPlaneClientCertificate to get ResolvedRefs condition with status=True")
-		watchFor(t, ctx, w, apiwatch.Modified, func(c *configurationv1alpha1.KongDataPlaneClientCertificate) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(c *configurationv1alpha1.KongDataPlaneClientCertificate) bool {
 			if c.GetName() != createdCert.GetName() {
 				return false
 			}
@@ -281,6 +281,6 @@ func TestKongDataPlaneClientCertificate(t *testing.T) {
 			return k8sutils.HasConditionTrue(configurationv1alpha1.KongReferenceGrantConditionTypeResolvedRefs, c)
 		}, "KongDataPlaneClientCertificate didn't get ResolvedRefs status condition set to True")
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.DataPlaneCertificatesSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.DataPlaneCertificatesSDK, waitTime, tickTime)
 	})
 }

--- a/test/envtest/konnect_entities_kongkey_test.go
+++ b/test/envtest/konnect_entities_kongkey_test.go
@@ -78,7 +78,7 @@ func TestKongKey(t *testing.T) {
 		},
 	}, nil)
 
-	w := setupWatch[configurationv1alpha1.KongKeyList](t, ctx, cl, client.InNamespace(ns.Name))
+	w := SetupWatch[configurationv1alpha1.KongKeyList](t, ctx, cl, client.InNamespace(ns.Name))
 
 	t.Run("without KongKeySet", func(t *testing.T) {
 		t.Log("Creating KongKey")
@@ -87,7 +87,7 @@ func TestKongKey(t *testing.T) {
 		)
 
 		t.Log("Waiting for KongKey to be programmed")
-		watchFor(t, ctx, w, apiwatch.Modified, func(c *configurationv1alpha1.KongKey) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(c *configurationv1alpha1.KongKey) bool {
 			if c.GetName() != createdKey.GetName() {
 				return false
 			}
@@ -97,7 +97,7 @@ func TestKongKey(t *testing.T) {
 			})
 		}, "KongKey's Programmed condition should be true eventually")
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.KeysSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.KeysSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on KongKey update")
 		sdk.KeysSDK.EXPECT().UpsertKey(mock.Anything, mock.MatchedBy(func(r sdkkonnectops.UpsertKeyRequest) bool {
@@ -110,7 +110,7 @@ func TestKongKey(t *testing.T) {
 		certToPatch.Spec.Tags = append(certToPatch.Spec.Tags, "addedTag")
 		require.NoError(t, clientNamespaced.Patch(ctx, certToPatch, client.MergeFrom(createdKey)))
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.KeysSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.KeysSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on KongKey deletion")
 		sdk.KeysSDK.EXPECT().DeleteKey(mock.Anything, cp.GetKonnectStatus().GetKonnectID(), keyID).
@@ -119,7 +119,7 @@ func TestKongKey(t *testing.T) {
 		t.Log("Deleting KongKey")
 		require.NoError(t, cl.Delete(ctx, createdKey))
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.KeysSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.KeysSDK, waitTime, tickTime)
 	})
 
 	t.Run("without KongKeySet but with conflict response", func(t *testing.T) {
@@ -162,7 +162,7 @@ func TestKongKey(t *testing.T) {
 		)
 
 		t.Log("Waiting for KongKey to be programmed")
-		watchFor(t, ctx, w, apiwatch.Modified, func(k *configurationv1alpha1.KongKey) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(k *configurationv1alpha1.KongKey) bool {
 			if k.GetName() != createdKey.GetName() {
 				return false
 			}
@@ -172,7 +172,7 @@ func TestKongKey(t *testing.T) {
 			})
 		}, "KongKey's Programmed condition should be true eventually")
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.KeysSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.KeysSDK, waitTime, tickTime)
 	})
 
 	t.Run("with KongKeySet", func(t *testing.T) {
@@ -191,7 +191,7 @@ func TestKongKey(t *testing.T) {
 		)
 
 		t.Log("Waiting for KeySetRefValid condition to be false")
-		watchFor(t, ctx, w, apiwatch.Modified, func(c *configurationv1alpha1.KongKey) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(c *configurationv1alpha1.KongKey) bool {
 			if c.GetName() != createdKey.GetName() {
 				return false
 			}
@@ -221,7 +221,7 @@ func TestKongKey(t *testing.T) {
 		updateKongKeySetStatusWithProgrammed(t, ctx, clientNamespaced, keySet, keySetID, cp.GetKonnectStatus().GetKonnectID())
 
 		t.Log("Waiting for KongKey to be programmed and associated with KongKeySet")
-		watchFor(t, ctx, w, apiwatch.Modified, func(c *configurationv1alpha1.KongKey) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(c *configurationv1alpha1.KongKey) bool {
 			if c.GetName() != createdKey.GetName() {
 				return false
 			}
@@ -239,7 +239,7 @@ func TestKongKey(t *testing.T) {
 			return programmed && associated && keySetIDPopulated && exactlyZeroOwnerReference
 		}, "KongKey's Programmed and KeySetRefValid conditions should be true eventually")
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.KeysSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.KeysSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on KongKeySet deattachment")
 		sdk.KeysSDK.EXPECT().UpsertKey(mock.Anything, mock.MatchedBy(func(r sdkkonnectops.UpsertKeyRequest) bool {
@@ -253,7 +253,7 @@ func TestKongKey(t *testing.T) {
 		require.NoError(t, clientNamespaced.Patch(ctx, keyToPatch, client.MergeFrom(createdKey)))
 
 		t.Log("Waiting for KongKey to be deattached from KongKeySet")
-		watchFor(t, ctx, w, apiwatch.Modified, func(c *configurationv1alpha1.KongKey) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(c *configurationv1alpha1.KongKey) bool {
 			if c.GetName() != createdKey.GetName() {
 				return false
 			}
@@ -265,7 +265,7 @@ func TestKongKey(t *testing.T) {
 			return len(c.GetOwnerReferences()) == 0
 		}, "KongKey should be deattached from KongKeySet eventually")
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.KeysSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.KeysSDK, waitTime, tickTime)
 	})
 
 	t.Run("removing referenced CP sets the status conditions properly", func(t *testing.T) {
@@ -277,7 +277,7 @@ func TestKongKey(t *testing.T) {
 		apiAuth := deploy.KonnectAPIAuthConfigurationWithProgrammed(t, ctx, clientNamespaced)
 		cp := deploy.KonnectGatewayControlPlaneWithID(t, ctx, clientNamespaced, apiAuth)
 
-		w := setupWatch[configurationv1alpha1.KongKeyList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[configurationv1alpha1.KongKeyList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations on KongKey creation")
 		sdk.KeysSDK.EXPECT().
@@ -305,18 +305,18 @@ func TestKongKey(t *testing.T) {
 				cg.Spec.Tags = append(cg.Spec.Tags, "test-1")
 			},
 		)
-		eventuallyAssertSDKExpectations(t, factory.SDK.KeysSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.KeysSDK, waitTime, tickTime)
 
 		t.Log("Waiting for object to be programmed and get Konnect ID")
-		watchFor(t, ctx, w, apiwatch.Modified, conditionProgrammedIsSetToTrueAndCPRefIsKonnectNamespacedRef(created, id),
+		WatchFor(t, ctx, w, apiwatch.Modified, ConditionProgrammedIsSetToTrueAndCPRefIsKonnectNamespacedRef(created, id),
 			fmt.Sprintf("Key didn't get Programmed status condition or didn't get the correct %s Konnect ID assigned", id))
 
 		t.Log("Deleting KonnectGatewayControlPlane")
 		require.NoError(t, clientNamespaced.Delete(ctx, cp))
 
 		t.Log("Waiting for KongKey to be get Programmed and ControlPlaneRefValid conditions with status=False")
-		watchFor(t, ctx, w, apiwatch.Modified,
-			conditionsAreSetWhenReferencedControlPlaneIsMissing(created),
+		WatchFor(t, ctx, w, apiwatch.Modified,
+			ConditionsAreSetWhenReferencedControlPlaneIsMissing(created),
 			"KongKey didn't get Programmed and/or ControlPlaneRefValid status condition set to False",
 		)
 	})
@@ -326,7 +326,7 @@ func TestKongKey(t *testing.T) {
 		keyName := "adopted-key"
 		keyKID := "adopted-key-id"
 
-		w := setupWatch[configurationv1alpha1.KongKeyList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[configurationv1alpha1.KongKeyList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations for getting and updating key set")
 		sdk.KeysSDK.EXPECT().GetKey(mock.Anything, keyKonnectID, cp.GetKonnectID()).Return(
@@ -353,7 +353,7 @@ func TestKongKey(t *testing.T) {
 		)
 
 		t.Logf("Waiting for KongKey %s to be programmed and set Konnect ID", client.ObjectKeyFromObject(createdKey))
-		watchFor(t, ctx, w, apiwatch.Modified, func(key *configurationv1alpha1.KongKey) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(key *configurationv1alpha1.KongKey) bool {
 			return key.Name == createdKey.Name &&
 				k8sutils.IsProgrammed(key) &&
 				key.GetKonnectID() == keyKonnectID

--- a/test/envtest/konnect_entities_kongkeyset_test.go
+++ b/test/envtest/konnect_entities_kongkeyset_test.go
@@ -74,22 +74,22 @@ func TestKongKeySet(t *testing.T) {
 			},
 		}, nil)
 
-		w := setupWatch[configurationv1alpha1.KongKeySetList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[configurationv1alpha1.KongKeySetList](t, ctx, cl, client.InNamespace(ns.Name))
 		createdKeySet := deploy.KongKeySet(t, ctx, clientNamespaced, keySetName,
 			deploy.WithKonnectNamespacedRefControlPlaneRef(cp),
 		)
 
 		t.Log("Waiting for KongKeySet to be programmed")
-		watchFor(t, ctx, w, apiwatch.Modified,
-			assertsAnd(
-				objectMatchesName(createdKeySet),
-				objectHasConditionProgrammedSetToTrue[*configurationv1alpha1.KongKeySet](),
+		WatchFor(t, ctx, w, apiwatch.Modified,
+			AssertsAnd(
+				ObjectMatchesName(createdKeySet),
+				ObjectHasConditionProgrammedSetToTrue[*configurationv1alpha1.KongKeySet](),
 			),
 			"KongKeySet's Programmed condition should be true eventually",
 		)
 
 		t.Log("Waiting for KongKeySet to be created in the SDK")
-		eventuallyAssertSDKExpectations(t, factory.SDK.KeySetsSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.KeySetsSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on KongKeySet update")
 		sdk.KeySetsSDK.EXPECT().UpsertKeySet(mock.Anything, mock.MatchedBy(func(r sdkkonnectops.UpsertKeySetRequest) bool {
@@ -103,16 +103,16 @@ func TestKongKeySet(t *testing.T) {
 		require.NoError(t, clientNamespaced.Patch(ctx, certToPatch, client.MergeFrom(createdKeySet)))
 
 		t.Log("Waiting for KongKeySet to be updated")
-		watchFor(t, ctx, w, apiwatch.Modified,
-			assertsAnd(
-				objectMatchesName(createdKeySet),
-				objectHasConditionProgrammedSetToTrue[*configurationv1alpha1.KongKeySet](),
+		WatchFor(t, ctx, w, apiwatch.Modified,
+			AssertsAnd(
+				ObjectMatchesName(createdKeySet),
+				ObjectHasConditionProgrammedSetToTrue[*configurationv1alpha1.KongKeySet](),
 			),
 			"KongKeySet should be updated",
 		)
 
 		t.Log("Waiting for KongKeySet to be updated in the SDK")
-		eventuallyAssertSDKExpectations(t, factory.SDK.KeySetsSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.KeySetsSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on KongKeySet deletion")
 		sdk.KeySetsSDK.EXPECT().DeleteKeySet(mock.Anything, cp.GetKonnectStatus().GetKonnectID(), keySetID).
@@ -130,7 +130,7 @@ func TestKongKeySet(t *testing.T) {
 			}, waitTime, tickTime,
 		)
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.KeySetsSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.KeySetsSDK, waitTime, tickTime)
 	})
 
 	t.Run("should handle conflict in creation correctly", func(t *testing.T) {
@@ -164,16 +164,16 @@ func TestKongKeySet(t *testing.T) {
 			},
 		}, nil)
 
-		w := setupWatch[configurationv1alpha1.KongKeySetList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[configurationv1alpha1.KongKeySetList](t, ctx, cl, client.InNamespace(ns.Name))
 		deploy.KongKeySet(t, ctx, clientNamespaced, keySetName,
 			deploy.WithKonnectNamespacedRefControlPlaneRef(cp),
 		)
 		t.Log("Watching for KeySet to verify the created KeySet programmed")
-		watchFor(t, ctx, w, apiwatch.Modified, func(c *configurationv1alpha1.KongKeySet) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(c *configurationv1alpha1.KongKeySet) bool {
 			return c.GetKonnectID() == keySetID && k8sutils.IsProgrammed(c)
 		}, "KeySet should be programmed and have ID in status after handling conflict")
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.ConsumersSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.ConsumersSDK, waitTime, tickTime)
 	})
 
 	t.Run("removing referenced CP sets the status conditions properly", func(t *testing.T) {
@@ -185,7 +185,7 @@ func TestKongKeySet(t *testing.T) {
 		apiAuth := deploy.KonnectAPIAuthConfigurationWithProgrammed(t, ctx, clientNamespaced)
 		cp := deploy.KonnectGatewayControlPlaneWithID(t, ctx, clientNamespaced, apiAuth)
 
-		w := setupWatch[configurationv1alpha1.KongKeySetList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[configurationv1alpha1.KongKeySetList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations on KongKeySet creation")
 		sdk.KeySetsSDK.EXPECT().
@@ -215,17 +215,17 @@ func TestKongKeySet(t *testing.T) {
 		)
 
 		t.Log("Waiting for object to be programmed and get Konnect ID")
-		watchFor(t, ctx, w, apiwatch.Modified, conditionProgrammedIsSetToTrueAndCPRefIsKonnectNamespacedRef(created, id),
+		WatchFor(t, ctx, w, apiwatch.Modified, ConditionProgrammedIsSetToTrueAndCPRefIsKonnectNamespacedRef(created, id),
 			fmt.Sprintf("Key didn't get Programmed status condition or didn't get the correct %s Konnect ID assigned", id))
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.KeysSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.KeysSDK, waitTime, tickTime)
 
 		t.Log("Deleting KonnectGatewayControlPlane")
 		require.NoError(t, clientNamespaced.Delete(ctx, cp))
 
 		t.Log("Waiting for KongKeySet to be get Programmed and ControlPlaneRefValid conditions with status=False")
-		watchFor(t, ctx, w, apiwatch.Modified,
-			conditionsAreSetWhenReferencedControlPlaneIsMissing(created),
+		WatchFor(t, ctx, w, apiwatch.Modified,
+			ConditionsAreSetWhenReferencedControlPlaneIsMissing(created),
 			"KongKeySet didn't get Programmed and/or ControlPlaneRefValid status condition set to False",
 		)
 	})
@@ -234,7 +234,7 @@ func TestKongKeySet(t *testing.T) {
 		keySetID := uuid.NewString()
 		keySetName := "adopted-key-set"
 
-		w := setupWatch[configurationv1alpha1.KongKeySetList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[configurationv1alpha1.KongKeySetList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations for getting and updating key set")
 		sdk.KeySetsSDK.EXPECT().GetKeySet(mock.Anything, keySetID, cp.GetKonnectID()).Return(
@@ -260,7 +260,7 @@ func TestKongKeySet(t *testing.T) {
 		)
 
 		t.Logf("Waiting for KongKeySet %s to be programmed and set Konnect ID", client.ObjectKeyFromObject(createdKeySet))
-		watchFor(t, ctx, w, apiwatch.Modified, func(keySet *configurationv1alpha1.KongKeySet) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(keySet *configurationv1alpha1.KongKeySet) bool {
 			return keySet.Name == createdKeySet.Name &&
 				k8sutils.IsProgrammed(keySet) &&
 				keySet.GetKonnectID() == keySetID

--- a/test/envtest/konnect_entities_kongroute_test.go
+++ b/test/envtest/konnect_entities_kongroute_test.go
@@ -69,7 +69,7 @@ func TestKongRoute(t *testing.T) {
 	t.Run("adding, patching and deleting KongRoute", func(t *testing.T) {
 		const routeID = "route-12345"
 
-		w := setupWatch[configurationv1alpha1.KongRouteList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[configurationv1alpha1.KongRouteList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations on Route creation")
 		sdk.RoutesSDK.EXPECT().
@@ -102,14 +102,14 @@ func TestKongRoute(t *testing.T) {
 		)
 
 		t.Log("Waiting for Route to be programmed and get Konnect ID")
-		watchFor(t, ctx, w, apiwatch.Modified, func(r *configurationv1alpha1.KongRoute) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(r *configurationv1alpha1.KongRoute) bool {
 			if r.GetName() != createdRoute.GetName() {
 				return false
 			}
 			return r.GetKonnectID() == routeID && k8sutils.IsProgrammed(r)
 		}, "KongRoute didn't get Programmed status condition or didn't get the correct (route-12345) Konnect ID assigned")
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.RoutesSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.RoutesSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on Route update")
 		sdk.RoutesSDK.EXPECT().
@@ -129,7 +129,7 @@ func TestKongRoute(t *testing.T) {
 		require.NoError(t, clientNamespaced.Patch(ctx, routeToPatch, client.MergeFrom(createdRoute)))
 
 		t.Log("Waiting for Route to get the update")
-		watchFor(t, ctx, w, apiwatch.Modified, func(r *configurationv1alpha1.KongRoute) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(r *configurationv1alpha1.KongRoute) bool {
 			if r.GetName() != createdRoute.GetName() {
 				return false
 			}
@@ -139,7 +139,7 @@ func TestKongRoute(t *testing.T) {
 			return r.GetKonnectID() == routeID && k8sutils.IsProgrammed(r)
 		}, "KongRoute didn't get patched with PreserveHost=true")
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.RoutesSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.RoutesSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on Route deletion")
 		sdk.RoutesSDK.EXPECT().
@@ -160,7 +160,7 @@ func TestKongRoute(t *testing.T) {
 		routeID := uuid.NewString()
 		routeName := "test-adoption-" + uuid.NewString()[:8]
 
-		w := setupWatch[configurationv1alpha1.KongRouteList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[configurationv1alpha1.KongRouteList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations for getting and updating routes")
 		sdk.RoutesSDK.EXPECT().GetRoute(
@@ -196,7 +196,7 @@ func TestKongRoute(t *testing.T) {
 		)
 
 		t.Logf("Waiting for the KongRoute %s/%s to get KonnectID and marked as programmed", ns.Name, createdRoute.Name)
-		watchFor(t, ctx, w, apiwatch.Modified, func(r *configurationv1alpha1.KongRoute) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(r *configurationv1alpha1.KongRoute) bool {
 			return r.Name == createdRoute.Name && r.GetKonnectID() == routeID && k8sutils.IsProgrammed(r)
 		},
 			fmt.Sprintf("KongRoute did not get programmed and set KonnectID to %s", routeID),
@@ -215,7 +215,7 @@ func TestKongRoute(t *testing.T) {
 		routeID := uuid.NewString()
 		routeName := "test-adoption-" + uuid.NewString()[:8]
 
-		w := setupWatch[configurationv1alpha1.KongRouteList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[configurationv1alpha1.KongRouteList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations for getting and updating routes")
 		sdk.RoutesSDK.EXPECT().GetRoute(
@@ -248,7 +248,7 @@ func TestKongRoute(t *testing.T) {
 		)
 
 		t.Logf("Waiting for the KongRoute %s/%s to get KonnectID and marked as programmed", ns.Name, createdRoute.Name)
-		watchFor(t, ctx, w, apiwatch.Modified, func(r *configurationv1alpha1.KongRoute) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(r *configurationv1alpha1.KongRoute) bool {
 			return r.Name == createdRoute.Name && r.GetKonnectID() == routeID && k8sutils.IsProgrammed(r)
 		},
 			fmt.Sprintf("KongRoute did not get programmed and set KonnectID to %s", routeID),
@@ -259,7 +259,7 @@ func TestKongRoute(t *testing.T) {
 		routeID := uuid.NewString()
 		routeName := "test-adoption-" + uuid.NewString()[:8]
 
-		w := setupWatch[configurationv1alpha1.KongRouteList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[configurationv1alpha1.KongRouteList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations for getting routes")
 		sdk.RoutesSDK.EXPECT().GetRoute(
@@ -287,9 +287,9 @@ func TestKongRoute(t *testing.T) {
 		)
 
 		t.Logf("Waiting for the KongRoute %s/%s to be marked as not programmed and not adopted", ns.Name, createdRoute.Name)
-		watchFor(t, ctx, w, apiwatch.Modified, func(r *configurationv1alpha1.KongRoute) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(r *configurationv1alpha1.KongRoute) bool {
 			return r.Name == createdRoute.Name &&
-				conditionsContainProgrammedFalse(r.GetConditions()) &&
+				ConditionsContainProgrammedFalse(r.GetConditions()) &&
 				lo.ContainsBy(r.GetConditions(), func(c metav1.Condition) bool {
 					return c.Type == konnectv1alpha1.KonnectEntityAdoptedConditionType &&
 						c.Status == metav1.ConditionFalse
@@ -301,7 +301,7 @@ func TestKongRoute(t *testing.T) {
 	})
 
 	t.Run("Cross namespace ref KongRoute -> KonnectNamespacedRefControlPlane yields ResolvedRefs=False without KongReferenceGrant", func(t *testing.T) {
-		w := setupWatch[configurationv1alpha1.KongRouteList](t, ctx, cl2, client.InNamespace(ns2.Name))
+		w := SetupWatch[configurationv1alpha1.KongRouteList](t, ctx, cl2, client.InNamespace(ns2.Name))
 
 		t.Log("Don't setting SDK expectations on KongRoute creation as we do not expect any operations to be made upstream")
 
@@ -311,7 +311,7 @@ func TestKongRoute(t *testing.T) {
 		)
 
 		t.Log("Waiting for Route to get ResolvedRefs condition with status=False")
-		watchFor(t, ctx, w, apiwatch.Modified, func(kr *configurationv1alpha1.KongRoute) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(kr *configurationv1alpha1.KongRoute) bool {
 			if kr.GetName() != createdRoute.GetName() {
 				return false
 			}
@@ -339,7 +339,7 @@ func TestKongRoute(t *testing.T) {
 
 		var paths = []string{"/path"}
 
-		w := setupWatch[configurationv1alpha1.KongRouteList](t, ctx, cl2, client.InNamespace(ns2.Name))
+		w := SetupWatch[configurationv1alpha1.KongRouteList](t, ctx, cl2, client.InNamespace(ns2.Name))
 
 		t.Log("Setting up SDK expectations on Route creation")
 		sdk.RoutesSDK.EXPECT().
@@ -383,7 +383,7 @@ func TestKongRoute(t *testing.T) {
 		)
 
 		t.Log("Waiting for Route to get ResolvedRefs condition with status=False")
-		watchFor(t, ctx, w, apiwatch.Modified, func(kr *configurationv1alpha1.KongRoute) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(kr *configurationv1alpha1.KongRoute) bool {
 			if kr.GetName() != createdRoute.GetName() {
 				return false
 			}
@@ -401,11 +401,11 @@ func TestKongRoute(t *testing.T) {
 			}
 			return k8sutils.HasConditionTrue(configurationv1alpha1.KongReferenceGrantConditionTypeResolvedRefs, kr)
 		}, "KongRoute didn't get ResolvedRefs status condition set to True")
-		eventuallyAssertSDKExpectations(t, factory.SDK.RoutesSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.RoutesSDK, waitTime, tickTime)
 	})
 
 	t.Run("Cross namespace ref KongRoute -> KongService yields ResolvedRefs=False without KongReferenceGrant", func(t *testing.T) {
-		w := setupWatch[configurationv1alpha1.KongRouteList](t, ctx, cl2, client.InNamespace(ns2.Name))
+		w := SetupWatch[configurationv1alpha1.KongRouteList](t, ctx, cl2, client.InNamespace(ns2.Name))
 
 		t.Log("Don't set SDK expectations on KongRoute creation as we do not expect any operations to be made upstream")
 
@@ -425,7 +425,7 @@ func TestKongRoute(t *testing.T) {
 		)
 
 		t.Log("Waiting for Route to get ResolvedRefs condition with status=False")
-		watchFor(t, ctx, w, apiwatch.Modified, func(kr *configurationv1alpha1.KongRoute) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(kr *configurationv1alpha1.KongRoute) bool {
 			if kr.GetName() != createdRoute.GetName() {
 				return false
 			}
@@ -451,7 +451,7 @@ func TestKongRoute(t *testing.T) {
 
 		var paths = []string{"/cross-ns-path"}
 
-		w := setupWatch[configurationv1alpha1.KongRouteList](t, ctx, cl2, client.InNamespace(ns2.Name))
+		w := SetupWatch[configurationv1alpha1.KongRouteList](t, ctx, cl2, client.InNamespace(ns2.Name))
 
 		t.Log("Setting up SDK expectations on Route creation")
 		sdk.RoutesSDK.EXPECT().
@@ -522,7 +522,7 @@ func TestKongRoute(t *testing.T) {
 		)
 
 		t.Log("Waiting for Route to get ResolvedRefs condition with status=True and be Programmed")
-		watchFor(t, ctx, w, apiwatch.Modified, func(kr *configurationv1alpha1.KongRoute) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(kr *configurationv1alpha1.KongRoute) bool {
 			if kr.GetName() != createdRoute.GetName() {
 				return false
 			}
@@ -542,6 +542,6 @@ func TestKongRoute(t *testing.T) {
 				kr.GetKonnectID() == routeID && k8sutils.IsProgrammed(kr)
 		}, "KongRoute didn't get ResolvedRefs status condition set to True or wasn't Programmed")
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.RoutesSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.RoutesSDK, waitTime, tickTime)
 	})
 }

--- a/test/envtest/konnect_entities_kongservice_test.go
+++ b/test/envtest/konnect_entities_kongservice_test.go
@@ -79,7 +79,7 @@ func TestKongService(t *testing.T) {
 		)
 		updateKongUpstreamStatusWithProgrammed(t, ctx, clientNamespaced, upstream, upstreamID, cp.GetKonnectID())
 
-		w := setupWatch[configurationv1alpha1.KongServiceList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[configurationv1alpha1.KongServiceList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations on Service creation")
 		sdk.ServicesSDK.EXPECT().
@@ -109,11 +109,11 @@ func TestKongService(t *testing.T) {
 		)
 
 		t.Log("Waiting for Service to be programmed and get Konnect ID")
-		watchFor(t, ctx, w, apiwatch.Modified, func(kt *configurationv1alpha1.KongService) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(kt *configurationv1alpha1.KongService) bool {
 			return kt.GetKonnectID() == serviceID && k8sutils.IsProgrammed(kt)
 		}, "KongService didn't get Programmed status condition or didn't get the correct (service-12345) Konnect ID assigned")
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.ServicesSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.ServicesSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on Service update")
 		sdk.ServicesSDK.EXPECT().
@@ -131,18 +131,18 @@ func TestKongService(t *testing.T) {
 		require.NoError(t, clientNamespaced.Patch(ctx, serviceToPatch, client.MergeFrom(createdService)))
 
 		t.Log("Waiting for Service to be patched")
-		watchFor(t, ctx, w, apiwatch.Modified,
-			assertsAnd(
-				objectMatchesName(createdService),
-				objectMatchesKonnectID[*configurationv1alpha1.KongService](serviceID),
-				objectHasConditionProgrammedSetToTrue[*configurationv1alpha1.KongService](),
+		WatchFor(t, ctx, w, apiwatch.Modified,
+			AssertsAnd(
+				ObjectMatchesName(createdService),
+				ObjectMatchesKonnectID[*configurationv1alpha1.KongService](serviceID),
+				ObjectHasConditionProgrammedSetToTrue[*configurationv1alpha1.KongService](),
 				func(s *configurationv1alpha1.KongService) bool {
 					return s.Spec.Port == port
 				},
 			),
 			"KongService didn't get patched",
 		)
-		eventuallyAssertSDKExpectations(t, factory.SDK.ServicesSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.ServicesSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on Service deletion")
 		sdk.ServicesSDK.EXPECT().
@@ -157,7 +157,7 @@ func TestKongService(t *testing.T) {
 		require.NoError(t, clientNamespaced.Delete(ctx, createdService))
 		eventually.WaitForObjectToNotExist(t, ctx, cl, createdService, waitTime, tickTime)
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.ServicesSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.ServicesSDK, waitTime, tickTime)
 	})
 
 	t.Run("trying to attach KongService to KonnectGatewayControlPlane of type KIC fails (due to CP being read only)", func(t *testing.T) {
@@ -177,7 +177,7 @@ func TestKongService(t *testing.T) {
 		)
 		updateKongUpstreamStatusWithProgrammed(t, ctx, clientNamespaced, upstream, upstreamID, cp.GetKonnectID())
 
-		w := setupWatch[configurationv1alpha1.KongServiceList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[configurationv1alpha1.KongServiceList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations on Service creation")
 		errBody := `{
@@ -213,10 +213,10 @@ func TestKongService(t *testing.T) {
 				s.Spec.Host = host
 			},
 		)
-		eventuallyAssertSDKExpectations(t, factory.SDK.ServicesSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.ServicesSDK, waitTime, tickTime)
 
 		t.Log("Waiting for Service to get the Programmed condition set to False")
-		watchFor(t, ctx, w, apiwatch.Modified, func(kt *configurationv1alpha1.KongService) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(kt *configurationv1alpha1.KongService) bool {
 			if kt.GetName() != createdService.GetName() {
 				return false
 			}
@@ -245,7 +245,7 @@ func TestKongService(t *testing.T) {
 		apiAuth := deploy.KonnectAPIAuthConfigurationWithProgrammed(t, ctx, clientNamespaced)
 		cp := deploy.KonnectGatewayControlPlaneWithID(t, ctx, clientNamespaced, apiAuth)
 
-		w := setupWatch[configurationv1alpha1.KongServiceList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[configurationv1alpha1.KongServiceList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations on Service creation")
 		sdk.ServicesSDK.EXPECT().
@@ -275,15 +275,15 @@ func TestKongService(t *testing.T) {
 		)
 
 		t.Log("Waiting for object to be programmed and get Konnect ID")
-		watchFor(t, ctx, w, apiwatch.Modified, conditionProgrammedIsSetToTrueAndCPRefIsKonnectNamespacedRef(created, id),
+		WatchFor(t, ctx, w, apiwatch.Modified, ConditionProgrammedIsSetToTrueAndCPRefIsKonnectNamespacedRef(created, id),
 			fmt.Sprintf("KongService didn't get Programmed status condition or didn't get the correct %s Konnect ID assigned", id))
 
 		t.Log("Deleting KonnectGatewayControlPlane")
 		require.NoError(t, clientNamespaced.Delete(ctx, cp))
 
 		t.Log("Waiting for Service to be get Programmed and ControlPlaneRefValid conditions with status=False")
-		watchFor(t, ctx, w, apiwatch.Modified,
-			conditionsAreSetWhenReferencedControlPlaneIsMissing(created),
+		WatchFor(t, ctx, w, apiwatch.Modified,
+			ConditionsAreSetWhenReferencedControlPlaneIsMissing(created),
 			"KongService didn't get Programmed and/or ControlPlaneRefValid status condition set to False")
 	})
 
@@ -298,7 +298,7 @@ func TestKongService(t *testing.T) {
 		apiAuth := deploy.KonnectAPIAuthConfigurationWithProgrammed(t, ctx, clientNamespaced)
 		cp := deploy.KonnectGatewayControlPlaneWithID(t, ctx, clientNamespaced, apiAuth)
 
-		w := setupWatch[configurationv1alpha1.KongServiceList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[configurationv1alpha1.KongServiceList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations on Service creation")
 		sdk.ServicesSDK.EXPECT().
@@ -327,17 +327,17 @@ func TestKongService(t *testing.T) {
 		)
 
 		t.Log("Waiting for object to be programmed and get Konnect ID")
-		watchFor(t, ctx, w, apiwatch.Modified, conditionProgrammedIsSetToTrueAndCPRefIsKonnectNamespacedRef(created, id),
+		WatchFor(t, ctx, w, apiwatch.Modified, ConditionProgrammedIsSetToTrueAndCPRefIsKonnectNamespacedRef(created, id),
 			fmt.Sprintf("Consumer didn't get Programmed status condition or didn't get the correct %s Konnect ID assigned", id))
 
 		t.Log("Deleting KonnectGatewayControlPlane")
 		require.NoError(t, clientNamespaced.Delete(ctx, cp))
 
 		t.Log("Waiting for object to be get Programmed and ControlPlaneRefValid conditions with status=False and konnect cleanup finalizer removed")
-		watchFor(t, ctx, w, apiwatch.Modified,
-			assertsAnd(
-				assertNot(objectHasFinalizer[*configurationv1alpha1.KongService](konnect.KonnectCleanupFinalizer)),
-				conditionsAreSetWhenReferencedControlPlaneIsMissing(created),
+		WatchFor(t, ctx, w, apiwatch.Modified,
+			AssertsAnd(
+				AssertNot(ObjectHasFinalizer[*configurationv1alpha1.KongService](konnect.KonnectCleanupFinalizer)),
+				ConditionsAreSetWhenReferencedControlPlaneIsMissing(created),
 			),
 			"Object didn't get Programmed and/or ControlPlaneRefValid status condition set to False",
 		)
@@ -362,10 +362,10 @@ func TestKongService(t *testing.T) {
 		)
 
 		t.Log("Waiting for object to be get Programmed with status=True and konnect cleanup finalizer re added")
-		watchFor(t, ctx, w, apiwatch.Modified,
-			assertsAnd(
-				objectHasConditionProgrammedSetToTrue[*configurationv1alpha1.KongService](),
-				objectHasFinalizer[*configurationv1alpha1.KongService](konnect.KonnectCleanupFinalizer),
+		WatchFor(t, ctx, w, apiwatch.Modified,
+			AssertsAnd(
+				ObjectHasConditionProgrammedSetToTrue[*configurationv1alpha1.KongService](),
+				ObjectHasFinalizer[*configurationv1alpha1.KongService](konnect.KonnectCleanupFinalizer),
 			),
 			"Object didn't get Programmed set to True",
 		)
@@ -373,7 +373,7 @@ func TestKongService(t *testing.T) {
 
 	t.Run("adopting a service in override mode then deleting it", func(t *testing.T) {
 		serviceKonnectID := uuid.NewString()
-		w := setupWatch[configurationv1alpha1.KongServiceList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[configurationv1alpha1.KongServiceList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations for getting and updating service")
 		sdk.ServicesSDK.EXPECT().GetService(
@@ -399,7 +399,7 @@ func TestKongService(t *testing.T) {
 		)
 
 		t.Logf("Waiting for the KongService %s/%s to be programmed and get Konnect ID", ns.Name, createdService.Name)
-		watchFor(t, t.Context(), w, apiwatch.Modified, func(ks *configurationv1alpha1.KongService) bool {
+		WatchFor(t, t.Context(), w, apiwatch.Modified, func(ks *configurationv1alpha1.KongService) bool {
 			return ks.Name == createdService.Name &&
 				ks.GetKonnectID() == serviceKonnectID && k8sutils.IsProgrammed(ks)
 		},
@@ -417,7 +417,7 @@ func TestKongService(t *testing.T) {
 		require.NoError(t, clientNamespaced.Delete(t.Context(), createdService))
 
 		t.Log("Waiting for the SDK's DeleteService to be called")
-		eventuallyAssertSDKExpectations(t, factory.SDK.ServicesSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.ServicesSDK, waitTime, tickTime)
 
 		t.Log("Waiting for the KongService to disappear")
 		eventually.WaitForObjectToNotExist(t, ctx, cl, createdService, waitTime, tickTime)
@@ -425,7 +425,7 @@ func TestKongService(t *testing.T) {
 
 	t.Run("adopting a service with NotFound error returned from upstream", func(t *testing.T) {
 		serviceKonnectID := uuid.NewString()
-		w := setupWatch[configurationv1alpha1.KongServiceList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[configurationv1alpha1.KongServiceList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations for getting service")
 		sdk.ServicesSDK.EXPECT().GetService(
@@ -443,9 +443,9 @@ func TestKongService(t *testing.T) {
 		)
 
 		t.Logf("Waiting for the KongService %s/%s to be marked as not programmed", ns.Name, createdService.Name)
-		watchFor(t, t.Context(), w, apiwatch.Modified, func(ks *configurationv1alpha1.KongService) bool {
+		WatchFor(t, t.Context(), w, apiwatch.Modified, func(ks *configurationv1alpha1.KongService) bool {
 			return ks.Name == createdService.Name &&
-				conditionsContainProgrammedFalse(ks.GetConditions()) &&
+				ConditionsContainProgrammedFalse(ks.GetConditions()) &&
 				lo.ContainsBy(ks.GetConditions(), func(c metav1.Condition) bool {
 					return c.Type == konnectv1alpha1.KonnectEntityAdoptedConditionType &&
 						c.Status == metav1.ConditionFalse
@@ -457,7 +457,7 @@ func TestKongService(t *testing.T) {
 
 	t.Run("adopting a service with the k8s-uid tag already exists in the upstream service", func(t *testing.T) {
 		serviceKonnectID := uuid.NewString()
-		w := setupWatch[configurationv1alpha1.KongServiceList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[configurationv1alpha1.KongServiceList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations for getting service")
 		sdk.ServicesSDK.EXPECT().GetService(
@@ -486,9 +486,9 @@ func TestKongService(t *testing.T) {
 		)
 
 		t.Logf("Waiting for the KongService %s/%s to be marked as not programmed", ns.Name, createdService.Name)
-		watchFor(t, t.Context(), w, apiwatch.Modified, func(ks *configurationv1alpha1.KongService) bool {
+		WatchFor(t, t.Context(), w, apiwatch.Modified, func(ks *configurationv1alpha1.KongService) bool {
 			return ks.Name == createdService.Name &&
-				conditionsContainProgrammedFalse(ks.GetConditions()) &&
+				ConditionsContainProgrammedFalse(ks.GetConditions()) &&
 				lo.ContainsBy(ks.GetConditions(), func(c metav1.Condition) bool {
 					return c.Type == konnectv1alpha1.KonnectEntityAdoptedConditionType &&
 						c.Status == metav1.ConditionFalse
@@ -501,7 +501,7 @@ func TestKongService(t *testing.T) {
 	})
 
 	t.Run("Cross namespace ref KongService -> KonnectNamespacedRefControlPlane yields ResolvedRefs=False without KongReferenceGrant", func(t *testing.T) {
-		w := setupWatch[configurationv1alpha1.KongServiceList](t, ctx, cl2, client.InNamespace(ns2.Name))
+		w := SetupWatch[configurationv1alpha1.KongServiceList](t, ctx, cl2, client.InNamespace(ns2.Name))
 
 		t.Log("Don't setting SDK expectations on Service creation as we do not expect any operations to be made upstream")
 
@@ -511,7 +511,7 @@ func TestKongService(t *testing.T) {
 		)
 
 		t.Log("Waiting for Service to get ResolvedRefs condition with status=False")
-		watchFor(t, ctx, w, apiwatch.Modified, func(ks *configurationv1alpha1.KongService) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(ks *configurationv1alpha1.KongService) bool {
 			if ks.GetName() != createdService.GetName() {
 				return false
 			}
@@ -537,7 +537,7 @@ func TestKongService(t *testing.T) {
 			id   = "service-1234566"
 		)
 
-		w := setupWatch[configurationv1alpha1.KongServiceList](t, ctx, cl2, client.InNamespace(ns2.Name))
+		w := SetupWatch[configurationv1alpha1.KongServiceList](t, ctx, cl2, client.InNamespace(ns2.Name))
 
 		t.Log("Setting up SDK expectations on Service creation")
 		sdk.ServicesSDK.EXPECT().
@@ -579,7 +579,7 @@ func TestKongService(t *testing.T) {
 		)
 
 		t.Log("Waiting for Service to get ResolvedRefs condition with status=False")
-		watchFor(t, ctx, w, apiwatch.Modified, func(ks *configurationv1alpha1.KongService) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(ks *configurationv1alpha1.KongService) bool {
 			if ks.GetName() != createdService.GetName() {
 				return false
 			}
@@ -598,13 +598,13 @@ func TestKongService(t *testing.T) {
 			return k8sutils.HasConditionTrue(configurationv1alpha1.KongReferenceGrantConditionTypeResolvedRefs, ks)
 		}, "KongService didn't get ResolvedRefs status condition set to True")
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.ServicesSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.ServicesSDK, waitTime, tickTime)
 	})
 
 	t.Run("network error on create sets Programmed condition to False", func(t *testing.T) {
 		const host = "network-error-test.com"
 
-		w := setupWatch[configurationv1alpha1.KongServiceList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[configurationv1alpha1.KongServiceList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations to return a network error on Service creation")
 		networkErr := &url.Error{
@@ -632,7 +632,7 @@ func TestKongService(t *testing.T) {
 		)
 
 		t.Log("Waiting for Service to get Programmed condition with status=False due to network error")
-		watchFor(t, ctx, w, apiwatch.Modified, func(ks *configurationv1alpha1.KongService) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(ks *configurationv1alpha1.KongService) bool {
 			if ks.GetName() != createdService.GetName() {
 				return false
 			}
@@ -646,10 +646,10 @@ func TestKongService(t *testing.T) {
 			// can always be cleaned up. The previous behaviour (finalizer added only
 			// after a successful create) would leave no finalizer here.
 			return c.Status == metav1.ConditionFalse && c.Reason == "FailedToCreate" &&
-				objectHasFinalizer[*configurationv1alpha1.KongService](konnect.KonnectCleanupFinalizer)(ks)
+				ObjectHasFinalizer[*configurationv1alpha1.KongService](konnect.KonnectCleanupFinalizer)(ks)
 		}, "KongService should get Programmed=False on network error and still carry the cleanup finalizer")
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.ServicesSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.ServicesSDK, waitTime, tickTime)
 	})
 
 	t.Run("network error on update sets Programmed condition to False", func(t *testing.T) {
@@ -659,7 +659,7 @@ func TestKongService(t *testing.T) {
 			newPort   = int64(9090)
 		)
 
-		w := setupWatch[configurationv1alpha1.KongServiceList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[configurationv1alpha1.KongServiceList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations on Service creation (success)")
 		sdk.ServicesSDK.EXPECT().
@@ -689,13 +689,13 @@ func TestKongService(t *testing.T) {
 		)
 
 		t.Log("Waiting for Service to be programmed and get Konnect ID")
-		watchFor(t, ctx, w, apiwatch.Modified, func(ks *configurationv1alpha1.KongService) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(ks *configurationv1alpha1.KongService) bool {
 			return ks.GetName() == createdService.GetName() &&
 				ks.GetKonnectID() == serviceID &&
 				k8sutils.IsProgrammed(ks)
 		}, "KongService didn't get Programmed status condition or didn't get the correct Konnect ID assigned")
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.ServicesSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.ServicesSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations to return a network error on Service update")
 		networkErr := &url.Error{
@@ -719,7 +719,7 @@ func TestKongService(t *testing.T) {
 		require.NoError(t, clientNamespaced.Patch(ctx, serviceToPatch, client.MergeFrom(createdService)))
 
 		t.Log("Waiting for Service to get Programmed condition with status=False due to network error on update")
-		watchFor(t, ctx, w, apiwatch.Modified, func(ks *configurationv1alpha1.KongService) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(ks *configurationv1alpha1.KongService) bool {
 			if ks.GetName() != createdService.GetName() {
 				return false
 			}
@@ -737,6 +737,6 @@ func TestKongService(t *testing.T) {
 				c.Reason == konnectv1alpha1.KonnectEntityProgrammedReasonKonnectAPIOpFailed
 		}, "KongService should get the Programmed condition set to status=False due to network error on update")
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.ServicesSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.ServicesSDK, waitTime, tickTime)
 	})
 }

--- a/test/envtest/konnect_entities_kongsni_test.go
+++ b/test/envtest/konnect_entities_kongsni_test.go
@@ -58,7 +58,7 @@ func TestKongSNI(t *testing.T) {
 		t.Log("Creating KongCertificate and setting it to Programmed")
 		createdCert := deploy.KongCertificateAttachedToCPWithProgrammed(t, ctx, clientNamespaced, cp, "cert-12345")
 
-		w := setupWatch[configurationv1alpha1.KongSNIList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[configurationv1alpha1.KongSNIList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK for creating SNI")
 		sdk.SNIsSDK.EXPECT().CreateSniWithCertificate(
@@ -82,7 +82,7 @@ func TestKongSNI(t *testing.T) {
 		)
 
 		t.Log("Waiting for SNI to be programmed and get Konnect ID")
-		watchFor(t, ctx, w, apiwatch.Modified, func(s *configurationv1alpha1.KongSNI) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(s *configurationv1alpha1.KongSNI) bool {
 			return s.GetKonnectID() == "sni-12345" && k8sutils.IsProgrammed(s)
 		}, "SNI didn't get Programmed status condition or didn't get the correct (sni-12345) Konnect ID assigned")
 
@@ -101,7 +101,7 @@ func TestKongSNI(t *testing.T) {
 		sniToPatch.Spec.Name = "test2.kong-sni.example.com"
 		require.NoError(t, clientNamespaced.Patch(ctx, sniToPatch, client.MergeFrom(createdSNI)))
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.SNIsSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.SNIsSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK for deleting SNI")
 		sdk.SNIsSDK.EXPECT().DeleteSniWithCertificate(
@@ -124,7 +124,7 @@ func TestKongSNI(t *testing.T) {
 			"KongSNI was not deleted",
 		)
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.SNIsSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.SNIsSDK, waitTime, tickTime)
 	})
 
 	t.Run("Adopting an existing SNI", func(t *testing.T) {
@@ -135,7 +135,7 @@ func TestKongSNI(t *testing.T) {
 		t.Log("Creating KongCertificate and setting it to Programmed")
 		createdCert := deploy.KongCertificateAttachedToCPWithProgrammed(t, ctx, clientNamespaced, cp, certID)
 
-		w := setupWatch[configurationv1alpha1.KongSNIList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[configurationv1alpha1.KongSNIList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations for getting and updating SNIs")
 		sdk.SNIsSDK.EXPECT().GetSniWithCertificate(
@@ -165,7 +165,7 @@ func TestKongSNI(t *testing.T) {
 		)
 
 		t.Logf("Waiting for KongSNI %s to get programmed and set Konnect ID", client.ObjectKeyFromObject(createdSNI))
-		watchFor(t, ctx, w, apiwatch.Modified, func(sni *configurationv1alpha1.KongSNI) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(sni *configurationv1alpha1.KongSNI) bool {
 			return sni.Name == createdSNI.Name &&
 				k8sutils.IsProgrammed(sni) &&
 				sni.GetKonnectID() == sniID

--- a/test/envtest/konnect_entities_kongtarget_test.go
+++ b/test/envtest/konnect_entities_kongtarget_test.go
@@ -66,7 +66,7 @@ func TestKongTarget(t *testing.T) {
 		)
 		updateKongUpstreamStatusWithProgrammed(t, ctx, clientNamespaced, upstream, upstreamID, cp.GetKonnectID())
 
-		w := setupWatch[configurationv1alpha1.KongTargetList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[configurationv1alpha1.KongTargetList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations on Target creation")
 		sdk.TargetsSDK.EXPECT().CreateTargetWithUpstream(
@@ -90,11 +90,11 @@ func TestKongTarget(t *testing.T) {
 		)
 
 		t.Log("Waiting for Target to be programmed and get Konnect ID")
-		watchFor(t, ctx, w, apiwatch.Modified, func(kt *configurationv1alpha1.KongTarget) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(kt *configurationv1alpha1.KongTarget) bool {
 			return kt.GetKonnectID() == targetID && k8sutils.IsProgrammed(kt)
 		}, "KongTarget didn't get Programmed status condition or didn't get the correct (target-12345) Konnect ID assigned")
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.TargetsSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.TargetsSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on Target update")
 		sdk.TargetsSDK.EXPECT().UpsertTargetWithUpstream(
@@ -109,7 +109,7 @@ func TestKongTarget(t *testing.T) {
 		targetToPatch.Spec.Weight = 200
 		require.NoError(t, clientNamespaced.Patch(ctx, targetToPatch, client.MergeFrom(createdTarget)))
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.TargetsSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.TargetsSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on Target deletion")
 		sdk.TargetsSDK.EXPECT().DeleteTargetWithUpstream(
@@ -123,7 +123,7 @@ func TestKongTarget(t *testing.T) {
 		require.NoError(t, clientNamespaced.Delete(ctx, createdTarget))
 		eventually.WaitForObjectToNotExist(t, ctx, cl, createdTarget, waitTime, tickTime)
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.TargetsSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.TargetsSDK, waitTime, tickTime)
 	})
 
 	t.Run("Adopting a target with an upstream", func(t *testing.T) {
@@ -138,7 +138,7 @@ func TestKongTarget(t *testing.T) {
 		)
 		updateKongUpstreamStatusWithProgrammed(t, ctx, clientNamespaced, upstream, upstreamID, cp.GetKonnectID())
 
-		w := setupWatch[configurationv1alpha1.KongTargetList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[configurationv1alpha1.KongTargetList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations for getting and updating targets")
 		sdk.TargetsSDK.EXPECT().GetTargetWithUpstream(
@@ -166,7 +166,7 @@ func TestKongTarget(t *testing.T) {
 		)
 
 		t.Logf("Waiting for KongTarget %s/%s to set Konnect ID and programmed condition", ns.Name, createdTarget.Name)
-		watchFor(t, ctx, w, apiwatch.Modified, func(kt *configurationv1alpha1.KongTarget) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(kt *configurationv1alpha1.KongTarget) bool {
 			return createdTarget.Name == kt.Name &&
 				kt.GetKonnectID() == targetID && k8sutils.IsProgrammed(kt)
 		},
@@ -185,6 +185,6 @@ func TestKongTarget(t *testing.T) {
 		require.NoError(t, clientNamespaced.Delete(ctx, createdTarget))
 		eventually.WaitForObjectToNotExist(t, ctx, cl, createdTarget, waitTime, tickTime)
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.TargetsSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.TargetsSDK, waitTime, tickTime)
 	})
 }

--- a/test/envtest/konnect_entities_kongupstream_test.go
+++ b/test/envtest/konnect_entities_kongupstream_test.go
@@ -53,7 +53,7 @@ func TestKongUpstream(t *testing.T) {
 	apiAuth := deploy.KonnectAPIAuthConfigurationWithProgrammed(t, ctx, clientNamespaced)
 	cp := deploy.KonnectGatewayControlPlaneWithID(t, ctx, clientNamespaced, apiAuth)
 
-	w := setupWatch[configurationv1alpha1.KongUpstreamList](t, ctx, cl, client.InNamespace(ns.Name))
+	w := SetupWatch[configurationv1alpha1.KongUpstreamList](t, ctx, cl, client.InNamespace(ns.Name))
 
 	t.Run("adding, patching and deleting KongUpstream", func(t *testing.T) {
 		const upstreamID = "upstream-12345"
@@ -86,11 +86,11 @@ func TestKongUpstream(t *testing.T) {
 		)
 
 		t.Log("Waiting for Upstream to be programmed and get Konnect ID")
-		watchFor(t, ctx, w, apiwatch.Modified, func(r *configurationv1alpha1.KongUpstream) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(r *configurationv1alpha1.KongUpstream) bool {
 			return r.GetKonnectID() == upstreamID && k8sutils.IsProgrammed(r)
 		}, "KongUpstream didn't get Programmed status condition or didn't get the correct (upstream-12345) Konnect ID assigned")
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.UpstreamsSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.UpstreamsSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on Upstream update")
 		sdk.UpstreamsSDK.EXPECT().
@@ -110,7 +110,7 @@ func TestKongUpstream(t *testing.T) {
 		upstreamToPatch.Spec.HashFallbackHeader = new("X-Hash-Header")
 		require.NoError(t, clientNamespaced.Patch(ctx, upstreamToPatch, client.MergeFrom(createdUpstream)))
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.UpstreamsSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.UpstreamsSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on Upstream deletion")
 		sdk.UpstreamsSDK.EXPECT().
@@ -125,7 +125,7 @@ func TestKongUpstream(t *testing.T) {
 		require.NoError(t, clientNamespaced.Delete(ctx, createdUpstream))
 		eventually.WaitForObjectToNotExist(t, ctx, cl, createdUpstream, waitTime, tickTime)
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.UpstreamsSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.UpstreamsSDK, waitTime, tickTime)
 	})
 
 	t.Run("removing referenced CP sets the status conditions properly", func(t *testing.T) {
@@ -137,7 +137,7 @@ func TestKongUpstream(t *testing.T) {
 		apiAuth := deploy.KonnectAPIAuthConfigurationWithProgrammed(t, ctx, clientNamespaced)
 		cp := deploy.KonnectGatewayControlPlaneWithID(t, ctx, clientNamespaced, apiAuth)
 
-		w := setupWatch[configurationv1alpha1.KongUpstreamList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[configurationv1alpha1.KongUpstreamList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations on Upstream creation")
 		sdk.UpstreamsSDK.EXPECT().
@@ -165,18 +165,18 @@ func TestKongUpstream(t *testing.T) {
 				s.Spec.Tags = append(s.Spec.Tags, "test-1")
 			},
 		)
-		eventuallyAssertSDKExpectations(t, factory.SDK.UpstreamsSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.UpstreamsSDK, waitTime, tickTime)
 
 		t.Log("Waiting for object to be programmed and get Konnect ID")
-		watchFor(t, ctx, w, apiwatch.Modified, conditionProgrammedIsSetToTrueAndCPRefIsKonnectNamespacedRef(created, id),
+		WatchFor(t, ctx, w, apiwatch.Modified, ConditionProgrammedIsSetToTrueAndCPRefIsKonnectNamespacedRef(created, id),
 			fmt.Sprintf("KongUpstream didn't get Programmed status condition or didn't get the correct %s Konnect ID assigned", id))
 
 		t.Log("Deleting KonnectGatewayControlPlane")
 		require.NoError(t, clientNamespaced.Delete(ctx, cp))
 
 		t.Log("Waiting for Service to be get Programmed and ControlPlaneRefValid conditions with status=False")
-		watchFor(t, ctx, w, apiwatch.Modified,
-			conditionsAreSetWhenReferencedControlPlaneIsMissing(created),
+		WatchFor(t, ctx, w, apiwatch.Modified,
+			ConditionsAreSetWhenReferencedControlPlaneIsMissing(created),
 			"KongUpstream didn't get Programmed and/or ControlPlaneRefValid status condition set to False")
 	})
 
@@ -184,7 +184,7 @@ func TestKongUpstream(t *testing.T) {
 		upstreamID := uuid.NewString()
 		upstreamName := uuid.NewString()[:8] + ".example.test"
 
-		w := setupWatch[configurationv1alpha1.KongUpstreamList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[configurationv1alpha1.KongUpstreamList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations for getting and updating upstreams")
 		sdk.UpstreamsSDK.EXPECT().GetUpstream(
@@ -212,7 +212,7 @@ func TestKongUpstream(t *testing.T) {
 		)
 
 		t.Logf("Waiting for KongUpstream %s/%s to set Konnect ID and programmed condition", ns.Name, createdUpstream.Name)
-		watchFor(t, ctx, w, apiwatch.Modified, func(u *configurationv1alpha1.KongUpstream) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(u *configurationv1alpha1.KongUpstream) bool {
 			return createdUpstream.Name == u.Name &&
 				u.GetKonnectID() == upstreamID && k8sutils.IsProgrammed(u)
 		},
@@ -226,7 +226,7 @@ func TestKongUpstream(t *testing.T) {
 		require.NoError(t, clientNamespaced.Delete(ctx, createdUpstream))
 		eventually.WaitForObjectToNotExist(t, ctx, cl, createdUpstream, waitTime, tickTime)
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.UpstreamsSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.UpstreamsSDK, waitTime, tickTime)
 
 	})
 }

--- a/test/envtest/konnect_entities_kongvault_test.go
+++ b/test/envtest/konnect_entities_kongvault_test.go
@@ -78,7 +78,7 @@ func TestKongVault(t *testing.T) {
 		}),
 	)
 
-	vaultWatch := setupWatch[configurationv1alpha1.KongVaultList](t, ctx, cl)
+	vaultWatch := SetupWatch[configurationv1alpha1.KongVaultList](t, ctx, cl)
 
 	t.Run("Cross namespace ref KongVault -> KonnectNamespacedRefControlPlane yields ResolvedRefs=False without KongReferenceGrant", func(t *testing.T) {
 		const (
@@ -90,7 +90,7 @@ func TestKongVault(t *testing.T) {
 		createdVault := deploy.KongVaultAttachedToCP(t, ctx, cl, vaultBackend, vaultPrefix, []byte(vaultRawConfig), cp2)
 
 		t.Log("Waiting for KongVault to get ResolvedRefs condition with status=False")
-		watchFor(t, ctx, vaultWatch, apiwatch.Modified, func(kv *configurationv1alpha1.KongVault) bool {
+		WatchFor(t, ctx, vaultWatch, apiwatch.Modified, func(kv *configurationv1alpha1.KongVault) bool {
 			if kv.GetName() != createdVault.GetName() {
 				return false
 			}
@@ -136,11 +136,11 @@ func TestKongVault(t *testing.T) {
 		vault := deploy.KongVaultAttachedToCP(t, ctx, cl, vaultBackend, vaultPrefix, []byte(vaultRawConfig), cp)
 
 		t.Log("Waiting for KongVault to be programmed")
-		watchFor(t, ctx, vaultWatch, apiwatch.Modified, func(v *configurationv1alpha1.KongVault) bool {
+		WatchFor(t, ctx, vaultWatch, apiwatch.Modified, func(v *configurationv1alpha1.KongVault) bool {
 			return v.GetKonnectID() == vaultID && k8sutils.IsProgrammed(v)
 		}, "KongVault didn't get Programmed status condition or didn't get the correct (vault-12345) Konnect ID assigned")
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.VaultSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.VaultSDK, waitTime, tickTime)
 
 		t.Log("Setting up mock SDK for vault update")
 		sdk.VaultSDK.EXPECT().UpsertVault(mock.Anything, mock.MatchedBy(func(r sdkkonnectops.UpsertVaultRequest) bool {
@@ -154,7 +154,7 @@ func TestKongVault(t *testing.T) {
 		vaultToPatch.Spec.Description = vaultDespription
 		require.NoError(t, clientNamespaced.Patch(ctx, vaultToPatch, client.MergeFrom(vault)))
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.VaultSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.VaultSDK, waitTime, tickTime)
 
 		t.Log("Setting up mock SDK for vault deletion")
 		sdk.VaultSDK.EXPECT().DeleteVault(mock.Anything, cp.GetKonnectStatus().GetKonnectID(), vaultID).
@@ -163,7 +163,7 @@ func TestKongVault(t *testing.T) {
 		t.Log("Deleting KongVault")
 		require.NoError(t, cl.Delete(ctx, vault))
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.VaultSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.VaultSDK, waitTime, tickTime)
 	})
 
 	t.Run("should correctly handle conflict on create", func(t *testing.T) {
@@ -214,7 +214,7 @@ func TestKongVault(t *testing.T) {
 		vault := deploy.KongVaultAttachedToCP(t, ctx, cl, vaultBackend, vaultPrefix, []byte(vaultRawConfig), cp)
 
 		t.Log("Waiting for KongVault to be programmed")
-		watchFor(t, ctx, vaultWatch, apiwatch.Modified, func(v *configurationv1alpha1.KongVault) bool {
+		WatchFor(t, ctx, vaultWatch, apiwatch.Modified, func(v *configurationv1alpha1.KongVault) bool {
 			if v.GetName() != vault.GetName() {
 				return false
 			}
@@ -225,7 +225,7 @@ func TestKongVault(t *testing.T) {
 			})
 		}, "KongVault's Programmed condition should be true eventually")
 
-		eventuallyAssertSDKExpectations(t, factory.SDK.VaultSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.VaultSDK, waitTime, tickTime)
 	})
 
 	t.Run("Adopting existing vault", func(t *testing.T) {
@@ -265,7 +265,7 @@ func TestKongVault(t *testing.T) {
 		)
 
 		t.Logf("Watching for vault %s to be programmed and set Konnect ID", createdVault.Name)
-		watchFor(t, ctx, vaultWatch, apiwatch.Modified, func(kv *configurationv1alpha1.KongVault) bool {
+		WatchFor(t, ctx, vaultWatch, apiwatch.Modified, func(kv *configurationv1alpha1.KongVault) bool {
 			return kv.Name == createdVault.Name &&
 				k8sutils.IsProgrammed(kv) &&
 				kv.GetKonnectID() == vaultID

--- a/test/envtest/konnect_entities_konnectapiauthconfiguration_referencegrant_test.go
+++ b/test/envtest/konnect_entities_konnectapiauthconfiguration_referencegrant_test.go
@@ -77,7 +77,7 @@ func TestKonnectAPIAuthConfigurationReferenceGrant(t *testing.T) {
 		},
 	)
 
-	w := setupWatch[konnectv1alpha1.KonnectAPIAuthConfigurationList](t, ctx, cl, client.InNamespace(ns.Name))
+	w := SetupWatch[konnectv1alpha1.KonnectAPIAuthConfigurationList](t, ctx, cl, client.InNamespace(ns.Name))
 
 	t.Log("Creating a KonnectAPIAuthConfiguration referencing the Secret cross-namespace (no grant yet)")
 	apiAuth := &konnectv1alpha1.KonnectAPIAuthConfiguration{
@@ -97,7 +97,7 @@ func TestKonnectAPIAuthConfigurationReferenceGrant(t *testing.T) {
 	require.NoError(t, clientNamespaced.Create(ctx, apiAuth))
 
 	t.Log("Waiting for KonnectAPIAuthConfiguration to have ResolvedRefs=False/RefNotPermitted (no grant)")
-	watchFor(t, ctx, w, apiwatch.Modified, func(a *konnectv1alpha1.KonnectAPIAuthConfiguration) bool {
+	WatchFor(t, ctx, w, apiwatch.Modified, func(a *konnectv1alpha1.KonnectAPIAuthConfiguration) bool {
 		if a.GetName() != apiAuth.GetName() {
 			return false
 		}
@@ -126,7 +126,7 @@ func TestKonnectAPIAuthConfigurationReferenceGrant(t *testing.T) {
 	)
 
 	t.Log("Waiting for KonnectAPIAuthConfiguration to become ResolvedRefs=True and APIAuthValid=True after the grant")
-	watchFor(t, ctx, w, apiwatch.Modified, func(a *konnectv1alpha1.KonnectAPIAuthConfiguration) bool {
+	WatchFor(t, ctx, w, apiwatch.Modified, func(a *konnectv1alpha1.KonnectAPIAuthConfiguration) bool {
 		if a.GetName() != apiAuth.GetName() {
 			return false
 		}

--- a/test/envtest/konnect_entities_konnectapiauthconfiguration_test.go
+++ b/test/envtest/konnect_entities_konnectapiauthconfiguration_test.go
@@ -62,12 +62,12 @@ func TestKonnectAPIAuthConfiguration(t *testing.T) {
 				nil,
 			)
 
-		w := setupWatch[konnectv1alpha1.KonnectAPIAuthConfigurationList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[konnectv1alpha1.KonnectAPIAuthConfigurationList](t, ctx, cl, client.InNamespace(ns.Name))
 		apiAuth := deploy.KonnectAPIAuthConfiguration(t, ctx, clientNamespaced)
 		t.Cleanup(func() { assert.NoError(t, cl.Delete(ctx, apiAuth)) })
 
 		t.Log("Waiting for KonnectAPIAuthConfiguration to be APIAuthValid=true")
-		watchFor(t, ctx, w, apiwatch.Modified, func(r *konnectv1alpha1.KonnectAPIAuthConfiguration) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(r *konnectv1alpha1.KonnectAPIAuthConfiguration) bool {
 			return client.ObjectKeyFromObject(r) == client.ObjectKeyFromObject(apiAuth) &&
 				r.Status.OrganizationID == "12345" &&
 				k8sutils.HasConditionTrue("APIAuthValid", r)
@@ -85,12 +85,12 @@ func TestKonnectAPIAuthConfiguration(t *testing.T) {
 				},
 			)
 
-		w := setupWatch[konnectv1alpha1.KonnectAPIAuthConfigurationList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[konnectv1alpha1.KonnectAPIAuthConfigurationList](t, ctx, cl, client.InNamespace(ns.Name))
 		apiAuth := deploy.KonnectAPIAuthConfiguration(t, ctx, clientNamespaced)
 		t.Cleanup(func() { assert.NoError(t, cl.Delete(ctx, apiAuth)) })
 
 		t.Log("Waiting for KonnectAPIAuthConfiguration to be APIAuthValid=true")
-		watchFor(t, ctx, w, apiwatch.Modified, func(r *konnectv1alpha1.KonnectAPIAuthConfiguration) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(r *konnectv1alpha1.KonnectAPIAuthConfiguration) bool {
 			return client.ObjectKeyFromObject(r) == client.ObjectKeyFromObject(apiAuth) &&
 				k8sutils.HasConditionFalse("APIAuthValid", r)
 		}, "KonnectAPIAuthConfiguration didn't get APIAuthValid status condition set to false")
@@ -105,12 +105,12 @@ func TestKonnectAPIAuthConfiguration(t *testing.T) {
 				nil,
 			)
 
-		w := setupWatch[konnectv1alpha1.KonnectAPIAuthConfigurationList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[konnectv1alpha1.KonnectAPIAuthConfigurationList](t, ctx, cl, client.InNamespace(ns.Name))
 		apiAuth := deploy.KonnectAPIAuthConfiguration(t, ctx, clientNamespaced)
 		t.Cleanup(func() { assert.NoError(t, cl.Delete(ctx, apiAuth)) })
 
 		t.Log("Waiting for KonnectAPIAuthConfiguration to be APIAuthValid=false")
-		watchFor(t, ctx, w, apiwatch.Modified, func(r *konnectv1alpha1.KonnectAPIAuthConfiguration) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(r *konnectv1alpha1.KonnectAPIAuthConfiguration) bool {
 			return client.ObjectKeyFromObject(r) == client.ObjectKeyFromObject(apiAuth) &&
 				k8sutils.HasConditionFalse("APIAuthValid", r)
 		}, "KonnectAPIAuthConfiguration didn't get APIAuthValid status condition set to false")
@@ -125,12 +125,12 @@ func TestKonnectAPIAuthConfiguration(t *testing.T) {
 				nil,
 			)
 
-		w := setupWatch[konnectv1alpha1.KonnectAPIAuthConfigurationList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[konnectv1alpha1.KonnectAPIAuthConfigurationList](t, ctx, cl, client.InNamespace(ns.Name))
 		apiAuth := deploy.KonnectAPIAuthConfiguration(t, ctx, clientNamespaced)
 		t.Cleanup(func() { assert.NoError(t, cl.Delete(ctx, apiAuth)) })
 
 		t.Log("Waiting for KonnectAPIAuthConfiguration to be APIAuthValid=false")
-		watchFor(t, ctx, w, apiwatch.Modified, func(r *konnectv1alpha1.KonnectAPIAuthConfiguration) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(r *konnectv1alpha1.KonnectAPIAuthConfiguration) bool {
 			return client.ObjectKeyFromObject(r) == client.ObjectKeyFromObject(apiAuth) &&
 				k8sutils.HasConditionFalse("APIAuthValid", r)
 		}, "KonnectAPIAuthConfiguration didn't get APIAuthValid status condition set to false")
@@ -143,12 +143,12 @@ func TestKonnectAPIAuthConfiguration(t *testing.T) {
 				nil,
 			)
 
-		w := setupWatch[konnectv1alpha1.KonnectAPIAuthConfigurationList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[konnectv1alpha1.KonnectAPIAuthConfigurationList](t, ctx, cl, client.InNamespace(ns.Name))
 		apiAuth := deploy.KonnectAPIAuthConfiguration(t, ctx, clientNamespaced)
 		t.Cleanup(func() { assert.NoError(t, cl.Delete(ctx, apiAuth)) })
 
 		t.Log("Waiting for KonnectAPIAuthConfiguration to be APIAuthValid=false")
-		watchFor(t, ctx, w, apiwatch.Modified, func(r *konnectv1alpha1.KonnectAPIAuthConfiguration) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(r *konnectv1alpha1.KonnectAPIAuthConfiguration) bool {
 			return client.ObjectKeyFromObject(r) == client.ObjectKeyFromObject(apiAuth) &&
 				k8sutils.HasConditionFalse("APIAuthValid", r)
 		}, "KonnectAPIAuthConfiguration didn't get APIAuthValid status condition set to false")
@@ -161,12 +161,12 @@ func TestKonnectAPIAuthConfiguration(t *testing.T) {
 				errors.New("some error"),
 			)
 
-		w := setupWatch[konnectv1alpha1.KonnectAPIAuthConfigurationList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[konnectv1alpha1.KonnectAPIAuthConfigurationList](t, ctx, cl, client.InNamespace(ns.Name))
 		apiAuth := deploy.KonnectAPIAuthConfiguration(t, ctx, clientNamespaced)
 		t.Cleanup(func() { assert.NoError(t, cl.Delete(ctx, apiAuth)) })
 
 		t.Log("Waiting for KonnectAPIAuthConfiguration to be APIAuthValid=false")
-		watchFor(t, ctx, w, apiwatch.Modified, func(r *konnectv1alpha1.KonnectAPIAuthConfiguration) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(r *konnectv1alpha1.KonnectAPIAuthConfiguration) bool {
 			return client.ObjectKeyFromObject(r) == client.ObjectKeyFromObject(apiAuth) &&
 				k8sutils.HasConditionFalse("APIAuthValid", r)
 		}, "KonnectAPIAuthConfiguration didn't get APIAuthValid status condition set to false")

--- a/test/envtest/konnect_entities_konnectcloudgatewaynetwork_test.go
+++ b/test/envtest/konnect_entities_konnectcloudgatewaynetwork_test.go
@@ -52,7 +52,7 @@ func TestKonnectCloudGatewayNetwork(t *testing.T) {
 
 	t.Run("Creating, updating and deleting Konnect cloud gateway network", func(t *testing.T) {
 		t.Log("Setting up a watch for KonnectCloudGatewayNetwork events")
-		w := setupWatch[konnectv1alpha1.KonnectCloudGatewayNetworkList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[konnectv1alpha1.KonnectCloudGatewayNetworkList](t, ctx, cl, client.InNamespace(ns.Name))
 		t.Log("Setting up SDK expectations on creation")
 
 		var (
@@ -101,7 +101,7 @@ func TestKonnectCloudGatewayNetwork(t *testing.T) {
 		})
 
 		t.Log("Waiting for KonnectCloudGatewayNetwork to be Programmed and get a Konnect ID")
-		watchFor(t, ctx, w, apiwatch.Modified, func(n *konnectv1alpha1.KonnectCloudGatewayNetwork) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(n *konnectv1alpha1.KonnectCloudGatewayNetwork) bool {
 			return n.GetKonnectID() == networkID && conditionsContainProgrammed(n.GetConditions(), metav1.ConditionTrue)
 		}, "Did not see KonnectCloudGatewayNetwork get Programmed and Konnect ID set.")
 
@@ -124,12 +124,12 @@ func TestKonnectCloudGatewayNetwork(t *testing.T) {
 		eventually.WaitForObjectToNotExist(t, ctx, cl, network, waitTime, tickTime)
 
 		t.Log("Waiting for object to be deleted in the SDK")
-		eventuallyAssertSDKExpectations(t, factory.SDK.CloudGatewaysSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.CloudGatewaysSDK, waitTime, tickTime)
 	})
 
 	t.Run("Creating network when SDK returns ForbiddenError", func(t *testing.T) {
 		t.Log("Setting up a watch for KonnectCloudGatewayNetwork events")
-		w := setupWatch[konnectv1alpha1.KonnectCloudGatewayNetworkList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[konnectv1alpha1.KonnectCloudGatewayNetworkList](t, ctx, cl, client.InNamespace(ns.Name))
 		t.Log("Setting up SDK expectations on creation")
 
 		networkName := "cloud-gateway-network-test-" + uuid.NewString()[:8]
@@ -160,17 +160,17 @@ func TestKonnectCloudGatewayNetwork(t *testing.T) {
 		})
 
 		t.Log("Waiting for KonnectCloudGatewayNetwork to be Programmed and get a Konnect ID")
-		watchFor(t, ctx, w, apiwatch.Modified, func(n *konnectv1alpha1.KonnectCloudGatewayNetwork) bool {
-			return conditionsContainProgrammedFalse(n.GetConditions())
+		WatchFor(t, ctx, w, apiwatch.Modified, func(n *konnectv1alpha1.KonnectCloudGatewayNetwork) bool {
+			return ConditionsContainProgrammedFalse(n.GetConditions())
 		}, "Did not see KonnectCloudGatewayNetwork get Programmed condition set to false.")
 
 		t.Log("Waiting for the expected calls called in SDK")
-		eventuallyAssertSDKExpectations(t, factory.SDK.CloudGatewaysSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.CloudGatewaysSDK, waitTime, tickTime)
 	})
 
 	t.Run("Adopting a network with match mode", func(t *testing.T) {
 		t.Log("Setting up a watch for KonnectCloudGatewayNetwork events")
-		w := setupWatch[konnectv1alpha1.KonnectCloudGatewayNetworkList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[konnectv1alpha1.KonnectCloudGatewayNetworkList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		networkName := "cloud-gateway-network-test-adopt-" + uuid.NewString()[:8]
 		networkID := uuid.NewString()
@@ -220,9 +220,9 @@ func TestKonnectCloudGatewayNetwork(t *testing.T) {
 		})
 
 		t.Log("Waiting for KonnectCloudGatewayNetwork to be marked as programmed and get Konnect ID")
-		watchFor(t, t.Context(), w, apiwatch.Modified, func(n *konnectv1alpha1.KonnectCloudGatewayNetwork) bool {
+		WatchFor(t, t.Context(), w, apiwatch.Modified, func(n *konnectv1alpha1.KonnectCloudGatewayNetwork) bool {
 			return n.Name == createdNetwork.Name &&
-				conditionsContainProgrammedTrue(n.GetConditions()) &&
+				ConditionsContainProgrammedTrue(n.GetConditions()) &&
 				n.GetKonnectID() == networkID
 		},
 			"Did not see KonnectCloudGatewayNetwork turn Programmed and set Konnect ID",
@@ -231,7 +231,7 @@ func TestKonnectCloudGatewayNetwork(t *testing.T) {
 
 	t.Run("Adopting a network with match mode but not matching the network in Konnect", func(t *testing.T) {
 		t.Log("Setting up a watch for KonnectCloudGatewayNetwork events")
-		w := setupWatch[konnectv1alpha1.KonnectCloudGatewayNetworkList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[konnectv1alpha1.KonnectCloudGatewayNetworkList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		networkName := "cloud-gateway-network-test-adopt-" + uuid.NewString()[:8]
 		networkID := uuid.NewString()
@@ -281,9 +281,9 @@ func TestKonnectCloudGatewayNetwork(t *testing.T) {
 		})
 
 		t.Log("Waiting for KonnectCloudGatewayNetwork to be marked as not programmed")
-		watchFor(t, t.Context(), w, apiwatch.Modified, func(n *konnectv1alpha1.KonnectCloudGatewayNetwork) bool {
+		WatchFor(t, t.Context(), w, apiwatch.Modified, func(n *konnectv1alpha1.KonnectCloudGatewayNetwork) bool {
 			return n.Name == createdNetwork.Name &&
-				conditionsContainProgrammedFalse(n.GetConditions()) && lo.ContainsBy(
+				ConditionsContainProgrammedFalse(n.GetConditions()) && lo.ContainsBy(
 				n.GetConditions(), func(c metav1.Condition) bool {
 					return c.Type == konnectv1alpha1.KonnectEntityAdoptedConditionType &&
 						c.Status == metav1.ConditionFalse &&

--- a/test/envtest/konnect_entities_konnectdataplanegroupconfiguration_test.go
+++ b/test/envtest/konnect_entities_konnectdataplanegroupconfiguration_test.go
@@ -77,7 +77,7 @@ func TestKonnectDataPlaneGroupConfiguration(t *testing.T) {
 		)
 
 		t.Log("Setting up a watch for KonnectCloudGatewayDataPlaneGroupConfiguration events")
-		w := setupWatch[konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfigurationList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfigurationList](t, ctx, cl, client.InNamespace(ns.Name))
 		t.Log("Setting up SDK expectations on creation")
 		const expectedCPGeo = sdkkonnectcomp.ControlPlaneGeoUs // US is the default used by the Mock SDK, we expect this to be propagated.
 		sdk.CloudGatewaysSDK.EXPECT().CreateConfiguration(
@@ -117,12 +117,12 @@ func TestKonnectDataPlaneGroupConfiguration(t *testing.T) {
 		)
 
 		t.Log("Waiting for KonnectCloudGatewayDataPlaneGroupConfiguration to be programmed and get Konnect ID")
-		watchFor(t, ctx, w, apiwatch.Modified, func(c *konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfiguration) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(c *konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfiguration) bool {
 			return c.GetKonnectID() == id && k8sutils.IsProgrammed(c)
 		}, "KonnectCloudGatewayDataPlaneGroupConfiguration didn't get Programmed status condition or didn't get the correct Konnect ID assigned")
 
 		t.Log("Checking SDK operations")
-		eventuallyAssertSDKExpectations(t, factory.SDK.CloudGatewaysSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.CloudGatewaysSDK, waitTime, tickTime)
 
 		// NOTE: we delete the data plane group configuration by "creating" (using PUT)
 		// because Cloud Gateways DataPlane Group connfiguration API doesn't support
@@ -147,7 +147,7 @@ func TestKonnectDataPlaneGroupConfiguration(t *testing.T) {
 		eventually.WaitForObjectToNotExist(t, ctx, cl, dpg, waitTime, tickTime)
 
 		t.Log("Waiting for object to be deleted in the SDK")
-		eventuallyAssertSDKExpectations(t, factory.SDK.CloudGatewaysSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.CloudGatewaysSDK, waitTime, tickTime)
 	})
 
 	t.Run("namespacedRef adding and deleting", func(t *testing.T) {
@@ -163,7 +163,7 @@ func TestKonnectDataPlaneGroupConfiguration(t *testing.T) {
 		)
 
 		t.Log("Setting up a watch for KonnectCloudGatewayDataPlaneGroupConfiguration events")
-		w := setupWatch[konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfigurationList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfigurationList](t, ctx, cl, client.InNamespace(ns.Name))
 		t.Log("Setting up SDK expectations on creation")
 		const expectedCPGeo = sdkkonnectcomp.ControlPlaneGeoUs // US is the default used by the Mock SDK, we expect this to be propagated.
 		sdk.CloudGatewaysSDK.EXPECT().CreateConfiguration(
@@ -198,12 +198,12 @@ func TestKonnectDataPlaneGroupConfiguration(t *testing.T) {
 		)
 
 		t.Log("Waiting for KonnectCloudGatewayDataPlaneGroupConfiguration to be programmed and get Konnect ID")
-		watchFor(t, ctx, w, apiwatch.Modified, func(c *konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfiguration) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(c *konnectv1alpha1.KonnectCloudGatewayDataPlaneGroupConfiguration) bool {
 			return c.GetKonnectID() == id && k8sutils.IsProgrammed(c)
 		}, "KonnectCloudGatewayDataPlaneGroupConfiguration didn't get Programmed status condition or didn't get the correct Konnect ID assigned")
 
 		t.Log("Checking SDK operations")
-		eventuallyAssertSDKExpectations(t, factory.SDK.CloudGatewaysSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.CloudGatewaysSDK, waitTime, tickTime)
 
 		// NOTE: we delete the data plane group configuration by "creating" (using PUT)
 		// because Cloud Gateways DataPlane Group connfiguration API doesn't support
@@ -228,6 +228,6 @@ func TestKonnectDataPlaneGroupConfiguration(t *testing.T) {
 		eventually.WaitForObjectToNotExist(t, ctx, cl, dpg, waitTime, tickTime)
 
 		t.Log("Waiting for object to be deleted in the SDK")
-		eventuallyAssertSDKExpectations(t, factory.SDK.CloudGatewaysSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.CloudGatewaysSDK, waitTime, tickTime)
 	})
 }

--- a/test/envtest/konnect_entities_konnecttransitgateway_test.go
+++ b/test/envtest/konnect_entities_konnecttransitgateway_test.go
@@ -57,7 +57,7 @@ func TestKonnectCloudGatewayTransitGateway(t *testing.T) {
 		)
 
 		t.Log("Setting up a watch for KonnectCloudGatewayTransitGateway events")
-		w := setupWatch[konnectv1alpha1.KonnectCloudGatewayTransitGatewayList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[konnectv1alpha1.KonnectCloudGatewayTransitGatewayList](t, ctx, cl, client.InNamespace(ns.Name))
 		t.Log("Setting up SDK expectations on creation")
 		sdk.CloudGatewaysSDK.EXPECT().CreateTransitGateway(
 			mock.Anything,
@@ -121,7 +121,7 @@ func TestKonnectCloudGatewayTransitGateway(t *testing.T) {
 		require.NoError(t, clientNamespaced.Create(ctx, tg))
 
 		t.Log("Waiting for KonnectCloudGatewayTransitGateway to be Programmed and get a Konnect ID")
-		watchFor(t, ctx, w, apiwatch.Modified, func(tg *konnectv1alpha1.KonnectCloudGatewayTransitGateway) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(tg *konnectv1alpha1.KonnectCloudGatewayTransitGateway) bool {
 			return tg.GetKonnectID() == id && conditionsContainProgrammed(tg.GetConditions(), metav1.ConditionTrue)
 		}, "Did not see KonnectCloudGatewayTransitGateway get Programmed and Konnect ID set.")
 
@@ -144,7 +144,7 @@ func TestKonnectCloudGatewayTransitGateway(t *testing.T) {
 		oldTg := tg.DeepCopy()
 		tg.Spec.AWSTransitGateway.AttachmentConfig.RAMShareArn = "ram_share_arn_"
 		require.NoError(t, clientNamespaced.Patch(ctx, tg, client.MergeFrom(oldTg)))
-		watchFor(t, ctx, w, apiwatch.Modified, func(tg *konnectv1alpha1.KonnectCloudGatewayTransitGateway) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(tg *konnectv1alpha1.KonnectCloudGatewayTransitGateway) bool {
 			return tg.GetKonnectID() == id && tg.Status.State == sdkkonnectcomp.TransitGatewayStateReady
 		}, "Did not see KonnectCloudGatewayTransitGateway get status.state updated")
 
@@ -157,7 +157,7 @@ func TestKonnectCloudGatewayTransitGateway(t *testing.T) {
 		eventually.WaitForObjectToNotExist(t, ctx, cl, tg, waitTime, tickTime)
 
 		t.Log("Waiting for object to be deleted in the SDK")
-		eventuallyAssertSDKExpectations(t, factory.SDK.CloudGatewaysSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.CloudGatewaysSDK, waitTime, tickTime)
 	})
 
 	t.Run("Creating a transit gateway with existing name", func(t *testing.T) {
@@ -169,7 +169,7 @@ func TestKonnectCloudGatewayTransitGateway(t *testing.T) {
 		)
 
 		t.Log("Setting up a watch for KonnectCloudGatewayTransitGateway events")
-		w := setupWatch[konnectv1alpha1.KonnectCloudGatewayTransitGatewayList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[konnectv1alpha1.KonnectCloudGatewayTransitGatewayList](t, ctx, cl, client.InNamespace(ns.Name))
 		t.Log("Setting up SDK expectations on creation and listing")
 		sdk.CloudGatewaysSDK.EXPECT().CreateTransitGateway(
 			mock.Anything,
@@ -245,11 +245,11 @@ func TestKonnectCloudGatewayTransitGateway(t *testing.T) {
 		require.NoError(t, clientNamespaced.Create(ctx, tg))
 
 		t.Log("Waiting for KonnectCloudGatewayTransitGateway to be Programmed and get a Konnect ID")
-		watchFor(t, ctx, w, apiwatch.Modified, func(tg *konnectv1alpha1.KonnectCloudGatewayTransitGateway) bool {
+		WatchFor(t, ctx, w, apiwatch.Modified, func(tg *konnectv1alpha1.KonnectCloudGatewayTransitGateway) bool {
 			return tg.GetKonnectID() == id && conditionsContainProgrammed(tg.GetConditions(), metav1.ConditionTrue)
 		}, "Did not see KonnectCloudGatewayTransitGateway get Programmed and Konnect ID set.")
 
 		t.Log("Waiting for object to be deleted in the SDK")
-		eventuallyAssertSDKExpectations(t, factory.SDK.CloudGatewaysSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, factory.SDK.CloudGatewaysSDK, waitTime, tickTime)
 	})
 }

--- a/test/envtest/konnect_entities_portal_test.go
+++ b/test/envtest/konnect_entities_portal_test.go
@@ -59,7 +59,7 @@ func TestPortal(t *testing.T) {
 			initialDescription = "Portal created from envtest"
 		)
 
-		w := setupWatch[konnectv1alpha1.PortalList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[konnectv1alpha1.PortalList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		t.Log("Setting up SDK expectations on Portal creation")
 		sdk.PortalsSDK.EXPECT().
@@ -90,11 +90,11 @@ func TestPortal(t *testing.T) {
 		})
 
 		t.Log("Waiting for Portal to be programmed")
-		watchFor(t, ctx, w, apiwatch.Modified,
-			assertsAnd(
-				objectMatchesName(portal),
-				objectMatchesKonnectID[*konnectv1alpha1.Portal](portalID),
-				objectHasConditionProgrammedSetToTrue[*konnectv1alpha1.Portal](),
+		WatchFor(t, ctx, w, apiwatch.Modified,
+			AssertsAnd(
+				ObjectMatchesName(portal),
+				ObjectMatchesKonnectID[*konnectv1alpha1.Portal](portalID),
+				ObjectHasConditionProgrammedSetToTrue[*konnectv1alpha1.Portal](),
 				func(p *konnectv1alpha1.Portal) bool {
 					return controllerutil.ContainsFinalizer(p, konnect.KonnectCleanupFinalizer)
 				},
@@ -102,7 +102,7 @@ func TestPortal(t *testing.T) {
 			"Portal didn't get Programmed status condition, Konnect ID, or cleanup finalizer",
 		)
 
-		eventuallyAssertSDKExpectations(t, sdk.PortalsSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, sdk.PortalsSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on Portal update")
 		sdk.PortalsSDK.EXPECT().
@@ -120,11 +120,11 @@ func TestPortal(t *testing.T) {
 		require.NoError(t, clientNamespaced.Patch(ctx, portalToPatch, client.MergeFrom(portal)))
 
 		t.Log("Waiting for Portal to be patched")
-		watchFor(t, ctx, w, apiwatch.Modified,
-			assertsAnd(
-				objectMatchesName(portal),
-				objectMatchesKonnectID[*konnectv1alpha1.Portal](portalID),
-				objectHasConditionProgrammedSetToTrue[*konnectv1alpha1.Portal](),
+		WatchFor(t, ctx, w, apiwatch.Modified,
+			AssertsAnd(
+				ObjectMatchesName(portal),
+				ObjectMatchesKonnectID[*konnectv1alpha1.Portal](portalID),
+				ObjectHasConditionProgrammedSetToTrue[*konnectv1alpha1.Portal](),
 				func(p *konnectv1alpha1.Portal) bool {
 					return p.Spec.APISpec.DisplayName == updatedDisplayName
 				},
@@ -132,7 +132,7 @@ func TestPortal(t *testing.T) {
 			"Portal didn't get patched",
 		)
 
-		eventuallyAssertSDKExpectations(t, sdk.PortalsSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, sdk.PortalsSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on Portal deletion")
 		sdk.PortalsSDK.EXPECT().
@@ -142,13 +142,13 @@ func TestPortal(t *testing.T) {
 		t.Log("Deleting Portal")
 		require.NoError(t, clientNamespaced.Delete(ctx, portal))
 		eventually.WaitForObjectToNotExist(t, ctx, clientNamespaced, portal, waitTime, tickTime)
-		eventuallyAssertSDKExpectations(t, sdk.PortalsSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, sdk.PortalsSDK, waitTime, tickTime)
 	})
 
 	t.Run("should create Portal successfully on conflict when Portal with matching uid tag exists", func(t *testing.T) {
 		const portalID = "portal-conflict-id"
 
-		w := setupWatch[konnectv1alpha1.PortalList](t, ctx, cl, client.InNamespace(ns.Name))
+		w := SetupWatch[konnectv1alpha1.PortalList](t, ctx, cl, client.InNamespace(ns.Name))
 
 		// Declared up-front so the ListPortals expectation closure below can
 		// read the Portal's UID after k8s assigns it on Create.
@@ -182,15 +182,15 @@ func TestPortal(t *testing.T) {
 		portal = deploy.Portal(t, ctx, clientNamespaced, apiAuth)
 
 		t.Log("Waiting for Portal to be programmed after UID conflict lookup")
-		watchFor(t, ctx, w, apiwatch.Modified,
-			assertsAnd(
-				objectMatchesName(portal),
-				objectMatchesKonnectID[*konnectv1alpha1.Portal](portalID),
-				objectHasConditionProgrammedSetToTrue[*konnectv1alpha1.Portal](),
+		WatchFor(t, ctx, w, apiwatch.Modified,
+			AssertsAnd(
+				ObjectMatchesName(portal),
+				ObjectMatchesKonnectID[*konnectv1alpha1.Portal](portalID),
+				ObjectHasConditionProgrammedSetToTrue[*konnectv1alpha1.Portal](),
 			),
 			"Portal didn't get Programmed status condition or Konnect ID after conflict resolution",
 		)
 
-		eventuallyAssertSDKExpectations(t, sdk.PortalsSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, sdk.PortalsSDK, waitTime, tickTime)
 	})
 }

--- a/test/envtest/konnect_entities_portalcustomdomain_test.go
+++ b/test/envtest/konnect_entities_portalcustomdomain_test.go
@@ -63,7 +63,7 @@ func TestPortalCustomDomain(t *testing.T) {
 			initialHostname = "developer.example.com"
 		)
 
-		portalWatch := setupWatch[konnectv1alpha1.PortalList](t, ctx, cl, client.InNamespace(ns.Name))
+		portalWatch := SetupWatch[konnectv1alpha1.PortalList](t, ctx, cl, client.InNamespace(ns.Name))
 		sdk.PortalsSDK.EXPECT().
 			CreatePortal(mock.Anything, mock.MatchedBy(func(req sdkkonnectcomp.CreatePortal) bool {
 				return req.DisplayName != nil && *req.DisplayName == displayName &&
@@ -83,17 +83,17 @@ func TestPortalCustomDomain(t *testing.T) {
 		})
 
 		t.Log("Waiting for Portal to be programmed")
-		watchFor(t, ctx, portalWatch, apiwatch.Modified,
-			assertsAnd(
-				objectMatchesName(portal),
-				objectMatchesKonnectID[*konnectv1alpha1.Portal](portalID),
-				objectHasConditionProgrammedSetToTrue[*konnectv1alpha1.Portal](),
+		WatchFor(t, ctx, portalWatch, apiwatch.Modified,
+			AssertsAnd(
+				ObjectMatchesName(portal),
+				ObjectMatchesKonnectID[*konnectv1alpha1.Portal](portalID),
+				ObjectHasConditionProgrammedSetToTrue[*konnectv1alpha1.Portal](),
 			),
 			"Portal didn't get Programmed status condition or Konnect ID",
 		)
-		eventuallyAssertSDKExpectations(t, sdk.PortalsSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, sdk.PortalsSDK, waitTime, tickTime)
 
-		domainWatch := setupWatch[konnectv1alpha1.PortalCustomDomainList](t, ctx, cl, client.InNamespace(ns.Name))
+		domainWatch := SetupWatch[konnectv1alpha1.PortalCustomDomainList](t, ctx, cl, client.InNamespace(ns.Name))
 		domain := testEnvtestPortalCustomDomain(ns.Name, portal.GetName(), "Enabled", initialHostname)
 		expectedCreateRequest, err := domain.Spec.APISpec.ToCreatePortalCustomDomainRequest()
 		require.NoError(t, err)
@@ -110,10 +110,10 @@ func TestPortalCustomDomain(t *testing.T) {
 		require.NoError(t, clientNamespaced.Create(ctx, domain))
 
 		t.Log("Waiting for PortalCustomDomain to be programmed")
-		watchFor(t, ctx, domainWatch, apiwatch.Modified,
-			assertsAnd(
-				objectMatchesName(domain),
-				objectHasConditionProgrammedSetToTrue[*konnectv1alpha1.PortalCustomDomain](),
+		WatchFor(t, ctx, domainWatch, apiwatch.Modified,
+			AssertsAnd(
+				ObjectMatchesName(domain),
+				ObjectHasConditionProgrammedSetToTrue[*konnectv1alpha1.PortalCustomDomain](),
 				func(p *konnectv1alpha1.PortalCustomDomain) bool {
 					return p.GetPortalID() == portalID &&
 						p.GetKonnectID() == "" &&
@@ -122,7 +122,7 @@ func TestPortalCustomDomain(t *testing.T) {
 			),
 			"PortalCustomDomain didn't get Programmed status condition, Portal ID, or cleanup finalizer",
 		)
-		eventuallyAssertSDKExpectations(t, sdk.PortalCustomDomainsSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, sdk.PortalCustomDomainsSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on PortalCustomDomain update")
 		domainToPatch := domain.DeepCopy()
@@ -138,10 +138,10 @@ func TestPortalCustomDomain(t *testing.T) {
 		require.NoError(t, clientNamespaced.Patch(ctx, domainToPatch, client.MergeFrom(domain)))
 
 		t.Log("Waiting for PortalCustomDomain to be patched")
-		watchFor(t, ctx, domainWatch, apiwatch.Modified,
-			assertsAnd(
-				objectMatchesName(domain),
-				objectHasConditionProgrammedSetToTrue[*konnectv1alpha1.PortalCustomDomain](),
+		WatchFor(t, ctx, domainWatch, apiwatch.Modified,
+			AssertsAnd(
+				ObjectMatchesName(domain),
+				ObjectHasConditionProgrammedSetToTrue[*konnectv1alpha1.PortalCustomDomain](),
 				func(p *konnectv1alpha1.PortalCustomDomain) bool {
 					return p.Spec.APISpec.Enabled == "Disabled" &&
 						p.GetPortalID() == portalID &&
@@ -150,7 +150,7 @@ func TestPortalCustomDomain(t *testing.T) {
 			),
 			"PortalCustomDomain didn't get patched",
 		)
-		eventuallyAssertSDKExpectations(t, sdk.PortalCustomDomainsSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, sdk.PortalCustomDomainsSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on PortalCustomDomain deletion")
 		sdk.PortalCustomDomainsSDK.EXPECT().
@@ -160,7 +160,7 @@ func TestPortalCustomDomain(t *testing.T) {
 		t.Log("Deleting PortalCustomDomain")
 		require.NoError(t, clientNamespaced.Delete(ctx, domain))
 		eventually.WaitForObjectToNotExist(t, ctx, clientNamespaced, domain, waitTime, tickTime)
-		eventuallyAssertSDKExpectations(t, sdk.PortalCustomDomainsSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, sdk.PortalCustomDomainsSDK, waitTime, tickTime)
 	})
 }
 

--- a/test/envtest/konnect_entities_portalcustomization_test.go
+++ b/test/envtest/konnect_entities_portalcustomization_test.go
@@ -69,7 +69,7 @@ func TestPortalCustomization(t *testing.T) {
 			updatedRobots = "User-agent: *\nDisallow: /private"
 		)
 
-		portalWatch := setupWatch[konnectv1alpha1.PortalList](t, ctx, cl, client.InNamespace(ns.Name))
+		portalWatch := SetupWatch[konnectv1alpha1.PortalList](t, ctx, cl, client.InNamespace(ns.Name))
 		sdk.PortalsSDK.EXPECT().
 			CreatePortal(mock.Anything, mock.MatchedBy(func(req sdkkonnectcomp.CreatePortal) bool {
 				return req.DisplayName != nil && *req.DisplayName == displayName &&
@@ -89,17 +89,17 @@ func TestPortalCustomization(t *testing.T) {
 		})
 
 		t.Log("Waiting for Portal to be programmed")
-		watchFor(t, ctx, portalWatch, apiwatch.Modified,
-			assertsAnd(
-				objectMatchesName(portal),
-				objectMatchesKonnectID[*konnectv1alpha1.Portal](portalID),
-				objectHasConditionProgrammedSetToTrue[*konnectv1alpha1.Portal](),
+		WatchFor(t, ctx, portalWatch, apiwatch.Modified,
+			AssertsAnd(
+				ObjectMatchesName(portal),
+				ObjectMatchesKonnectID[*konnectv1alpha1.Portal](portalID),
+				ObjectHasConditionProgrammedSetToTrue[*konnectv1alpha1.Portal](),
 			),
 			"Portal didn't get Programmed status condition or Konnect ID",
 		)
-		eventuallyAssertSDKExpectations(t, sdk.PortalsSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, sdk.PortalsSDK, waitTime, tickTime)
 
-		customizationWatch := setupWatch[konnectv1alpha1.PortalCustomizationList](t, ctx, cl, client.InNamespace(ns.Name))
+		customizationWatch := SetupWatch[konnectv1alpha1.PortalCustomizationList](t, ctx, cl, client.InNamespace(ns.Name))
 		customization := testEnvtestPortalCustomization(ns.Name, portal.GetName(), initialCSS, initialLayout, initialRobots)
 		expectedCreateRequest, err := customization.Spec.APISpec.ToCreatePortalCustomization()
 		require.NoError(t, err)
@@ -120,10 +120,10 @@ func TestPortalCustomization(t *testing.T) {
 		require.NoError(t, clientNamespaced.Create(ctx, customization))
 
 		t.Log("Waiting for PortalCustomization to be programmed")
-		watchFor(t, ctx, customizationWatch, apiwatch.Modified,
-			assertsAnd(
-				objectMatchesName(customization),
-				objectHasConditionProgrammedSetToTrue[*konnectv1alpha1.PortalCustomization](),
+		WatchFor(t, ctx, customizationWatch, apiwatch.Modified,
+			AssertsAnd(
+				ObjectMatchesName(customization),
+				ObjectHasConditionProgrammedSetToTrue[*konnectv1alpha1.PortalCustomization](),
 				func(p *konnectv1alpha1.PortalCustomization) bool {
 					return p.GetPortalID() == portalID &&
 						p.GetKonnectID() == "" &&
@@ -135,7 +135,7 @@ func TestPortalCustomization(t *testing.T) {
 			),
 			"PortalCustomization didn't get Programmed status condition, Portal ID, or cleanup finalizer",
 		)
-		eventuallyAssertSDKExpectations(t, sdk.PortalCustomizationSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, sdk.PortalCustomizationSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on PortalCustomization update")
 		customizationToPatch := customization.DeepCopy()
@@ -159,10 +159,10 @@ func TestPortalCustomization(t *testing.T) {
 		require.NoError(t, clientNamespaced.Patch(ctx, customizationToPatch, client.MergeFrom(customization)))
 
 		t.Log("Waiting for PortalCustomization to be patched")
-		watchFor(t, ctx, customizationWatch, apiwatch.Modified,
-			assertsAnd(
-				objectMatchesName(customization),
-				objectHasConditionProgrammedSetToTrue[*konnectv1alpha1.PortalCustomization](),
+		WatchFor(t, ctx, customizationWatch, apiwatch.Modified,
+			AssertsAnd(
+				ObjectMatchesName(customization),
+				ObjectHasConditionProgrammedSetToTrue[*konnectv1alpha1.PortalCustomization](),
 				func(p *konnectv1alpha1.PortalCustomization) bool {
 					return p.GetPortalID() == portalID &&
 						p.GetKonnectID() == "" &&
@@ -173,7 +173,7 @@ func TestPortalCustomization(t *testing.T) {
 			),
 			"PortalCustomization didn't get patched",
 		)
-		eventuallyAssertSDKExpectations(t, sdk.PortalCustomizationSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, sdk.PortalCustomizationSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on PortalCustomization deletion")
 		sdk.PortalCustomizationSDK.EXPECT().
@@ -189,7 +189,7 @@ func TestPortalCustomization(t *testing.T) {
 		t.Log("Deleting PortalCustomization")
 		require.NoError(t, clientNamespaced.Delete(ctx, customization))
 		eventually.WaitForObjectToNotExist(t, ctx, clientNamespaced, customization, waitTime, tickTime)
-		eventuallyAssertSDKExpectations(t, sdk.PortalCustomizationSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, sdk.PortalCustomizationSDK, waitTime, tickTime)
 	})
 }
 

--- a/test/envtest/konnect_entities_portalemailconfig_test.go
+++ b/test/envtest/konnect_entities_portalemailconfig_test.go
@@ -69,7 +69,7 @@ func TestPortalEmailConfig(t *testing.T) {
 			initialReplyToMail = "support@example.com"
 		)
 
-		portalWatch := setupWatch[konnectv1alpha1.PortalList](t, ctx, cl, client.InNamespace(ns.Name))
+		portalWatch := SetupWatch[konnectv1alpha1.PortalList](t, ctx, cl, client.InNamespace(ns.Name))
 		sdk.PortalsSDK.EXPECT().
 			CreatePortal(mock.Anything, mock.MatchedBy(func(req sdkkonnectcomp.CreatePortal) bool {
 				return req.DisplayName != nil && *req.DisplayName == displayName &&
@@ -89,17 +89,17 @@ func TestPortalEmailConfig(t *testing.T) {
 		})
 
 		t.Log("Waiting for Portal to be programmed")
-		watchFor(t, ctx, portalWatch, apiwatch.Modified,
-			assertsAnd(
-				objectMatchesName(portal),
-				objectMatchesKonnectID[*konnectv1alpha1.Portal](portalID),
-				objectHasConditionProgrammedSetToTrue[*konnectv1alpha1.Portal](),
+		WatchFor(t, ctx, portalWatch, apiwatch.Modified,
+			AssertsAnd(
+				ObjectMatchesName(portal),
+				ObjectMatchesKonnectID[*konnectv1alpha1.Portal](portalID),
+				ObjectHasConditionProgrammedSetToTrue[*konnectv1alpha1.Portal](),
 			),
 			"Portal didn't get Programmed status condition or Konnect ID",
 		)
-		eventuallyAssertSDKExpectations(t, sdk.PortalsSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, sdk.PortalsSDK, waitTime, tickTime)
 
-		emailConfigWatch := setupWatch[konnectv1alpha1.PortalEmailConfigList](t, ctx, cl, client.InNamespace(ns.Name))
+		emailConfigWatch := SetupWatch[konnectv1alpha1.PortalEmailConfigList](t, ctx, cl, client.InNamespace(ns.Name))
 		emailConfig := testEnvtestPortalEmailConfig(
 			ns.Name,
 			portal.GetName(),
@@ -123,11 +123,11 @@ func TestPortalEmailConfig(t *testing.T) {
 		require.NoError(t, clientNamespaced.Create(ctx, emailConfig))
 
 		t.Log("Waiting for PortalEmailConfig to be programmed")
-		watchFor(t, ctx, emailConfigWatch, apiwatch.Modified,
-			assertsAnd(
-				objectMatchesName(emailConfig),
-				objectMatchesKonnectID[*konnectv1alpha1.PortalEmailConfig](emailConfigID),
-				objectHasConditionProgrammedSetToTrue[*konnectv1alpha1.PortalEmailConfig](),
+		WatchFor(t, ctx, emailConfigWatch, apiwatch.Modified,
+			AssertsAnd(
+				ObjectMatchesName(emailConfig),
+				ObjectMatchesKonnectID[*konnectv1alpha1.PortalEmailConfig](emailConfigID),
+				ObjectHasConditionProgrammedSetToTrue[*konnectv1alpha1.PortalEmailConfig](),
 				func(p *konnectv1alpha1.PortalEmailConfig) bool {
 					return p.GetPortalID() == portalID &&
 						controllerutil.ContainsFinalizer(p, konnect.KonnectCleanupFinalizer)
@@ -135,7 +135,7 @@ func TestPortalEmailConfig(t *testing.T) {
 			),
 			"PortalEmailConfig didn't get Programmed status condition, Portal ID, Konnect ID, or cleanup finalizer",
 		)
-		eventuallyAssertSDKExpectations(t, sdk.PortalEmailsSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, sdk.PortalEmailsSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on PortalEmailConfig update")
 		emailConfigToPatch := emailConfig.DeepCopy()
@@ -152,11 +152,11 @@ func TestPortalEmailConfig(t *testing.T) {
 		require.NoError(t, clientNamespaced.Patch(ctx, emailConfigToPatch, client.MergeFrom(emailConfig)))
 
 		t.Log("Waiting for PortalEmailConfig to be patched")
-		watchFor(t, ctx, emailConfigWatch, apiwatch.Modified,
-			assertsAnd(
-				objectMatchesName(emailConfig),
-				objectMatchesKonnectID[*konnectv1alpha1.PortalEmailConfig](emailConfigID),
-				objectHasConditionProgrammedSetToTrue[*konnectv1alpha1.PortalEmailConfig](),
+		WatchFor(t, ctx, emailConfigWatch, apiwatch.Modified,
+			AssertsAnd(
+				ObjectMatchesName(emailConfig),
+				ObjectMatchesKonnectID[*konnectv1alpha1.PortalEmailConfig](emailConfigID),
+				ObjectHasConditionProgrammedSetToTrue[*konnectv1alpha1.PortalEmailConfig](),
 				func(p *konnectv1alpha1.PortalEmailConfig) bool {
 					return p.Spec.APISpec.DomainName != nil && *p.Spec.APISpec.DomainName == updatedDomainName &&
 						p.Spec.APISpec.FromEmail != nil && *p.Spec.APISpec.FromEmail == updatedFromEmail
@@ -164,7 +164,7 @@ func TestPortalEmailConfig(t *testing.T) {
 			),
 			"PortalEmailConfig didn't get patched",
 		)
-		eventuallyAssertSDKExpectations(t, sdk.PortalEmailsSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, sdk.PortalEmailsSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on PortalEmailConfig deletion")
 		sdk.PortalEmailsSDK.EXPECT().
@@ -174,7 +174,7 @@ func TestPortalEmailConfig(t *testing.T) {
 		t.Log("Deleting PortalEmailConfig")
 		require.NoError(t, clientNamespaced.Delete(ctx, emailConfig))
 		eventually.WaitForObjectToNotExist(t, ctx, clientNamespaced, emailConfig, waitTime, tickTime)
-		eventuallyAssertSDKExpectations(t, sdk.PortalEmailsSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, sdk.PortalEmailsSDK, waitTime, tickTime)
 	})
 }
 

--- a/test/envtest/konnect_entities_portalpage_test.go
+++ b/test/envtest/konnect_entities_portalpage_test.go
@@ -69,7 +69,7 @@ func TestPortalPage(t *testing.T) {
 			displayName  = "Developer Portal"
 		)
 
-		portalWatch := setupWatch[konnectv1alpha1.PortalList](t, ctx, cl, client.InNamespace(ns.Name))
+		portalWatch := SetupWatch[konnectv1alpha1.PortalList](t, ctx, cl, client.InNamespace(ns.Name))
 		sdk.PortalsSDK.EXPECT().
 			CreatePortal(mock.Anything, mock.MatchedBy(func(req sdkkonnectcomp.CreatePortal) bool {
 				return req.DisplayName != nil && *req.DisplayName == displayName &&
@@ -89,17 +89,17 @@ func TestPortalPage(t *testing.T) {
 		})
 
 		t.Log("Waiting for Portal to be programmed")
-		watchFor(t, ctx, portalWatch, apiwatch.Modified,
-			assertsAnd(
-				objectMatchesName(portal),
-				objectMatchesKonnectID[*konnectv1alpha1.Portal](portalID),
-				objectHasConditionProgrammedSetToTrue[*konnectv1alpha1.Portal](),
+		WatchFor(t, ctx, portalWatch, apiwatch.Modified,
+			AssertsAnd(
+				ObjectMatchesName(portal),
+				ObjectMatchesKonnectID[*konnectv1alpha1.Portal](portalID),
+				ObjectHasConditionProgrammedSetToTrue[*konnectv1alpha1.Portal](),
 			),
 			"Portal didn't get Programmed status condition or Konnect ID",
 		)
-		eventuallyAssertSDKExpectations(t, sdk.PortalsSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, sdk.PortalsSDK, waitTime, tickTime)
 
-		pageWatch := setupWatch[konnectv1alpha1.PortalPageList](t, ctx, cl, client.InNamespace(ns.Name))
+		pageWatch := SetupWatch[konnectv1alpha1.PortalPageList](t, ctx, cl, client.InNamespace(ns.Name))
 		page := testEnvtestPortalPage(ns.Name, portal.GetName(), initialTitle, initialSlug, initialBody, description)
 		expectedCreateRequest, err := page.Spec.APISpec.ToCreatePortalPageRequest()
 		require.NoError(t, err)
@@ -116,11 +116,11 @@ func TestPortalPage(t *testing.T) {
 		require.NoError(t, clientNamespaced.Create(ctx, page))
 
 		t.Log("Waiting for PortalPage to be programmed")
-		watchFor(t, ctx, pageWatch, apiwatch.Modified,
-			assertsAnd(
-				objectMatchesName(page),
-				objectMatchesKonnectID[*konnectv1alpha1.PortalPage](pageID),
-				objectHasConditionProgrammedSetToTrue[*konnectv1alpha1.PortalPage](),
+		WatchFor(t, ctx, pageWatch, apiwatch.Modified,
+			AssertsAnd(
+				ObjectMatchesName(page),
+				ObjectMatchesKonnectID[*konnectv1alpha1.PortalPage](pageID),
+				ObjectHasConditionProgrammedSetToTrue[*konnectv1alpha1.PortalPage](),
 				func(p *konnectv1alpha1.PortalPage) bool {
 					return p.GetPortalID() == portalID &&
 						controllerutil.ContainsFinalizer(p, konnect.KonnectCleanupFinalizer)
@@ -128,7 +128,7 @@ func TestPortalPage(t *testing.T) {
 			),
 			"PortalPage didn't get Programmed status condition, Portal ID, Konnect ID, or cleanup finalizer",
 		)
-		eventuallyAssertSDKExpectations(t, sdk.PortalPagesSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, sdk.PortalPagesSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on PortalPage update")
 		pageToPatch := page.DeepCopy()
@@ -149,11 +149,11 @@ func TestPortalPage(t *testing.T) {
 		require.NoError(t, clientNamespaced.Patch(ctx, pageToPatch, client.MergeFrom(page)))
 
 		t.Log("Waiting for PortalPage to be patched")
-		watchFor(t, ctx, pageWatch, apiwatch.Modified,
-			assertsAnd(
-				objectMatchesName(page),
-				objectMatchesKonnectID[*konnectv1alpha1.PortalPage](pageID),
-				objectHasConditionProgrammedSetToTrue[*konnectv1alpha1.PortalPage](),
+		WatchFor(t, ctx, pageWatch, apiwatch.Modified,
+			AssertsAnd(
+				ObjectMatchesName(page),
+				ObjectMatchesKonnectID[*konnectv1alpha1.PortalPage](pageID),
+				ObjectHasConditionProgrammedSetToTrue[*konnectv1alpha1.PortalPage](),
 				func(p *konnectv1alpha1.PortalPage) bool {
 					return string(p.Spec.APISpec.Title) == updatedTitle &&
 						string(p.Spec.APISpec.Content) == updatedBody
@@ -161,7 +161,7 @@ func TestPortalPage(t *testing.T) {
 			),
 			"PortalPage didn't get patched",
 		)
-		eventuallyAssertSDKExpectations(t, sdk.PortalPagesSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, sdk.PortalPagesSDK, waitTime, tickTime)
 
 		t.Log("Setting up SDK expectations on PortalPage deletion")
 		sdk.PortalPagesSDK.EXPECT().
@@ -171,7 +171,7 @@ func TestPortalPage(t *testing.T) {
 		t.Log("Deleting PortalPage")
 		require.NoError(t, clientNamespaced.Delete(ctx, page))
 		eventually.WaitForObjectToNotExist(t, ctx, clientNamespaced, page, waitTime, tickTime)
-		eventuallyAssertSDKExpectations(t, sdk.PortalPagesSDK, waitTime, tickTime)
+		EventuallyAssertSDKExpectations(t, sdk.PortalPagesSDK, waitTime, tickTime)
 	})
 }
 

--- a/test/envtest/run.go
+++ b/test/envtest/run.go
@@ -22,11 +22,10 @@ import (
 	managercfg "github.com/kong/kong-operator/v2/ingress-controller/pkg/manager/config"
 	"github.com/kong/kong-operator/v2/ingress-controller/test/health"
 	"github.com/kong/kong-operator/v2/ingress-controller/test/mocks"
+	"github.com/kong/kong-operator/v2/test/envtest/create"
 )
 
 const (
-	// PublishServiceName is the name of the publish service used in Gateway API tests.
-	PublishServiceName = "publish-svc"
 
 	// ManagerStartupWaitTime is the time to wait for the manager to start.
 	ManagerStartupWaitTime = 5 * time.Second
@@ -97,7 +96,7 @@ func WithGatewayToReconcile(gatewayNN string) func(cfg *managercfg.Config) {
 func WithPublishService(namespace string) func(cfg *managercfg.Config) {
 	return func(cfg *managercfg.Config) {
 		cfg.PublishService = mo.Some(k8stypes.NamespacedName{
-			Name:      PublishServiceName,
+			Name:      create.PublishServiceName,
 			Namespace: namespace,
 		})
 	}

--- a/test/envtest/setup.go
+++ b/test/envtest/setup.go
@@ -25,10 +25,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
 	"sigs.k8s.io/controller-runtime/pkg/webhook/conversion"
 
-	"github.com/kong/kong-operator/v2/ingress-controller/test/controllers/gateway"
-	"github.com/kong/kong-operator/v2/ingress-controller/test/gatewayapi"
 	"github.com/kong/kong-operator/v2/ingress-controller/test/store"
-	"github.com/kong/kong-operator/v2/ingress-controller/test/util/builder"
 	testutil "github.com/kong/kong-operator/v2/pkg/utils/test"
 	"github.com/kong/kong-operator/v2/test/helpers/kcfg"
 )
@@ -200,69 +197,6 @@ func deployIngressClass(ctx context.Context, t *testing.T, name string, client c
 		},
 	}
 	require.NoError(t, client.Create(ctx, ingress))
-}
-
-// deployGateway deploys a Gateway, GatewayClass, and ingress service for use in tests.
-func deployGatewayUsingGatewayClass(ctx context.Context, t *testing.T, client client.Client, gwc gatewayapi.GatewayClass) gatewayapi.Gateway {
-	ns := CreateNamespace(ctx, t, client)
-
-	publishSvc := corev1.Service{
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace: ns.Name,
-			Name:      PublishServiceName,
-		},
-		Spec: corev1.ServiceSpec{
-			Ports: builder.NewServicePort().
-				WithName("http").
-				WithProtocol(corev1.ProtocolTCP).
-				WithPort(8000).
-				IntoSlice(),
-		},
-	}
-	require.NoError(t, client.Create(ctx, &publishSvc))
-	t.Cleanup(func() { _ = client.Delete(ctx, &publishSvc) })
-
-	gw := gatewayapi.Gateway{
-		Spec: gatewayapi.GatewaySpec{
-			GatewayClassName: gatewayapi.ObjectName(gwc.Name),
-			Listeners: []gatewayapi.Listener{
-				{
-					Name:          "http",
-					Protocol:      gatewayapi.HTTPProtocolType,
-					Port:          gatewayapi.PortNumber(8000),
-					AllowedRoutes: builder.NewAllowedRoutesFromAllNamespaces(),
-				},
-			},
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			Namespace:    ns.Name,
-			GenerateName: "gw-",
-		},
-	}
-	require.NoError(t, client.Create(ctx, &gw))
-	t.Cleanup(func() { _ = client.Delete(ctx, &gw) })
-
-	return gw
-}
-
-func deployGateway(ctx context.Context, t *testing.T, client client.Client) (gatewayapi.Gateway, gatewayapi.GatewayClass) {
-	gwc := gatewayapi.GatewayClass{
-		Spec: gatewayapi.GatewayClassSpec{
-			ControllerName: gateway.GetControllerName(),
-		},
-		ObjectMeta: metav1.ObjectMeta{
-			GenerateName: "gwc-",
-			Annotations: map[string]string{
-				"konghq.com/gatewayclass-unmanaged": "placeholder",
-			},
-		},
-	}
-	require.NoError(t, client.Create(ctx, &gwc))
-	t.Cleanup(func() { _ = client.Delete(ctx, &gwc) })
-
-	gw := deployGatewayUsingGatewayClass(ctx, t, client, gwc)
-
-	return gw, gwc
 }
 
 // NameFromT returns a name suitable for use in Kubernetes resources for a given test.

--- a/test/envtest/specific_gateway_envtest_test.go
+++ b/test/envtest/specific_gateway_envtest_test.go
@@ -12,6 +12,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	"github.com/kong/kong-operator/v2/ingress-controller/test/gatewayapi"
+	"github.com/kong/kong-operator/v2/test/envtest/create"
 	"github.com/kong/kong-operator/v2/test/helpers/asserts"
 )
 
@@ -30,10 +31,10 @@ func TestSpecificGatewayNN(t *testing.T) {
 	ctrlClient := NewControllerClient(t, scheme, envcfg)
 
 	var (
-		gw, gwc = deployGateway(ctx, t, ctrlClient)
+		gw, gwc = create.Gateway(ctx, t, ctrlClient)
 		nn      = client.ObjectKeyFromObject(&gw)
 		// We use the same GatewayClass here.
-		gwIgnored = deployGatewayUsingGatewayClass(ctx, t, ctrlClient, gwc)
+		gwIgnored = create.GatewayUsingGatewayClass(ctx, t, ctrlClient, gwc)
 		nnIgnored = client.ObjectKeyFromObject(&gwIgnored)
 	)
 
@@ -47,8 +48,8 @@ func TestSpecificGatewayNN(t *testing.T) {
 	)
 
 	const routeCount = 10
-	routes := createHTTPRoutes(ctx, t, ctrlClient, gw, routeCount)
-	ignoredRoutes := createHTTPRoutes(ctx, t, ctrlClient, gwIgnored, routeCount)
+	routes := create.HTTPRoutes(ctx, t, ctrlClient, gw, routeCount)
+	ignoredRoutes := create.HTTPRoutes(ctx, t, ctrlClient, gwIgnored, routeCount)
 
 	t.Run("configured specific gateway gets its listener status filled", func(t *testing.T) {
 		require.Eventually(t, func() bool {

--- a/test/envtest/update/status.go
+++ b/test/envtest/update/status.go
@@ -1,0 +1,50 @@
+package update
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	konnectv1alpha1 "github.com/kong/kong-operator/v2/api/konnect/v1alpha1"
+	konnectv1alpha2 "github.com/kong/kong-operator/v2/api/konnect/v1alpha2"
+	k8sutils "github.com/kong/kong-operator/v2/pkg/utils/kubernetes"
+	"github.com/kong/kong-operator/v2/test/envtest/consts"
+	"github.com/kong/kong-operator/v2/test/mocks/sdkmocks"
+)
+
+func UpdateKonnectEventGatewayStatusWithProgrammed(
+	t *testing.T,
+	ctx context.Context,
+	cl client.Client,
+	obj *konnectv1alpha1.KonnectEventGateway,
+	id string,
+) {
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		if !assert.NoError(ct, cl.Get(ctx, client.ObjectKeyFromObject(obj), obj)) {
+			return
+		}
+		obj.Status.KonnectEntityStatus = konnectv1alpha2.KonnectEntityStatus{
+			ID:        id,
+			ServerURL: sdkmocks.SDKServerURL,
+			OrgID:     "org-id",
+		}
+		obj.Status.Conditions = []metav1.Condition{
+			programmedCondition(obj.GetGeneration()),
+		}
+		assert.NoError(ct, cl.Status().Update(ctx, obj))
+	}, consts.WaitTime, consts.TickTime)
+}
+
+func programmedCondition(generation int64) metav1.Condition {
+	return k8sutils.NewConditionWithGeneration(
+		konnectv1alpha1.KonnectEntityProgrammedConditionType,
+		metav1.ConditionTrue,
+		konnectv1alpha1.KonnectEntityProgrammedReasonProgrammed,
+		"",
+		generation,
+	)
+}

--- a/test/envtest/update_status.go
+++ b/test/envtest/update_status.go
@@ -18,7 +18,7 @@ import (
 	"github.com/kong/kong-operator/v2/test/mocks/sdkmocks"
 )
 
-func updateKongConsumerStatusWithKonnectID(
+func UpdateKongConsumerStatusWithKonnectID(
 	t *testing.T,
 	ctx context.Context,
 	cl client.Client,
@@ -34,7 +34,7 @@ func updateKongConsumerStatusWithKonnectID(
 	require.NoError(t, cl.Status().Update(ctx, obj))
 }
 
-func updateKongConsumerGroupStatusWithKonnectID(
+func UpdateKongConsumerGroupStatusWithKonnectID(
 	t *testing.T,
 	ctx context.Context,
 	cl client.Client,
@@ -50,7 +50,7 @@ func updateKongConsumerGroupStatusWithKonnectID(
 	require.NoError(t, cl.Status().Update(ctx, obj))
 }
 
-func updateKongServiceStatusWithProgrammed(
+func UpdateKongServiceStatusWithProgrammed(
 	t *testing.T,
 	ctx context.Context,
 	cl client.Client,
@@ -69,7 +69,7 @@ func updateKongServiceStatusWithProgrammed(
 	require.NoError(t, cl.Status().Update(ctx, obj))
 }
 
-func updateKongRouteStatusWithProgrammed(
+func UpdateKongRouteStatusWithProgrammed(
 	t *testing.T,
 	ctx context.Context,
 	cl client.Client,

--- a/test/envtest/watch.go
+++ b/test/envtest/watch.go
@@ -30,11 +30,11 @@ func (w watch[T]) WatchI() apiwatch.Interface {
 	return w.w
 }
 
-// setupWatch sets up a watch.Interface for the provided client.ObjectList.
+// SetupWatch sets up a watch.Interface for the provided client.ObjectList.
 // It is useful if an action needs to be performed between setting up the watch
 // and starting to watch for actual events on that watch.
 // It returns the watch.Interface and registers its cleanup using t.Cleanup.
-func setupWatch[
+func SetupWatch[
 	TList interface {
 		GetItems() []T
 	},
@@ -70,9 +70,9 @@ func setupWatch[
 	}
 }
 
-// watchFor watches for an event of type eventType using the provided watch.Interface.
+// WatchFor watches for an event of type eventType using the provided watch.Interface.
 // It is a wrapper of helpers.WatchFor which uses the type safe `watch` and a fixed timeout.
-func watchFor[
+func WatchFor[
 	T client.Object,
 ](
 	t *testing.T,

--- a/test/envtest/watch_test.go
+++ b/test/envtest/watch_test.go
@@ -25,10 +25,10 @@ func TestWatch(t *testing.T) {
 		}
 	)
 
-	wConsumer := setupWatch[configurationv1.KongConsumerList](t, ctx, cl)
+	wConsumer := SetupWatch[configurationv1.KongConsumerList](t, ctx, cl)
 	require.NoError(t, cl.Create(ctx, consumer))
-	watchFor(t, ctx, wConsumer, apiwatch.Added,
-		objectMatchesName(consumer),
+	WatchFor(t, ctx, wConsumer, apiwatch.Added,
+		ObjectMatchesName(consumer),
 		"error",
 	)
 }

--- a/test/helpers/deploy/deploy_resources.go
+++ b/test/helpers/deploy/deploy_resources.go
@@ -1694,6 +1694,7 @@ func Namespace(
 	t *testing.T,
 	ctx context.Context,
 	cl client.Client,
+	opts ...ObjOption,
 ) *corev1.Namespace {
 	t.Helper()
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Split envtest suite into several jobs to cut down the total wall time required for the suite to run.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
