### PR TITLE
test(e2e): add aigateway ai-proxy chainsaw e2e (AI GW 1.1)

### DIFF
--- a/.github/workflows/__e2e_chainsaw_tests.yaml
+++ b/.github/workflows/__e2e_chainsaw_tests.yaml
@@ -32,6 +32,7 @@ jobs:
         - gateway
         - hybridgateway
         - konnect
+        - aigateway
         # TODO: fix eventgateway suite and re-enable it in the matrix once they are stable again.
         # TODO: https://github.com/Kong/kong-operator/issues/4757
         # - eventgateway
@@ -82,10 +83,14 @@ jobs:
           --set image.tag=${{ env.TAG }} \
           --set env.enable_controller_konnect=true \
           --set env.enable_controller_kegdataplane=true \
+          --set env.enable_controller_aigatewaydataplane=true \
           --wait
 
     - name: DNS lookup for us.control-plane.konghq.tech
       run: dig us.control-plane.konghq.tech
+
+    - name: Apply chainsaw suite prerequisites
+      run: make test.e2e.chainsaw.prereq DIRNAME=${{ matrix.suite }}
 
     - name: set kong ee version
       run: |

--- a/Makefile
+++ b/Makefile
@@ -838,6 +838,15 @@ test.e2e:
 
 CHAINSAW_TEST_DIR ?= ./test/e2e/chainsaw
 CHAINSAW_CONFIG ?= ./test/e2e/chainsaw/.chainsaw.yaml
+CHAINSAW_FIXTURES_DIR ?= ./test/e2e/chainsaw/fixtures
+
+# DIRNAME is passed to the dispatcher via the environment (never substituted into the
+# recipe), so its value can never be parsed as a shell command.
+.PHONY: test.e2e.chainsaw.prereq
+test.e2e.chainsaw.prereq: export DIRNAME := $(DIRNAME)
+test.e2e.chainsaw.prereq: ## Apply prerequisite fixtures for a chainsaw suite (usage: DIRNAME=<suite>).
+	bash $(CHAINSAW_FIXTURES_DIR)/run-prereq.sh
+
 .PHONY: test.e2e.chainsaw
 test.e2e.chainsaw: chainsaw grpcurl ## Run chainsaw e2e tests.
 	GATEWAY_IMAGE=$(shell $(YQ) -ojson -r '.chainsaw.kong-ee' < $(TEST_DEPENDENCIES_FILE))

