### PR TITLE
[backport release/2.2.x] revert(#4465): wait for child cleanup before releasing root finalizer(#4785)

### DIFF
--- a/controller/hybridgateway/controller.go
+++ b/controller/hybridgateway/controller.go
@@ -394,9 +394,9 @@ func (r *HybridGatewayReconciler[t, tPtr]) cleanupGeneratedResources(
 	logger logr.Logger,
 	conv converter.APIConverter[t],
 ) (bool, error) {
-	// Use the existing cleanup logic but do not wait for generated resources to
-	// fully disappear before releasing the root finalizer. Generated resources
-	// have their own cleanup/finalizer flows; keeping the Gateway API object in
-	// deletion until every child finishes can block immediate same-name re-creates.
-	return cleanOrphanedResourcesWithoutWaitingForDeletes[t, tPtr](ctx, r.Client, logger, conv)
+	// On the deletion path we create a fresh converter but do not run Translate(),
+	// so cleanOrphanedResources() sees no desired output objects. That makes all
+	// owned generated resources orphan candidates, and we wait for their deletion
+	// before releasing the root finalizer.
+	return cleanOrphanedResources[t, tPtr](ctx, r.Client, logger, conv)
 }

--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -493,6 +493,16 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(ctx context.Context, ent TE
 
 	apiAuthRef, err := GetAPIAuthRefNN(ctx, r.Client, ent)
 	if err != nil {
+		// Entities such as KongTargets resolve API authentication through their
+		// parent resource. The parent ControlPlane can disappear between the
+		// reference checks above and this lookup. In that case the ControlPlane's
+		// deletion has already removed its Konnect entities, so keeping the child
+		// cleanup finalizer would only leave the Kubernetes resource terminating
+		// forever.
+		if handled, res, finalizerErr := removeCleanupFinalizerIfControlPlaneIsGone(ctx, r.Client, ent, err); handled {
+			return res, finalizerErr
+		}
+
 		if crossnamespace.IsReferenceNotGranted(err) {
 			log.Info(logger, "cross-namespace reference to KonnectAPIAuthConfiguration is not granted", "error", err.Error())
 			if requeue, res, retErr := handleAPIAuthStatusCondition(ctx, r.Client, ent, konnectv1alpha1.KonnectAPIAuthConfiguration{}, apiAuthRef, err, programmedFalseCondition); requeue {
@@ -798,6 +808,35 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(ctx context.Context, ent TE
 	return ctrl.Result{
 		RequeueAfter: r.SyncPeriod,
 	}, nil
+}
+
+func removeCleanupFinalizerIfControlPlaneIsGone[
+	T constraints.SupportedKonnectEntityType,
+	TEnt constraints.EntityType[T],
+](
+	ctx context.Context,
+	cl client.Client,
+	ent TEnt,
+	err error,
+) (bool, ctrl.Result, error) {
+	if _, ok := errors.AsType[controlplane.ReferencedControlPlaneDoesNotExistError](err); !ok {
+		return false, ctrl.Result{}, nil
+	}
+
+	if controllerutil.RemoveFinalizer(ent, KonnectCleanupFinalizer) {
+		if err := cl.Update(ctx, ent); err != nil {
+			switch {
+			case apierrors.IsConflict(err):
+				return true, ctrl.Result{Requeue: true}, nil
+			case apierrors.IsNotFound(err):
+				return true, ctrl.Result{}, nil
+			default:
+				return true, ctrl.Result{}, fmt.Errorf("failed to remove finalizer %s: %w", KonnectCleanupFinalizer, err)
+			}
+		}
+	}
+
+	return true, ctrl.Result{}, nil
 }
 
 // reconcilePendingKonnectID reconciles the cached view of the object with the

--- a/controller/konnect/reconciler_generic_apiauthref_test.go
+++ b/controller/konnect/reconciler_generic_apiauthref_test.go
@@ -1,0 +1,162 @@
+package konnect
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	commonv1alpha1 "github.com/kong/kong-operator/v2/api/common/v1alpha1"
+	configurationv1alpha1 "github.com/kong/kong-operator/v2/api/configuration/v1alpha1"
+	konnectv1alpha2 "github.com/kong/kong-operator/v2/api/konnect/v1alpha2"
+	"github.com/kong/kong-operator/v2/controller/pkg/controlplane"
+	"github.com/kong/kong-operator/v2/modules/manager/logging"
+	"github.com/kong/kong-operator/v2/modules/manager/scheme"
+)
+
+func TestReconcileRemovesFinalizerWhenControlPlaneDisappearsBeforeAPIAuthLookup(t *testing.T) {
+	upstream := testKongUpstreamOK.DeepCopy()
+	controlPlane := testControlPlaneOK.DeepCopy()
+	target := &configurationv1alpha1.KongTarget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:       "target",
+			Namespace:  "default",
+			Finalizers: []string{KonnectCleanupFinalizer},
+		},
+		Spec: configurationv1alpha1.KongTargetSpec{
+			UpstreamRef: commonv1alpha1.NamespacedRef{Name: upstream.Name},
+		},
+	}
+
+	controlPlaneGets := 0
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme.Get()).
+		WithObjects(target, upstream, controlPlane).
+		WithStatusSubresource(target).
+		WithInterceptorFuncs(interceptor.Funcs{
+			Get: func(
+				ctx context.Context,
+				cl client.WithWatch,
+				key client.ObjectKey,
+				obj client.Object,
+				opts ...client.GetOption,
+			) error {
+				if _, ok := obj.(*konnectv1alpha2.KonnectGatewayControlPlane); ok && key == client.ObjectKeyFromObject(controlPlane) {
+					controlPlaneGets++
+					if controlPlaneGets > 1 {
+						return apierrors.NewNotFound(
+							schema.GroupResource{Group: "konnect.konghq.com", Resource: "konnectgatewaycontrolplanes"},
+							key.Name,
+						)
+					}
+				}
+				return cl.Get(ctx, key, obj, opts...)
+			},
+		}).
+		Build()
+
+	reconciler := NewKonnectEntityReconciler[configurationv1alpha1.KongTarget](
+		nil, logging.DevelopmentMode, cl,
+	)
+	res, err := reconciler.Reconcile(t.Context(), target)
+	require.NoError(t, err)
+	assert.Equal(t, ctrl.Result{}, res)
+	assert.Equal(t, 2, controlPlaneGets)
+
+	var updated configurationv1alpha1.KongTarget
+	require.NoError(t, cl.Get(t.Context(), client.ObjectKeyFromObject(target), &updated))
+	assert.NotContains(t, updated.Finalizers, KonnectCleanupFinalizer)
+}
+
+func TestRemoveCleanupFinalizerIfControlPlaneIsGone(t *testing.T) {
+	newTarget := func() *configurationv1alpha1.KongTarget {
+		return &configurationv1alpha1.KongTarget{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:       "target",
+				Namespace:  "default",
+				Finalizers: []string{KonnectCleanupFinalizer},
+			},
+		}
+	}
+	missingControlPlaneErr := controlplane.ReferencedControlPlaneDoesNotExistError{
+		Reference: commonv1alpha1.ControlPlaneRef{
+			Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+			KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+				Name: "missing-control-plane",
+			},
+		},
+		Err: apierrors.NewNotFound(
+			schema.GroupResource{Group: "konnect.konghq.com", Resource: "konnectgatewaycontrolplanes"},
+			"missing-control-plane",
+		),
+	}
+
+	t.Run("ignores unrelated errors", func(t *testing.T) {
+		target := newTarget()
+		cl := fake.NewClientBuilder().WithScheme(scheme.Get()).WithObjects(target).Build()
+
+		handled, res, err := removeCleanupFinalizerIfControlPlaneIsGone[configurationv1alpha1.KongTarget](
+			t.Context(), cl, target, assert.AnError,
+		)
+
+		require.NoError(t, err)
+		assert.False(t, handled)
+		assert.Equal(t, ctrl.Result{}, res)
+		assert.Contains(t, target.Finalizers, KonnectCleanupFinalizer)
+	})
+
+	t.Run("removes finalizer when control plane is gone", func(t *testing.T) {
+		target := newTarget()
+		cl := fake.NewClientBuilder().WithScheme(scheme.Get()).WithObjects(target).Build()
+
+		handled, res, err := removeCleanupFinalizerIfControlPlaneIsGone[configurationv1alpha1.KongTarget](
+			t.Context(), cl, target, missingControlPlaneErr,
+		)
+
+		require.NoError(t, err)
+		assert.True(t, handled)
+		assert.Equal(t, ctrl.Result{}, res)
+
+		var updated configurationv1alpha1.KongTarget
+		require.NoError(t, cl.Get(t.Context(), client.ObjectKeyFromObject(target), &updated))
+		assert.NotContains(t, updated.Finalizers, KonnectCleanupFinalizer)
+	})
+
+	t.Run("requeues on update conflict", func(t *testing.T) {
+		target := newTarget()
+		cl := fake.NewClientBuilder().
+			WithScheme(scheme.Get()).
+			WithObjects(target).
+			WithInterceptorFuncs(interceptor.Funcs{
+				Update: func(
+					_ context.Context,
+					_ client.WithWatch,
+					obj client.Object,
+					_ ...client.UpdateOption,
+				) error {
+					return apierrors.NewConflict(
+						schema.GroupResource{Group: "configuration.konghq.com", Resource: "kongtargets"},
+						obj.GetName(),
+						assert.AnError,
+					)
+				},
+			}).
+			Build()
+
+		handled, res, err := removeCleanupFinalizerIfControlPlaneIsGone[configurationv1alpha1.KongTarget](
+			t.Context(), cl, target, missingControlPlaneErr,
+		)
+
+		require.NoError(t, err)
+		assert.True(t, handled)
+		assert.Equal(t, ctrl.Result{Requeue: true}, res)
+	})
+}


### PR DESCRIPTION
… 

(cherry picked from commit 2b4365642556823bfadea400d6c639d3912182de)

**What this PR does / why we need it**:

**Which issue this PR fixes**

backport #4785 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
