### PR TITLE
ci: fix dependabot grouping for github-actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -34,22 +34,11 @@ updates:
         patterns:
           - "sigs.k8s.io/gateway-api/*"
      # Specify a name for the group, which will be used in pull request titles and branch names.
-     actions:
-        # Define patterns to include dependencies in the group (based on dependency name).
-        applies-to: version-updates # Applies the group rule to version updates.
-        patterns:
-          - "actions/*"
-     # Specify a name for the group, which will be used in pull request titles and branch names.
      aws-sdk-go-v2:
         # Define patterns to include dependencies in the group (based on dependency name).
         applies-to: version-updates # Applies the group rule to version updates.
         patterns:
           - "github.com/aws/aws-sdk-go-v2/*"
-     codeql:
-        # Define patterns to include dependencies in the group (based on dependency name)
-        applies-to: version-updates # Applies the group rule to version updates
-        patterns:
-          - "github/codeql-action/*"
 - package-ecosystem: github-actions
   directory: /
   schedule:
@@ -58,6 +47,16 @@ updates:
   - github_actions
   cooldown:
     default-days: 2
+  # Create a group of dependencies to be updated together in one pull request
+  groups:
+     actions:
+        applies-to: version-updates # Applies the group rule to version updates.
+        patterns:
+          - "actions/*"
+     codeql:
+        applies-to: version-updates # Applies the group rule to version updates
+        patterns:
+          - "github/codeql-action/*"
 - package-ecosystem: docker
   directory: /
   schedule:


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
