### PR TITLE
[Backport release/2.1.x]Preserve only one CA certificate if they have dupe IDs

### DIFF
--- a/ingress-controller/internal/dataplane/translator/translate_cacert_test.go
+++ b/ingress-controller/internal/dataplane/translator/translate_cacert_test.go
@@ -1,0 +1,203 @@
+package translator
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/kong/kong-operator/v2/ingress-controller/internal/annotations"
+	"github.com/kong/kong-operator/v2/ingress-controller/internal/store"
+	"github.com/kong/kong-operator/v2/test/helpers/certificate"
+)
+
+func TestGetCACerts(t *testing.T) {
+	// validCACert is a self-signed certificate with the CA basic constraint set, so it can be translated.
+	validCACert, _ := certificate.MustGenerateCertPEMFormat(
+		certificate.WithCATrue(),
+		certificate.WithCommonName("ca.example.com"),
+	)
+	// nonCACert is a valid X.509 certificate but lacks the CA basic constraint, so it fails translation.
+	nonCACert, _ := certificate.MustGenerateCertPEMFormat(
+		certificate.WithCommonName("leaf.example.com"),
+	)
+
+	const dupID = "8214a145-a328-4c56-ab72-2973a56d4eba"
+
+	// makeCACertSecret builds a Secret labelled as a CA cert (so ListCACerts picks it up) with the given data.
+	makeCACertSecret := func(namespace, name string, creationTime time.Time, data map[string][]byte) *corev1.Secret {
+		return &corev1.Secret{
+			// TypeMeta must be set so causing objects have a non-empty GVK; otherwise the
+			// failures collector silently drops the registered translation failures.
+			TypeMeta: metav1.TypeMeta{Kind: "Secret", APIVersion: "v1"},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:              name,
+				Namespace:         namespace,
+				CreationTimestamp: metav1.NewTime(creationTime),
+				Labels: map[string]string{
+					"konghq.com/ca-cert": "true",
+				},
+				Annotations: map[string]string{
+					annotations.IngressClassKey: annotations.DefaultIngressClass,
+				},
+			},
+			Data: data,
+		}
+	}
+
+	// defaultSecret is a convenience wrapper for single-secret tests that don't exercise selection.
+	defaultSecret := func(name string, data map[string][]byte) *corev1.Secret {
+		return makeCACertSecret("default", name, time.Time{}, data)
+	}
+
+	t0 := time.Unix(0, 0)
+	t1 := time.Unix(1, 0)
+	t2 := time.Unix(2, 0)
+
+	testCases := []struct {
+		name                string
+		secrets             []*corev1.Secret
+		wantCertCount       int
+		wantFailureMessages []string
+	}{
+		{
+			name: "valid CA cert is translated",
+			secrets: []*corev1.Secret{
+				defaultSecret("valid", map[string][]byte{
+					"id":   []byte("8214a145-a328-4c56-ab72-2973a56d4eba"),
+					"cert": validCACert,
+				}),
+			},
+			wantCertCount:       1,
+			wantFailureMessages: nil,
+		},
+		{
+			name: "secret without 'id' field cannot be translated",
+			secrets: []*corev1.Secret{
+				defaultSecret("no-id", map[string][]byte{
+					"cert": validCACert,
+				}),
+			},
+			wantCertCount:       0,
+			wantFailureMessages: []string{"missing 'id' field"},
+		},
+		{
+			name: "secret without 'cert' field cannot be translated",
+			secrets: []*corev1.Secret{
+				defaultSecret("no-cert", map[string][]byte{
+					"id": []byte("8214a145-a328-4c56-ab72-2973a56d4eba"),
+				}),
+			},
+			wantCertCount:       0,
+			wantFailureMessages: []string{`neither "cert" nor "ca.crt"`},
+		},
+		{
+			// With equal timestamps and namespace, "dup-1" < "dup-2" so "dup-1" is preserved.
+			name: "secrets with duplicate 'id': lexicographically smallest name wins",
+			secrets: []*corev1.Secret{
+				makeCACertSecret("default", "dup-1", t0, map[string][]byte{
+					"id":   []byte(dupID),
+					"cert": validCACert,
+				}),
+				makeCACertSecret("default", "dup-2", t0, map[string][]byte{
+					"id":   []byte(dupID),
+					"cert": validCACert,
+				}),
+			},
+			wantCertCount:       1,
+			wantFailureMessages: []string{"duplicate 'id'"},
+		},
+		{
+			// The secret with the earliest creation timestamp is preserved; the later one gets a failure.
+			name: "secrets with duplicate 'id': earliest creation time wins",
+			secrets: []*corev1.Secret{
+				makeCACertSecret("default", "later", t2, map[string][]byte{
+					"id":   []byte(dupID),
+					"cert": validCACert,
+				}),
+				makeCACertSecret("default", "earlier", t1, map[string][]byte{
+					"id":   []byte(dupID),
+					"cert": validCACert,
+				}),
+			},
+			wantCertCount:       1,
+			wantFailureMessages: []string{"duplicate 'id'"},
+		},
+		{
+			// With equal timestamps, the secret in the lexicographically smaller namespace wins.
+			name: "secrets with duplicate 'id': smallest namespace wins on timestamp tie",
+			secrets: []*corev1.Secret{
+				makeCACertSecret("ns-b", "same-name", t0, map[string][]byte{
+					"id":   []byte(dupID),
+					"cert": validCACert,
+				}),
+				makeCACertSecret("ns-a", "same-name", t0, map[string][]byte{
+					"id":   []byte(dupID),
+					"cert": validCACert,
+				}),
+			},
+			wantCertCount:       1,
+			wantFailureMessages: []string{"duplicate 'id'"},
+		},
+		{
+			// Three objects with the same ID: only the overall winner is translated; the other two get failures.
+			name: "secrets with duplicate 'id': three duplicates, only winner translated",
+			secrets: []*corev1.Secret{
+				makeCACertSecret("default", "c", t2, map[string][]byte{
+					"id":   []byte(dupID),
+					"cert": validCACert,
+				}),
+				makeCACertSecret("default", "a", t1, map[string][]byte{
+					"id":   []byte(dupID),
+					"cert": validCACert,
+				}),
+				makeCACertSecret("default", "b", t1, map[string][]byte{
+					"id":   []byte(dupID),
+					"cert": validCACert,
+				}),
+			},
+			wantCertCount:       1,
+			wantFailureMessages: []string{"duplicate 'id'", "duplicate 'id'"},
+		},
+		{
+			name: "secret with invalid CA certificate cannot be translated",
+			secrets: []*corev1.Secret{
+				defaultSecret("not-a-ca", map[string][]byte{
+					"id":   []byte("8214a145-a328-4c56-ab72-2973a56d4eba"),
+					"cert": nonCACert,
+				}),
+			},
+			wantCertCount:       0,
+			wantFailureMessages: []string{"invalid secret CA certificate"},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeStore, err := store.NewFakeStore(store.FakeObjects{Secrets: tc.secrets})
+			require.NoError(t, err)
+			p := mustNewTranslator(t, fakeStore)
+
+			certs := p.getCACerts()
+			require.Len(t, certs, tc.wantCertCount)
+
+			translationFailures := p.popTranslationFailures()
+			require.Len(t, translationFailures, len(tc.wantFailureMessages))
+			// Failures may be reported in any order, so assert that every expected message
+			// has a matching failure rather than pairing them by index.
+			for _, want := range tc.wantFailureMessages {
+				require.Truef(t, func() bool {
+					for _, f := range translationFailures {
+						if strings.Contains(f.Message(), want) {
+							return true
+						}
+					}
+					return false
+				}(), "expected a translation failure containing %q, got %v", want, translationFailures)
+			}
+		})
+	}
+}

