### PR TITLE
chore(ci): extend codeql timeout

### DIFF
--- a/.github/workflows/codeql.yaml
+++ b/.github/workflows/codeql.yaml
@@ -38,7 +38,7 @@ permissions:
 
 jobs:
   analyze:
-    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT || 15) }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_EXTENDED_TIMEOUT_MINUTES || 20) }}
     name: analyze
     runs-on: ubuntu-latest
     permissions:


### PR DESCRIPTION
**What this PR does / why we need it**:

Prevent timeouts like this one:

https://github.com/Kong/kong-operator/actions/runs/29090947684/job/86355853986?pr=4865#step:8:316

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