--- a/test/e2e/chainsaw/aigateway/README.md
+++ b/test/e2e/chainsaw/aigateway/README.md
@@ -1,0 +1,64 @@
+# AIGateway chainsaw e2e
+
+Reproduces `ai-gateway-test-harness` criteria against the Kong Operator's Konnect AIGateway
+CRDs and `AIGatewayDataPlane`. Each test stands up a Konnect AIGateway control plane, an
+OpenAI-compatible provider + model, and an in-cluster data plane, then drives a real
+chat-completions request and asserts `HTTP 200` + the `X-Kong-LLM-Model` header.
+
+## Mock LLM upstream
+
+The providers point at a shared in-cluster mock (no external egress, no real tokens): an Ollama
+server behind a DB-less Kong proxy that enforces api-key auth. The manifests live in
+[`../fixtures/aigateway`](../fixtures/aigateway) (kept outside this directory so chainsaw does
+not run them as a test) and must be applied before the tests.
+
+The mock provides:
+
+- **Two models** served by Ollama — `qwen2.5:0.5b` and `gemma3:270m` — so multi-model /
+  load-balancing criteria have distinct backends to route across.
+- **Two independent providers** on the Kong proxy, exposed on the same route pattern, each with
+  its own api key isolated by an ACL group (a key only works on its own provider's route):
+
+  | Provider | Route | API key | ACL group |
+  |----------|-------|---------|-----------|
+  | A | `/provider-a` | `test-ai-gateway-key`   | `provider-a` |
+  | B | `/provider-b` | `test-ai-gateway-key-b` | `provider-b` |
+
+  Both routes forward to Ollama's `/v1/chat/completions`; the model is chosen by the request
+  body, so either provider can serve either model.
+
+In CI the fixtures are applied by the `aigateway` matrix job in
+`.github/workflows/__e2e_chainsaw_tests.yaml`.
+
+## Provider credentials
+
+Provider api keys are supplied via a Kubernetes `Secret` referenced with `secretRef` (labelled
+`konghq.com/secret: "true"`), never inline in the `AIGatewayModelProvider`. New tests must follow
+this pattern — create a `Secret` for the credential and reference it from the provider's
+`config.auth.headers[].value.secretRef`.
+
+## Running locally
+
+Requires a cluster with the operator deployed and the `konnect` + `aigatewaydataplane`
+controllers enabled (see the Helm `env.enable_controller_*` values), plus a Konnect token.
+
+```bash
+# 1. Apply the shared mock stack (runs test/e2e/chainsaw/fixtures/aigateway/prereq.sh).
+make test.e2e.chainsaw.prereq DIRNAME=aigateway
+
+# 2. Run the suite.
+KONNECT_TOKEN=<pat> KONNECT_SERVER_URL=<region>.api.konghq.tech \
+  CHAINSAW_TEST_DIR=test/e2e/chainsaw/aigateway \
+  make test.e2e.chainsaw
+
+# 3. Tear down the mock stack when done.
+kubectl delete -f test/e2e/chainsaw/fixtures/aigateway --ignore-not-found
+```
+
+## Notes
+
+- The `AIGatewayDataPlane` image is overridden (binding `aigw_dp_image`, env `AIGW_DP_IMAGE`)
+  to a `kong-ai-gateway-dev` build. The operator default (`kong-ai-gateway:2.0.0`) cannot load
+  the config the `.tech` org emits today.
+- On clusters that pull images slowly (e.g. colima), pre-load the mock and data plane images
+  with `kind load docker-image ... --name <cluster>`.

--- a/test/e2e/chainsaw/aigateway/ai-proxy/02-aigateway-provider-model-assert.yaml
+++ b/test/e2e/chainsaw/aigateway/ai-proxy/02-aigateway-provider-model-assert.yaml
@@ -1,0 +1,19 @@
+apiVersion: konnect.konghq.com/v1alpha1
+kind: AIGatewayModelProvider
+metadata:
+  name: openai-provider
+  namespace: ($namespace)
+status:
+  (conditions[?type == 'Programmed']):
+    - status: 'True'
+  (id != null): true
+---
+apiVersion: konnect.konghq.com/v1alpha1
+kind: AIGatewayModel
+metadata:
+  name: aigw11-model
+  namespace: ($namespace)
+status:
+  (conditions[?type == 'Programmed']):
+    - status: 'True'
+  (id != null): true

--- a/test/e2e/chainsaw/aigateway/ai-proxy/02-aigateway-provider-model.yaml
+++ b/test/e2e/chainsaw/aigateway/ai-proxy/02-aigateway-provider-model.yaml
@@ -1,0 +1,70 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openai-provider-credentials
+  namespace: ($namespace)
+  labels:
+    konghq.com/secret: "true"
+type: Opaque
+stringData:
+  apikey: test-ai-gateway-key
+---
+apiVersion: konnect.konghq.com/v1alpha1
+kind: AIGatewayModelProvider
+metadata:
+  name: openai-provider
+  namespace: ($namespace)
+spec:
+  aiGatewayRef:
+    type: namespacedRef
+    namespacedRef:
+      name: ($aigw_cp_name)
+  apiSpec:
+    type: openai
+    openai:
+      name: openai-provider
+      displayName: OpenAI (mock)
+      config:
+        auth:
+          headers:
+            - name: apikey
+              value:
+                type: secretRef
+                secretRef:
+                  name: openai-provider-credentials
+                  key: apikey
+---
+apiVersion: konnect.konghq.com/v1alpha1
+kind: AIGatewayModel
+metadata:
+  name: aigw11-model
+  namespace: ($namespace)
+spec:
+  aiGatewayRef:
+    type: namespacedRef
+    namespacedRef:
+      name: ($aigw_cp_name)
+  apiSpec:
+    type: model
+    model:
+      name: aigw11-model
+      displayName: AI GW 1.1 mock model
+      enabled: Enabled
+      formats:
+        - type: openai
+      capabilities:
+        - generate
+      config:
+        model:
+          alias: qwen2.5:0.5b
+          nameHeader: Enabled
+        route:
+          paths:
+            - /aigw11/chat
+      targets:
+        - name: qwen2.5:0.5b
+          provider: openai-provider
+          config:
+            type: openai
+            openai:
+              upstreamURL: http://kong-mock.kong-aigateway-mock.svc.cluster.local:8000/provider-a

--- a/test/e2e/chainsaw/aigateway/ai-proxy/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/aigateway/ai-proxy/chainsaw-test.yaml
@@ -1,0 +1,86 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: aigateway-ai-proxy
+spec:
+  description: |
+    AI GW 1.1 — AI Proxy Advanced. Stands up the Konnect AIGateway control plane, an
+    OpenAI-compatible provider + model exposing /aigw11/chat pointed at the shared mock
+    upstream, and an in-cluster AIGatewayDataPlane, then drives a real chat-completions
+    request and asserts a 200 response carrying the X-Kong-LLM-Model header.
+  bindings:
+    - name: test_name
+      value: ($namespace)
+    - name: konnect_token
+      value: (env('KONNECT_TOKEN'))
+    - name: konnect_url
+      value: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
+    - name: auth_secret_name
+      value: (join('-', [($test_name), 'konnect-auth-secret']))
+    - name: auth_secret_namespace
+      value: ($namespace)
+    - name: konnect_auth_name
+      value: (join('-', [($test_name), 'konnect-api-auth']))
+    - name: konnect_auth_namespace
+      value: ($namespace)
+    - name: aigw_cp_name
+      value: (join('-', [($test_name), 'cp']))
+    - name: aigw_cp_namespace
+      value: ($namespace)
+    - name: aigw_dp_name
+      value: (join('-', [($test_name), 'dp']))
+    - name: aigw_dp_image
+      value: (env('AIGW_DP_IMAGE') || 'kong/kong-ai-gateway-dev:2.0.1-rc.1')
+  steps:
+    - name: Create-auth-secret
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAuthSecret.yaml
+    - name: Create-konnect-api-auth
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration-secretref.yaml
+    - name: Create-konnect-aigateway
+      bindings:
+        - name: auth_name
+          value: ($konnect_auth_name)
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAIGateway.yaml
+    - name: Create-provider-and-model
+      try:
+        - apply:
+            file: 02-aigateway-provider-model.yaml
+        - assert:
+            file: 02-aigateway-provider-model-assert.yaml
+    - name: Create-aigateway-dataplane
+      bindings:
+        - name: namespace
+          value: ($namespace)
+      use:
+        template: ../../common/_step_templates/apply-assert-aigatewayDataPlane.yaml
+    - name: Drive-chat-completion-traffic
+      try:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+              - name: DP_SVC
+                value: (join('', [($aigw_dp_name), '-ingress']))
+              - name: ROUTE_PATH
+                value: /aigw11/chat
+              - name: MODEL_ALIAS
+                value: qwen2.5:0.5b
+              - name: EXPECT_HEADER
+                value: X-Kong-LLM-Model
+            content: |
+              bash ../../common/scripts/aigw_chat_completion.sh
+  catch:
+    - description: Capture debug snapshot on test failure.
+      script:
+        env:
+          - name: TEST_NAME
+            value: aigateway-ai-proxy
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: OPERATOR_NAMESPACE
+            value: kong-system
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh

--- a/test/e2e/chainsaw/common/_step_templates/apply-assert-aigatewayDataPlane.yaml
+++ b/test/e2e/chainsaw/common/_step_templates/apply-assert-aigatewayDataPlane.yaml
@@ -1,0 +1,56 @@
+# Template for creating and asserting an AIGatewayDataPlane.
+#
+# The operator auto-provisions the mTLS client Secret and the
+# AIGatewayDataPlaneCertificate; they are NOT created here.
+#
+# Required bindings:
+#   - aigw_dp_name: Name of the AIGatewayDataPlane to create.
+#   - aigw_cp_name: Name of the KonnectAIGateway it attaches to (same namespace).
+#   - namespace: Namespace where the AIGatewayDataPlane will be created.
+#   - aigw_dp_image: AI Gateway data plane container image. Overrides the operator
+#     default (kong/kong-ai-gateway:2.0.0), which is too old to load the config the
+#     .tech Konnect org emits. Must be pre-loaded into the cluster.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: StepTemplate
+metadata:
+  name: apply-assert-aigateway-dataplane
+spec:
+  try:
+    - apply:
+        resource:
+          apiVersion: aigateway.konghq.com/v1alpha1
+          kind: AIGatewayDataPlane
+          metadata:
+            name: ($aigw_dp_name)
+            namespace: ($namespace)
+          spec:
+            controlPlaneRef:
+              type: konnectNamespacedRef
+              konnectNamespacedRef:
+                name: ($aigw_cp_name)
+            deployment:
+              replicas: 1
+              podTemplateSpec:
+                spec:
+                  containers:
+                    - name: aigw
+                      image: ($aigw_dp_image)
+            network:
+              services:
+                ingress:
+                  type: LoadBalancer
+                  ports:
+                    - name: ingress
+                      port: 443
+                      targetPort: 8443
+    - assert:
+        resource:
+          apiVersion: aigateway.konghq.com/v1alpha1
+          kind: AIGatewayDataPlane
+          metadata:
+            name: ($aigw_dp_name)
+            namespace: ($namespace)
+          status:
+            (conditions[?type == 'Ready']):
+              - status: 'True'
+            (readyReplicas > `0`): true

--- a/test/e2e/chainsaw/common/_step_templates/apply-assert-konnectAIGateway.yaml
+++ b/test/e2e/chainsaw/common/_step_templates/apply-assert-konnectAIGateway.yaml
@@ -1,0 +1,39 @@
+# Template for creating and asserting a KonnectAIGateway (AI Gateway control plane).
+#
+# Required bindings:
+#   - aigw_cp_name: Name of the KonnectAIGateway to create.
+#   - aigw_cp_namespace: Namespace where the KonnectAIGateway will be created.
+#   - auth_name: Name of the KonnectAPIAuthConfiguration to reference (same namespace).
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: StepTemplate
+metadata:
+  name: apply-assert-konnect-aigateway
+spec:
+  try:
+    - apply:
+        resource:
+          apiVersion: konnect.konghq.com/v1alpha1
+          kind: KonnectAIGateway
+          metadata:
+            name: ($aigw_cp_name)
+            namespace: ($aigw_cp_namespace)
+          spec:
+            apiSpec:
+              name: ($aigw_cp_name)
+              displayName: ($aigw_cp_name)
+              description: AIGateway chainsaw e2e control plane
+            konnect:
+              authRef:
+                name: ($auth_name)
+    - assert:
+        resource:
+          apiVersion: konnect.konghq.com/v1alpha1
+          kind: KonnectAIGateway
+          metadata:
+            name: ($aigw_cp_name)
+            namespace: ($aigw_cp_namespace)
+          status:
+            (conditions[?type == 'Programmed']):
+              - status: 'True'
+            (id != null): true
+            (endpoints.configuration != null): true

--- a/test/e2e/chainsaw/common/scripts/aigw_chat_completion.sh
+++ b/test/e2e/chainsaw/common/scripts/aigw_chat_completion.sh
@@ -1,0 +1,67 @@
+#!/usr/bin/env bash
+# Drive a chat-completions request through an AIGatewayDataPlane and verify the
+# gateway processed it: HTTP 200 and the model header present.
+#
+# The request is issued from a short-lived curl Pod inside the cluster (the
+# AIGatewayDataPlane ingress is only reachable in-cluster), targeting the ingress
+# Service by DNS. Exits non-zero (failing the chainsaw step) unless a 200 with the
+# expected header is observed within the retry budget.
+#
+# Required env:
+#   NAMESPACE     Namespace the AIGatewayDataPlane / ingress Service live in.
+#   DP_SVC        Ingress Service name (typically <aigw-dp-name>-ingress).
+#   ROUTE_PATH    Route path configured on the model (e.g. /aigw11/chat).
+#   MODEL_ALIAS   Model alias to send in the request body.
+# Optional env:
+#   EXPECT_HEADER Response header proving AI Gateway processed the request.
+#                 Default: X-Kong-LLM-Model.
+#   PORT          Ingress Service port. Default: 443.
+#   CURL_IMAGE    Image for the in-cluster curl Pod. Default: curlimages/curl:latest.
+#   MAX_RETRIES   Retry attempts. Default: 60.
+#   RETRY_DELAY   Seconds between retries. Default: 5.
+set -o errexit
+set -o nounset
+set -o pipefail
+
+NAMESPACE="${NAMESPACE}"
+DP_SVC="${DP_SVC}"
+ROUTE_PATH="${ROUTE_PATH}"
+MODEL_ALIAS="${MODEL_ALIAS}"
+EXPECT_HEADER="${EXPECT_HEADER:-X-Kong-LLM-Model}"
+PORT="${PORT:-443}"
+CURL_IMAGE="${CURL_IMAGE:-curlimages/curl:latest}"
+MAX_RETRIES="${MAX_RETRIES:-60}"
+RETRY_DELAY="${RETRY_DELAY:-5}"
+
+POD="aigw-traffic-${RANDOM}"
+URL="https://${DP_SVC}.${NAMESPACE}.svc:${PORT}${ROUTE_PATH}/chat/completions"
+BODY="{\"model\":\"${MODEL_ALIAS}\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with exactly: Kong AI Gateway works.\"}]}"
+
+cleanup() {
+  kubectl -n "${NAMESPACE}" delete pod "${POD}" --ignore-not-found --grace-period=0 --force >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+kubectl -n "${NAMESPACE}" run "${POD}" \
+  --image="${CURL_IMAGE}" --image-pull-policy=IfNotPresent --restart=Never \
+  --command -- sleep 3600 >/dev/null
+kubectl -n "${NAMESPACE}" wait --for=condition=Ready "pod/${POD}" --timeout=120s >/dev/null
+
+for ATTEMPT in $(seq 1 "${MAX_RETRIES}"); do
+  OUT="$(kubectl -n "${NAMESPACE}" exec "${POD}" -- sh -c \
+    "curl -sk -m 60 -o /tmp/b -D /tmp/h -w '%{http_code}' -X POST '${URL}' \
+       -H 'Content-Type: application/json' -d '${BODY}'; echo; \
+     grep -i '^${EXPECT_HEADER}:' /tmp/h | head -1 | cut -d' ' -f2- | tr -d '\r'" \
+    2>/dev/null || true)"
+  CODE="$(printf '%s\n' "${OUT}" | sed -n '1p')"
+  HDR="$(printf '%s\n' "${OUT}" | sed -n '2p')"
+  if [ "${CODE}" = "200" ] && [ -n "${HDR}" ]; then
+    echo "ok: status=${CODE} ${EXPECT_HEADER}=${HDR}"
+    exit 0
+  fi
+  echo "attempt ${ATTEMPT}/${MAX_RETRIES}: status='${CODE}' header='${HDR}'" >&2
+  sleep "${RETRY_DELAY}"
+done
+
+echo "FAILED: no 200 with ${EXPECT_HEADER} after ${MAX_RETRIES} attempts (last status='${CODE}')" >&2
+exit 1

--- a/test/e2e/chainsaw/fixtures/aigateway/00-namespace.yaml
+++ b/test/e2e/chainsaw/fixtures/aigateway/00-namespace.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kong-aigateway-mock

--- a/test/e2e/chainsaw/fixtures/aigateway/10-ollama.yaml
+++ b/test/e2e/chainsaw/fixtures/aigateway/10-ollama.yaml
@@ -1,0 +1,52 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: ollama
+  namespace: kong-aigateway-mock
+  labels: { app: ollama }
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: ollama }
+  template:
+    metadata:
+      labels: { app: ollama }
+    spec:
+      containers:
+        - name: ollama
+          image: ollama/ollama:0.31.2
+          command: ["/bin/sh", "-c"]
+          args:
+            - |
+              ollama serve &
+              pid=$!
+              until ollama ls >/dev/null 2>&1; do sleep 1; done
+              ollama pull qwen2.5:0.5b
+              ollama pull gemma3:270m
+              wait $pid
+          ports:
+            - containerPort: 11434
+          readinessProbe:
+            exec:
+              command:
+                - /bin/sh
+                - -c
+                - "ollama ls | grep -q 'qwen2.5:0.5b' && ollama ls | grep -q 'gemma3:270m'"
+            initialDelaySeconds: 10
+            periodSeconds: 10
+            failureThreshold: 90
+          resources:
+            requests: { cpu: "500m", memory: "1Gi" }
+            limits: { memory: "2Gi" }
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: ollama
+  namespace: kong-aigateway-mock
+spec:
+  selector: { app: ollama }
+  ports:
+    - name: http
+      port: 11434
+      targetPort: 11434

--- a/test/e2e/chainsaw/fixtures/aigateway/20-kong-mock-config.yaml
+++ b/test/e2e/chainsaw/fixtures/aigateway/20-kong-mock-config.yaml
@@ -1,0 +1,58 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: kong-mock-config
+  namespace: kong-aigateway-mock
+data:
+  # Two mock LLM providers, both backed by the same Ollama, isolated by api key.
+  # Both use the same route pattern: /provider-<x> (strip_path), forwarding to
+  # Ollama's /v1/chat/completions.
+  #   Provider A: route /provider-a, key test-ai-gateway-key   (ACL group provider-a)
+  #   Provider B: route /provider-b, key test-ai-gateway-key-b (ACL group provider-b)
+  # The ACL plugin ensures each key only works on its own provider's route.
+  kong.yml: |
+    _format_version: "3.0"
+    services:
+      - name: ollama-a
+        url: http://ollama.kong-aigateway-mock.svc.cluster.local:11434/v1/chat/completions
+        routes:
+          - name: chat-a
+            paths:
+              - /provider-a
+            strip_path: true
+            plugins:
+              - name: key-auth
+                config:
+                  key_names:
+                    - apikey
+              - name: acl
+                config:
+                  allow:
+                    - provider-a
+      - name: ollama-b
+        url: http://ollama.kong-aigateway-mock.svc.cluster.local:11434/v1/chat/completions
+        routes:
+          - name: chat-b
+            paths:
+              - /provider-b
+            strip_path: true
+            plugins:
+              - name: key-auth
+                config:
+                  key_names:
+                    - apikey
+              - name: acl
+                config:
+                  allow:
+                    - provider-b
+    consumers:
+      - username: ai-gateway-a
+        keyauth_credentials:
+          - key: test-ai-gateway-key
+        acls:
+          - group: provider-a
+      - username: ai-gateway-b
+        keyauth_credentials:
+          - key: test-ai-gateway-key-b
+        acls:
+          - group: provider-b

--- a/test/e2e/chainsaw/fixtures/aigateway/20-kong-mock.yaml
+++ b/test/e2e/chainsaw/fixtures/aigateway/20-kong-mock.yaml
@@ -1,0 +1,50 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: kong-mock
+  namespace: kong-aigateway-mock
+  labels: { app: kong-mock }
+spec:
+  replicas: 1
+  selector:
+    matchLabels: { app: kong-mock }
+  template:
+    metadata:
+      labels: { app: kong-mock }
+    spec:
+      containers:
+        - name: kong
+          image: kong:3.9
+          env:
+            - { name: KONG_DATABASE, value: "off" }
+            - { name: KONG_DECLARATIVE_CONFIG, value: "/kong/declarative/kong.yml" }
+            - { name: KONG_PROXY_LISTEN, value: "0.0.0.0:8000" }
+            - { name: KONG_ADMIN_LISTEN, value: "off" }
+            - { name: KONG_STATUS_LISTEN, value: "0.0.0.0:8100" }
+          ports:
+            - containerPort: 8000
+            - containerPort: 8100
+          readinessProbe:
+            httpGet: { path: /status, port: 8100 }
+            initialDelaySeconds: 5
+            periodSeconds: 5
+            failureThreshold: 30
+          volumeMounts:
+            - name: declarative
+              mountPath: /kong/declarative
+      volumes:
+        - name: declarative
+          configMap:
+            name: kong-mock-config
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: kong-mock
+  namespace: kong-aigateway-mock
+spec:
+  selector: { app: kong-mock }
+  ports:
+    - name: proxy
+      port: 8000
+      targetPort: 8000

--- a/test/e2e/chainsaw/fixtures/aigateway/prereq.sh
+++ b/test/e2e/chainsaw/fixtures/aigateway/prereq.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+# Prerequisites for the aigateway chainsaw suite: the shared mock LLM stack
+# (Ollama + a DB-less Kong proxy doing api-key auth). Applies the manifests in
+# this directory and waits for both deployments to become ready.
+#
+# Optional env:
+#   OLLAMA_TIMEOUT      Rollout timeout for the Ollama deployment. Default: 600s.
+#   KONG_MOCK_TIMEOUT   Rollout timeout for the kong-mock deployment. Default: 180s.
+set -o errexit
+set -o nounset
+set -o pipefail
+
+OLLAMA_TIMEOUT="${OLLAMA_TIMEOUT:-600s}"
+KONG_MOCK_TIMEOUT="${KONG_MOCK_TIMEOUT:-180s}"
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Namespace first, then the rest of the manifests in this directory.
+kubectl apply -f "${SCRIPT_DIR}/00-namespace.yaml"
+kubectl apply -f "${SCRIPT_DIR}"
+
+kubectl -n kong-aigateway-mock rollout status deploy/ollama --timeout="${OLLAMA_TIMEOUT}"
+kubectl -n kong-aigateway-mock rollout status deploy/kong-mock --timeout="${KONG_MOCK_TIMEOUT}"

--- a/test/e2e/chainsaw/fixtures/run-prereq.sh
+++ b/test/e2e/chainsaw/fixtures/run-prereq.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Generic dispatcher for chainsaw suite prerequisites.
+#
+# Runs the prerequisite script for a suite (test/e2e/chainsaw/fixtures/<DIRNAME>/prereq.sh)
+# if it exists. No-ops for suites that have no prerequisites, so a single CI step can call
+# this for every matrix suite unconditionally.
+#
+# Required env:
+#   DIRNAME   Suite/fixtures directory name (e.g. "aigateway"). Strictly validated.
+set -o errexit
+set -o nounset
+set -o pipefail
+
+: "${DIRNAME:?DIRNAME must be set, e.g. DIRNAME=aigateway}"
+
+# Whitelist: lowercase alphanumerics with internal dashes only. Forbids "/", ".", "..",
+# whitespace and shell metacharacters, so DIRNAME can only name a direct child of this
+# directory (no path traversal, no injection).
+if ! printf '%s' "${DIRNAME}" | grep -Eq '^[a-z0-9]([a-z0-9-]*[a-z0-9])?$'; then
+  echo "[run-prereq] invalid DIRNAME '${DIRNAME}': must match ^[a-z0-9]([a-z0-9-]*[a-z0-9])?\$" >&2
+  exit 1
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SUITE_SCRIPT="${SCRIPT_DIR}/${DIRNAME}/prereq.sh"
+
+if [ -f "${SUITE_SCRIPT}" ]; then
+  echo "[run-prereq] applying prerequisites for suite '${DIRNAME}'"
+  bash "${SUITE_SCRIPT}"
+else
+  echo "[run-prereq] no prerequisites for suite '${DIRNAME}', skipping"
+fi


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds a chainsaw e2e suite for AIGateway support, reproducing `ai-gateway-test-harness` criterion AI GW 1.1 (AI Proxy). It creates the Konnect AIGateway control plane, an OpenAI-compatible provider + model exposing `/aigw11/chat`, and an in-cluster `AIGatewayDataPlane`, then drives a real chat-completions request and asserts `HTTP 200` + the `X-Kong-LLM-Model` header.

The LLM upstream is mocked in-cluster — Ollama behind a DB-less Kong proxy doing api-key auth — so the suite is self-contained (no external egress, no real tokens). The mock manifests live in `test/e2e/chainsaw/fixtures/aigateway` (outside the suite dir so chainsaw does not run them as a test) and are applied by the CI workflow only for the `aigateway` matrix suite.

The suite runs through the standard chainsaw matrix (`CHAINSAW_TEST_DIR=test/e2e/chainsaw/aigateway` + `make test.e2e.chainsaw`) — no bespoke Make target. `aigateway` is added to the e2e matrix and the operator Helm install enables the `aigatewaydataplane` controller.

Reusable pieces added: step templates `apply-assert-konnectAIGateway` and `apply-assert-aigatewayDataPlane`, and a parametrized traffic script — for the follow-up AI GW criteria.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

- The `AIGatewayDataPlane` image is overridden (via `podTemplateSpec`, binding `aigw_dp_image` / env `AIGW_DP_IMAGE`) to a `kong-ai-gateway-dev` build. The operator default `kong-ai-gateway:2.0.0` cannot load the config the `.tech` org emits today (`in 'plugins' ... 'model': value must be null`) — worth tracking whether `DefaultAIGatewayTag` should be bumped.
- Validated locally against `global.api.konghq.tech`; CI targets `us.api.konghq.tech`. First CI run for the `aigateway` matrix will confirm the region behaves the same.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes (n/a — test-only change)
