### PR TITLE
test(e2e): aigatewayagents e2e chainsaw tests

### DIFF
--- a/test/e2e/chainsaw/aigateway/agent-types/01-aigatewayagents.yaml
+++ b/test/e2e/chainsaw/aigateway/agent-types/01-aigatewayagents.yaml
@@ -1,0 +1,55 @@
+apiVersion: konnect.konghq.com/v1alpha1
+kind: AIGatewayAgent
+metadata:
+  name: ($http_agent_name)
+  namespace: ($namespace)
+spec:
+  aiGatewayRef:
+    type: namespacedRef
+    namespacedRef:
+      name: ($aigw_cp_name)
+  apiSpec:
+    name: ($http_agent_name)
+    displayName: ($http_agent_name)
+    type: http
+    enabled: Enabled
+    config:
+      url: (join('', ['http://', ($echo_deployment_name), '.', ($namespace), '.svc.cluster.local:1027']))
+      route:
+        paths:
+          - ($http_agent_route_path)
+        methods:
+          - GET
+          - POST
+        protocols:
+          - http
+          - https
+        stripPath: Enabled
+---
+apiVersion: konnect.konghq.com/v1alpha1
+kind: AIGatewayAgent
+metadata:
+  name: ($a2a_agent_name)
+  namespace: ($namespace)
+spec:
+  aiGatewayRef:
+    type: namespacedRef
+    namespacedRef:
+      name: ($aigw_cp_name)
+  apiSpec:
+    name: ($a2a_agent_name)
+    displayName: ($a2a_agent_name)
+    type: a2a
+    enabled: Enabled
+    config:
+      url: (join('', ['http://', ($echo_deployment_name), '.', ($namespace), '.svc.cluster.local:1027/a2a']))
+      route:
+        paths:
+          - ($a2a_agent_route_path)
+        methods:
+          - GET
+          - POST
+        protocols:
+          - http
+          - https
+        stripPath: Enabled

