### PR TITLE
[backport release/2.2.x] chore(ci): fix govulncheck (#4844)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@
 # Builder
 # ------------------------------------------------------------------------------
 
-FROM --platform=$BUILDPLATFORM golang:1.26.4@sha256:792443b89f65105abba56b9bd5e97f680a80074ac62fc844a584212f8c8102c3 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.26.5@sha256:079e59808d2d252516e27e3f3a9c003740dee7f75e55aa71528766d52bcfc16a AS builder
 
 WORKDIR /workspace
 ARG GOPATH

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/kong/kong-operator/v2
 
-go 1.26.4
+go 1.26.5
 
 require (
 	cloud.google.com/go/container v1.52.0

--- a/hack/govulncheck-with-excludes.sh
+++ b/hack/govulncheck-with-excludes.sh
@@ -5,6 +5,11 @@ set -Eeuo pipefail
 # It's highly inspired by https://github.com/tianon/gosu/blob/9dc5d8d7556e44d382b9f71734197b5071682c31/govulncheck-with-excludes.sh.
 # When govulncheck supports excluding vulnerabilities, this script should be removed: https://github.com/golang/go/issues/59507
 
+# Line-numbered trace prefix and an ERR trap so a failure (e.g. from jq) points
+# at the exact line without needing to hand-add "set -x" to debug it.
+export PS4='+ ${BASH_SOURCE##*/}:${LINENO}: '
+trap 'echo "govulncheck-with-excludes.sh: error at line ${LINENO} (exit $?)" >&2' ERR
+
 excludeVulns="$(jq -nc '[
 
   # Kubernetes kube-apiserver Vulnerable to Race Condition
@@ -21,7 +26,13 @@ excludeVulns="$(jq -nc '[
   # pgx is an indirect dependency (via terratest, testcontainers, certificate-transparency-go)
   # and is not imported or used anywhere in our code.
   "GO-2026-4771",
-  "GO-2026-4772"
+  "GO-2026-4772",
+
+  # The golang.org/x/crypto/openpgp package is unsafe by design,
+  # has numerous known security issues, is not maintained, and should not be used.
+  # If you are required to interoperate with OpenPGP systems and need a maintained package,
+  # consider github.com/ProtonMail/go-crypto/openpgp which is a maintained fork that aims to be a drop-in replacement for this package.
+  "GO-2026-5932"
 
 ]')"
 export excludeVulns
@@ -66,7 +77,7 @@ vulns="$(jq --arg filter_by "$filter_by" <<<"$json" -cs '
   )
   | unique
   | map($meta[.])
-')"
+' || exit 1)"
 if [ "$(jq <<<"$vulns" -r 'length')" -le 0 ]; then
   printf '%s\n' "$out"
   exit 1
@@ -78,9 +89,11 @@ filtered="$(jq <<<"$vulns" -c '
     .id as $id
     | $exclude | index($id) | not
   ))
-')"
+' || exit 1)"
 
-text="$(jq <<<"$filtered" -r 'map("- \(.id) (aka \(.aliases | join(", ")))\n\n\t\(.details | gsub("\n"; "\n\t"))") | join("\n\n")')"
+# .aliases is absent on some OSV entries (e.g. GO-2026-5932), default to [] so
+# "join" does not choke on null ("Cannot iterate over null (null)").
+text="$(jq <<<"$filtered" -r 'map("- \(.id) (aka \((.aliases // []) | join(", ")))\n\n\t\(.details | gsub("\n"; "\n\t"))") | join("\n\n")' || exit 1)"
 
 if [ -z "$text" ]; then
   printf 'No vulnerabilities found.\n'


### PR DESCRIPTION
(cherry picked from commit 7f28873548bd3f3c7c80642447efe2db4221125a)

**What this PR does / why we need it**:

**Which issue this PR fixes**

backport https://github.com/Kong/kong-operator/pull/4844

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
