### PR TITLE
fix(dataplane): avoid false positive warnings for operator-managed env vars

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,6 +137,13 @@
 
 ### Fixes
 
+- DataPlane: fix false-positive warnings about operator-managed environment
+  variables (`KONG_CLUSTER_CERT`, `KONG_CLUSTER_CERT_KEY`) being set by the
+  user. The Konnect extension processor injects these variables into the
+  in-memory DataPlane spec as a staging area for deployment generation; the
+  check now runs before that mutation so it only inspects what the user
+  actually wrote to the DataPlane object in Kubernetes.
+  [#4888](https://github.com/Kong/kong-operator/pull/4888)
 - Gateway: stop overwriting the user-configured `KONG_STREAM_LISTEN` for TLS
   listeners. The operator now enforces only the listen port and the `ssl` token,
   preserving the bind address (e.g. `[::]` for IPv6) and any listen options

--- a/controller/dataplane/bluegreen_controller.go
+++ b/controller/dataplane/bluegreen_controller.go
@@ -98,6 +98,8 @@ func (r *BlueGreenReconciler) SetupWithManager(ctx context.Context, mgr ctrl.Man
 func (r *BlueGreenReconciler) Reconcile(ctx context.Context, dataplane *operatorv1beta1.DataPlane) (ctrl.Result, error) {
 	logger := log.GetLogger(ctx, "dataplaneBlueGreen", r.LoggingMode)
 
+	warnOperatorManagedEnvVars(ctx, logger, dataplane, r.Client)
+
 	// Blue Green rollout strategy is not enabled, delegate to DataPlane controller.
 	if dataplane.Spec.Deployment.Rollout == nil || dataplane.Spec.Deployment.Rollout.Strategy.BlueGreen == nil {
 		if err := r.prunePreviewSubresources(ctx, dataplane); err != nil {
@@ -143,6 +145,7 @@ func (r *BlueGreenReconciler) Reconcile(ctx context.Context, dataplane *operator
 	// DataPlane is ready and we can proceed with deploying preview resources.
 
 	// customize the dataplane with the extensions field
+
 	log.Trace(logger, "applying extensions")
 	stop, result, err := extensions.ApplyExtensions(ctx, r.Client, dataplane, r.KonnectEnabled, &extensionskonnect.DataPlaneKonnectExtensionProcessor{})
 	if err != nil {

--- a/controller/dataplane/controller.go
+++ b/controller/dataplane/controller.go
@@ -74,6 +74,8 @@ func (r *Reconciler) Reconcile(ctx context.Context, dataplane *operatorv1beta1.D
 
 	log.Trace(logger, "reconciling DataPlane resource")
 
+	warnOperatorManagedEnvVars(ctx, logger, dataplane, r.Client)
+
 	if k8sutils.InitReady(dataplane) {
 		if patched, err := patchDataPlaneStatus(ctx, r.Client, logger, dataplane); err != nil {
 			return ctrl.Result{}, fmt.Errorf("failed initializing DataPlane Ready condition: %w", err)

--- a/controller/dataplane/owned_deployment.go
+++ b/controller/dataplane/owned_deployment.go
@@ -139,20 +139,6 @@ func (d *DeploymentBuilder) BuildAndDeploy(
 		return nil, op.Noop, fmt.Errorf("failed to mount konnect cert: %w", err)
 	}
 
-	// Genreate an error log if the user is trying to set environment variables that are managed by the operator, as this may cause unexpected behavior.
-	for _, envVar := range operatorManangedEnvVars {
-		found, err := envVarExistsInPodTemplateSpec(ctx, envVar, dataplane, d.client)
-		if err != nil {
-			return nil, op.Noop, fmt.Errorf("failed to check if env var %s exists in PodTemplateSpec: %w", envVar, err)
-		}
-		if found {
-			d.logger.Error(fmt.Errorf("operator maanged environment variable %s exists in DataPlane spec", envVar),
-				"DataPlane contains operator managed environment variable. This may cause unexpected behavior as the operator also manages this variable.",
-				"envVar", envVar, "dataPlane", client.ObjectKeyFromObject(dataplane).String(),
-			)
-		}
-	}
-
 	// TODO https://github.com/kong/kong-operator/issues/128
 	// This is a workaround to avoid patches clobbering the wrong EnvVar. We want to find an improved patch mechanism
 	// that doesn't clobber EnvVars (and other array fields) it shouldn't.
@@ -297,6 +283,26 @@ func podTemplateSpecHasRestartAnnotation(template *corev1.PodTemplateSpec) (stri
 	}
 	v, ok := template.Annotations[restartAnnotationKey]
 	return v, ok && v != ""
+}
+
+// warnOperatorManagedEnvVars logs an error for each operator-managed env var found in the
+// DataPlane spec. Call this before any extension processors mutate the in-memory spec so
+// the check reflects only user-authored values.
+func warnOperatorManagedEnvVars(ctx context.Context, logger logr.Logger, dataplane *operatorv1beta1.DataPlane, cl client.Client) {
+	for _, envVar := range operatorManangedEnvVars {
+		found, err := envVarExistsInPodTemplateSpec(ctx, envVar, dataplane, cl)
+		if err != nil {
+			logger.Error(err, "failed to check if operator managed env var exists in DataPlane spec", "envVar", envVar)
+			continue
+		}
+		if !found {
+			continue
+		}
+		logger.Error(fmt.Errorf("operator maanged environment variable %s exists in DataPlane spec", envVar),
+			"DataPlane contains operator managed environment variable. This may cause unexpected behavior as the operator also manages this variable.",
+			"envVar", envVar, "dataPlane", client.ObjectKeyFromObject(dataplane).String(),
+		)
+	}
 }
 
 // envVarExistsInPodTemplateSpec checks if an environment variable with the given name

--- a/controller/dataplane/owned_deployment_test.go
+++ b/controller/dataplane/owned_deployment_test.go
@@ -499,6 +499,78 @@ func TestSetClusterCertVars(t *testing.T) {
 	assert.True(t, keyEnvFound, "KONG_CLUSTER_CERT_KEY env var not found")
 }
 
+// errorCountSink is a minimal logr.LogSink that counts Error() calls.
+type errorCountSink struct{ count *int }
+
+func (s errorCountSink) Init(logr.RuntimeInfo)             {}
+func (s errorCountSink) Enabled(int) bool                  { return true }
+func (s errorCountSink) Info(_ int, _ string, _ ...any)    {}
+func (s errorCountSink) Error(_ error, _ string, _ ...any) { *s.count++ }
+func (s errorCountSink) WithValues(_ ...any) logr.LogSink  { return s }
+func (s errorCountSink) WithName(_ string) logr.LogSink    { return s }
+
+func TestWarnOperatorManagedEnvVars(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, operatorv1beta1.AddToScheme(scheme))
+
+	makeDP := func(envVars ...corev1.EnvVar) *operatorv1beta1.DataPlane {
+		return &operatorv1beta1.DataPlane{
+			ObjectMeta: metav1.ObjectMeta{Name: "dp", Namespace: "default"},
+			Spec: operatorv1beta1.DataPlaneSpec{
+				DataPlaneOptions: operatorv1beta1.DataPlaneOptions{
+					Deployment: operatorv1beta1.DataPlaneDeploymentOptions{
+						DeploymentOptions: operatorv1beta1.DeploymentOptions{
+							PodTemplateSpec: &corev1.PodTemplateSpec{
+								Spec: corev1.PodSpec{
+									Containers: []corev1.Container{
+										{Name: consts.DataPlaneProxyContainerName, Env: envVars},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		}
+	}
+
+	tests := []struct {
+		name         string
+		dp           *operatorv1beta1.DataPlane
+		expectErrors int
+	}{
+		{
+			name:         "no managed env vars in spec — no warning",
+			dp:           makeDP(),
+			expectErrors: 0,
+		},
+		{
+			name:         "user sets KONG_CLUSTER_CERT — one warning",
+			dp:           makeDP(corev1.EnvVar{Name: envKongClusterCert, Value: "/some/path"}),
+			expectErrors: 1,
+		},
+		{
+			name: "user sets both managed env vars — two warnings",
+			dp: makeDP(
+				corev1.EnvVar{Name: envKongClusterCert, Value: "/some/path/tls.crt"},
+				corev1.EnvVar{Name: envKongClusterCertKey, Value: "/some/path/tls.key"},
+			),
+			expectErrors: 2,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			count := 0
+			logger := logr.New(errorCountSink{count: &count})
+			cl := fakectrlruntimeclient.NewClientBuilder().WithScheme(scheme).Build()
+			warnOperatorManagedEnvVars(t.Context(), logger, tc.dp, cl)
+			assert.Equal(t, tc.expectErrors, count)
+		})
+	}
+}
+
 func TestPodTemplateSpecHasRestartAnnotation(t *testing.T) {
 	testCases := []struct {
 		name           string


### PR DESCRIPTION




**What this PR does / why we need it**:
The operator's Konnect extension processor mutates the DataPlane spec in memory during reconciliation, injecting KONG_CLUSTER_CERT and KONG_CLUSTER_CERT_KEY into PodTemplateSpec as a staging area for BuildAndDeploy to consume. The check that warns users about setting operator-managed env vars was running after this mutation, so it incorrectly flagged the operator's own injections as user-set values.

Move the check to run before ApplyExtensions mutates the spec, so it only observes what the user actually wrote to the DataPlane object in Kubernetes.fix: add 5 seconds timeout on server shutdown

No more errors like this in the logs:

```json

{"level":"error","ts":"2026-07-13T12:01:14Z","logger":"dataplane.deployment_builder","msg":"DataPlane contains operator managed environment variable. This may cause unexpected behavior as the operator also manages this variable.","controller":"dataplane","controllerGroup":"gateway-operator.konghq.com","controllerKind":"DataPlane","DataPlane":{"name":"chainsaw-accurate-mole-gateway-c6r79","namespace":"chainsaw-accurate-mole"},"namespace":"chainsaw-accurate-mole","name":"chainsaw-accurate-mole-gateway-c6r79","reconcileID":"f0b6737d-3d07-43ca-b192-c47ae0f0c22d","envVar":"KONG_CLUSTER_CERT_KEY","dataPlane":"chainsaw-accurate-mole/chainsaw-accurate-mole-gateway-c6r79","error":"operator maanged environment variable KONG_CLUSTER_CERT_KEY exists in DataPlane spec","stacktrace":"github.com/kong/kong-operator/v2/controller/dataplane.(*DeploymentBuilder).BuildAndDeploy\n\t/workspace/controller/dataplane/owned_deployment.go:149\ngithub.com/kong/kong-operator/v2/controller/dataplane.(*Reconciler).Reconcile\n\t/workspace/controller/dataplane/controller.go:223\ngithub.com/kong/kong-operator/v2/controller/dataplane.(*BlueGreenReconciler).Reconcile\n\t/workspace/controller/dataplane/bluegreen_controller.go:107\nsigs.k8s.io/controller-runtime/pkg/reconcile.(*objectReconcilerAdapter[...]).Reconcile\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.24.1/pkg/reconcile/reconcile.go:169\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Reconcile\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.24.1/pkg/internal/controller/controller.go:221\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.24.1/pkg/internal/controller/controller.go:478\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.24.1/pkg/internal/controller/controller.go:437\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1\n\t/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.24.1/pkg/internal/controller/controller.go:312"}
```
**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