--- a/test/e2e/chainsaw/aigateway/agent-types/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/aigateway/agent-types/chainsaw-test.yaml
@@ -1,0 +1,184 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: aigateway-agent-types
+spec:
+  description: |
+    Stands up a Konnect AIGateway control plane, starts the shared go-echo backend
+    in the test namespace, creates HTTP and A2A AIGatewayAgent routes to that
+    backend's matching protocol surfaces, and verifies an in-cluster
+    AIGatewayDataPlane only returns the expected response shape for matching
+    request types.
+  bindings:
+    - name: test_name
+      value: ($namespace)
+    - name: konnect_token
+      value: (env('KONNECT_TOKEN'))
+    - name: konnect_url
+      value: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
+    - name: auth_secret_name
+      value: (join('-', [($test_name), 'konnect-auth-secret']))
+    - name: auth_secret_namespace
+      value: ($namespace)
+    - name: konnect_auth_name
+      value: (join('-', [($test_name), 'konnect-api-auth']))
+    - name: konnect_auth_namespace
+      value: ($namespace)
+    - name: aigw_cp_name
+      value: (join('-', [($test_name), 'cp']))
+    - name: aigw_cp_namespace
+      value: ($namespace)
+    - name: aigw_dp_name
+      value: (join('-', [($test_name), 'dp']))
+    - name: aigw_dp_image
+      value: (env('AIGW_DP_IMAGE') || 'kong/kong-ai-gateway-dev:2.0.1-rc.1')
+    - name: echo_deployment_name
+      value: echo
+    - name: echo_deployment_namespace
+      value: ($namespace)
+    - name: echo_deployment_replicas
+      value: 1
+    - name: http_agent_name
+      value: (join('-', [($test_name), 'http-agent']))
+    - name: http_agent_route_path
+      value: /http-agent
+    - name: a2a_agent_name
+      value: (join('-', [($test_name), 'a2a-agent']))
+    - name: a2a_agent_route_path
+      value: /a2a-agent
+  steps:
+    - name: Create-auth-secret
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAuthSecret.yaml
+    - name: Create-konnect-api-auth
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration-secretref.yaml
+    - name: Create-konnect-aigateway
+      bindings:
+        - name: auth_name
+          value: ($konnect_auth_name)
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAIGateway.yaml
+    - name: Start-echo-agent-backend
+      use:
+        template: ../../common/_step_templates/apply-assert-echoService.yaml
+    - name: Create-aigateway-agents
+      try:
+        - apply:
+            file: 01-aigatewayagents.yaml
+        - assert:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: AIGatewayAgent
+              metadata:
+                name: ($http_agent_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'Programmed']):
+                  - status: 'True'
+                (id != null): true
+        - assert:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: AIGatewayAgent
+              metadata:
+                name: ($a2a_agent_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'Programmed']):
+                  - status: 'True'
+                (id != null): true
+    - name: Create-aigateway-dataplane
+      bindings:
+        - name: namespace
+          value: ($namespace)
+      use:
+        template: ../../common/_step_templates/apply-assert-aigatewayDataPlane.yaml
+    - name: Drive-matching-http-agent-traffic
+      try:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+              - name: DP_SVC
+                value: (join('', [($aigw_dp_name), '-ingress']))
+              - name: METHOD
+                value: GET
+              - name: ROUTE_PATH
+                value: (join('', [($http_agent_route_path), '?details=true']))
+              - name: EXPECTED_BODY
+                value: Running on Pod
+            content: |
+              bash ../../common/scripts/aigw_agent_request.sh
+    - name: Drive-matching-a2a-agent-traffic
+      try:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+              - name: DP_SVC
+                value: (join('', [($aigw_dp_name), '-ingress']))
+              - name: METHOD
+                value: POST
+              - name: ROUTE_PATH
+                value: ($a2a_agent_route_path)
+              - name: REQUEST_BODY
+                value: '{"jsonrpc":"2.0","id":"e2e-a2a","method":"message/send","params":{"message":{"role":"user","parts":[{"kind":"text","text":"hello"}]}}}'
+              - name: EXPECTED_JSONRPC
+                value: "2.0"
+              - name: EXPECTED_JSON_ID
+                value: e2e-a2a
+              - name: EXPECTED_JSON_RESULT_TEXT
+                value: mock A2A agent response from go-echo
+            content: |
+              bash ../../common/scripts/aigw_agent_request.sh
+    - name: Reject-a2a-request-on-http-agent
+      try:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+              - name: DP_SVC
+                value: (join('', [($aigw_dp_name), '-ingress']))
+              - name: METHOD
+                value: POST
+              - name: ROUTE_PATH
+                value: ($http_agent_route_path)
+              - name: REQUEST_BODY
+                value: '{"jsonrpc":"2.0","id":"e2e-cross","method":"message/send","params":{"message":{"role":"user"}}}'
+              - name: EXPECTED_BODY
+                value: jsonrpc
+              - name: UNEXPECTED_BODY
+                value: mock A2A agent response from go-echo
+            content: |
+              bash ../../common/scripts/aigw_agent_request.sh
+    - name: Reject-http-request-on-a2a-agent
+      try:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+              - name: DP_SVC
+                value: (join('', [($aigw_dp_name), '-ingress']))
+              - name: METHOD
+                value: GET
+              - name: ROUTE_PATH
+                value: ($a2a_agent_route_path)
+              - name: EXPECTED_STATUS
+                value: "405"
+              - name: UNEXPECTED_BODY
+                value: Running on Pod
+            content: |
+              bash ../../common/scripts/aigw_agent_request.sh
+  catch:
+    - description: Capture debug snapshot on test failure.
+      script:
+        env:
+          - name: TEST_NAME
+            value: aigateway-agent-types
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: OPERATOR_NAMESPACE
+            value: kong-system
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh

