### PR TITLE
chore(ci): refactor crds validation workflow

### DIFF
--- a/.github/workflows/__crdvalidation_tests.yaml
+++ b/.github/workflows/__crdvalidation_tests.yaml
@@ -17,13 +17,13 @@ env:
 
 jobs:
   crd-validation-tests:
-    timeout-minutes: ${{ fromJSON(vars.GHA_EXTENDED_TIMEOUT_MINUTES || 60) }}
+    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT || 10) }}
     runs-on: ubuntu-latest
-    name: ${{ format('{0} / {1}', matrix.kubernetes-node-version, matrix.crd_validation_test.name) }}
+    name: ${{ matrix.crd_validation_test.name }} - ${{ matrix.cluster_version }}
     strategy:
       fail-fast: false
       matrix:
-        kubernetes-node-version: ${{ fromJson(inputs.cluster_versions) }}
+        cluster_version: ${{ fromJson(inputs.cluster_versions) }}
         crd_validation_test:
         - name: root
           path: ./test/crdsvalidation
@@ -86,7 +86,7 @@ jobs:
       env:
         GO_TEST_PARALLEL: 2
       run: |
-        VERSION="${{ matrix.kubernetes-node-version }}"
+        VERSION="${{ matrix.cluster_version }}"
         # Remove leading 'v'
         VERSION="${VERSION#v}"
         # Remove patch number as envtest releases are not provided for every patch version

--- a/.github/workflows/__integration_tests.yaml
+++ b/.github/workflows/__integration_tests.yaml
@@ -33,7 +33,7 @@ jobs:
   integration-tests:
     timeout-minutes: ${{ fromJSON(vars.GHA_EXTENDED_TIMEOUT_MINUTES || 60) }}
     runs-on: ubuntu-latest
-    name: ${{ format('{0} {1} {2}', matrix.suite, matrix.router_flavor, inputs.cluster_version) }}
+    name: ${{ format('{0} {1} - {2}', matrix.suite, matrix.router_flavor, inputs.cluster_version) }}
     strategy:
       matrix:
         include:


### PR DESCRIPTION
**What this PR does / why we need it**:

Add cluster version to workflow run name so that it's easier to distinguish which version the CRD validation run is being launched against:

<img width="379" height="677" alt="image" src="https://github.com/user-attachments/assets/2f4a3d0e-9555-4059-81e7-80edca886827" />

vs proposed:

<img width="379" height="702" alt="image" src="https://github.com/user-attachments/assets/1bc59572-62fc-4000-9941-2af0b4811253" />


**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