--- a/ingress-controller/internal/dataplane/translator/translate_cacerts.go
+++ b/ingress-controller/internal/dataplane/translator/translate_cacerts.go
@@ -48,14 +48,52 @@ func (t *Translator) getCACerts() []kong.CACertificate {
 		return intermediateT{obj: configmap.DeepCopy(), data: configmap.Data}
 	})...)
 
-	caCerts := make([]kong.CACertificate, 0, len(caCertSecrets)+len(caCertConfigMaps))
+	// pickWinner returns the preferred and rejected intermediate for a shared ID.
+	// Priority: earliest creation timestamp → lexicographically smallest namespace → smallest name.
+	pickWinner := func(a, b intermediateT) (winner, loser intermediateT) {
+		aTime, bTime := a.obj.GetCreationTimestamp(), b.obj.GetCreationTimestamp()
+		if aTime.Before(&bTime) {
+			return a, b
+		}
+		if bTime.Before(&aTime) {
+			return b, a
+		}
+		aNS, bNS := a.obj.GetNamespace(), b.obj.GetNamespace()
+		if aNS < bNS {
+			return a, b
+		}
+		if bNS < aNS {
+			return b, a
+		}
+		if a.obj.GetName() <= b.obj.GetName() {
+			return a, b
+		}
+		return b, a
+	}
+
+	// First pass: report missing-ID failures and build a winners map (one entry per ID).
+	// When multiple objects share the same ID, keep the one with the earliest creation time
+	// (breaking ties by namespace then name). Non-winners are reported as translation failures immediately.
+	winners := make(map[string]intermediateT)
 	for _, caCertData := range caCertsData {
-		secretID, ok := caCertData.data["id"]
+		id, ok := caCertData.data["id"]
 		if !ok {
 			t.registerTranslationFailure("invalid secret CA certificate: missing 'id' field in data", caCertData.obj)
 			continue
 		}
+		existing, seen := winners[id]
+		if !seen {
+			winners[id] = caCertData
+			continue
+		}
+		winner, loser := pickWinner(existing, caCertData)
+		winners[id] = winner
+		t.registerTranslationFailure("invalid secret CA certificate: duplicate 'id' field in multiple objects", loser.obj)
+	}
 
+	// Second pass: validate and translate the single winner for each ID.
+	caCerts := make([]kong.CACertificate, 0, len(winners))
+	for secretID, caCertData := range winners {
 		// Allow the certificate key to be named either "cert" or "ca.crt".
 		caCertStr, certExists := caCertData.data["cert"]
 		if !certExists {


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