--- a/test/e2e/chainsaw/common/scripts/aigw_agent_request.sh
+++ b/test/e2e/chainsaw/common/scripts/aigw_agent_request.sh
@@ -1,0 +1,106 @@
+#!/usr/bin/env bash
+# Drive an HTTP request through an AIGatewayDataPlane to an AIGatewayAgent.
+set -o errexit
+set -o nounset
+set -o pipefail
+
+NAMESPACE="${NAMESPACE}"
+DP_SVC="${DP_SVC}"
+METHOD="${METHOD}"
+ROUTE_PATH="${ROUTE_PATH}"
+EXPECTED_BODY="${EXPECTED_BODY:-}"
+UNEXPECTED_BODY="${UNEXPECTED_BODY:-}"
+EXPECTED_JSONRPC="${EXPECTED_JSONRPC:-}"
+EXPECTED_JSON_ID="${EXPECTED_JSON_ID:-}"
+EXPECTED_JSON_RESULT_TEXT="${EXPECTED_JSON_RESULT_TEXT:-}"
+REQUEST_BODY="${REQUEST_BODY:-}"
+CONTENT_TYPE="${CONTENT_TYPE:-application/json}"
+EXPECTED_STATUS="${EXPECTED_STATUS:-200}"
+EXPECTED_STATUS_NOT="${EXPECTED_STATUS_NOT:-}"
+PORT="${PORT:-443}"
+CURL_IMAGE="${CURL_IMAGE:-curlimages/curl:latest}"
+MAX_RETRIES="${MAX_RETRIES:-60}"
+RETRY_DELAY="${RETRY_DELAY:-5}"
+
+POD="aigw-agent-traffic-${RANDOM}"
+URL="https://${DP_SVC}.${NAMESPACE}.svc:${PORT}${ROUTE_PATH}"
+
+cleanup() {
+  kubectl -n "${NAMESPACE}" delete pod "${POD}" --ignore-not-found --grace-period=0 --force >/dev/null 2>&1 || true
+}
+trap cleanup EXIT
+
+kubectl -n "${NAMESPACE}" run "${POD}" \
+  --image="${CURL_IMAGE}" --image-pull-policy=IfNotPresent --restart=Never \
+  --command -- sleep 3600 >/dev/null
+kubectl -n "${NAMESPACE}" wait --for=condition=Ready "pod/${POD}" --timeout=120s >/dev/null
+
+response_matches() {
+  local code="$1"
+  local body="$2"
+
+  if [ -n "${EXPECTED_STATUS_NOT}" ]; then
+    [ -n "${code}" ] && [ "${code}" != "000" ] || return 1
+    [ "${code}" != "${EXPECTED_STATUS_NOT}" ] || return 1
+  else
+    [ "${code}" = "${EXPECTED_STATUS}" ] || return 1
+  fi
+
+  if [ -n "${EXPECTED_BODY}" ]; then
+    printf '%s' "${body}" | grep -q "${EXPECTED_BODY}" || return 1
+  fi
+
+  if [ -n "${UNEXPECTED_BODY}" ]; then
+    ! printf '%s' "${body}" | grep -q "${UNEXPECTED_BODY}" || return 1
+  fi
+
+  if [ -n "${EXPECTED_JSONRPC}${EXPECTED_JSON_ID}${EXPECTED_JSON_RESULT_TEXT}" ]; then
+    command -v jq >/dev/null 2>&1 || {
+      echo "jq is required for JSON response assertions" >&2
+      return 1
+    }
+    printf '%s' "${body}" | jq -e . >/dev/null || return 1
+  fi
+
+  if [ -n "${EXPECTED_JSONRPC}" ]; then
+    [ "$(printf '%s' "${body}" | jq -r '.jsonrpc')" = "${EXPECTED_JSONRPC}" ] || return 1
+  fi
+
+  if [ -n "${EXPECTED_JSON_ID}" ]; then
+    [ "$(printf '%s' "${body}" | jq -r '.id')" = "${EXPECTED_JSON_ID}" ] || return 1
+  fi
+
+  if [ -n "${EXPECTED_JSON_RESULT_TEXT}" ]; then
+    [ "$(printf '%s' "${body}" | jq -r '.result.parts[0].text')" = "${EXPECTED_JSON_RESULT_TEXT}" ] || return 1
+  fi
+
+  return 0
+}
+
+for ATTEMPT in $(seq 1 "${MAX_RETRIES}"); do
+  OUT="$(kubectl -n "${NAMESPACE}" exec "${POD}" -- sh -c \
+    'body="$1"
+     method="$2"
+     url="$3"
+     content_type="$4"
+     if [ -n "$body" ]; then
+       curl -sk -m 30 -o /tmp/body -w "%{http_code}" -X "$method" -H "Content-Type: $content_type" --data "$body" "$url"
+     else
+       curl -sk -m 30 -o /tmp/body -w "%{http_code}" -X "$method" "$url"
+     fi
+     echo
+     cat /tmp/body' \
+    sh "${REQUEST_BODY}" "${METHOD}" "${URL}" "${CONTENT_TYPE}" \
+    2>/dev/null || true)"
+  CODE="$(printf '%s\n' "${OUT}" | sed -n '1p')"
+  BODY="$(printf '%s\n' "${OUT}" | sed '1d')"
+  if response_matches "${CODE}" "${BODY}"; then
+    echo "ok: status=${CODE}"
+    exit 0
+  fi
+  echo "attempt ${ATTEMPT}/${MAX_RETRIES}: status='${CODE}' body='${BODY}'" >&2
+  sleep "${RETRY_DELAY}"
+done
+
+echo "FAILED: response did not match expectations after ${MAX_RETRIES} attempts (last status='${CODE}')" >&2
+exit 1


### PR DESCRIPTION
**What this PR does / why we need it**:

in #4490 & #4831 we supported AIGatewayAgent, this PR added e2e chainsaws tests for AIGatewayAgent.

The test stands up a Konnect AIGateway control plane, starts the shared go-echo backend in the test namespace, creates HTTP and A2A AIGatewayAgent routes to that backend's matching protocol surfaces, and verifies an in-cluster AIGatewayDataPlane only returns the expected response shape for matching request types.

**Which issue this PR fixes**

Fixes #4934 

**Special notes for your reviewer**:

This PR should be merged after https://github.com/Kong/go-echo/pull/71 merged and released, which added a2a serving for go-echo.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
