### PR TITLE
tests: fix TestKongConsumer

### DIFF
--- a/test/envtest/konnect-api-gw/konnect_entities_kongconsumer_test.go
+++ b/test/envtest/konnect-api-gw/konnect_entities_kongconsumer_test.go
@@ -26,7 +26,6 @@ import (
 	configurationv1alpha1 "github.com/kong/kong-operator/v2/api/configuration/v1alpha1"
 	configurationv1beta1 "github.com/kong/kong-operator/v2/api/configuration/v1beta1"
 	konnectv1alpha1 "github.com/kong/kong-operator/v2/api/konnect/v1alpha1"
-	konnectv1alpha2 "github.com/kong/kong-operator/v2/api/konnect/v1alpha2"
 	"github.com/kong/kong-operator/v2/controller/konnect"
 	"github.com/kong/kong-operator/v2/modules/manager/logging"
 	"github.com/kong/kong-operator/v2/modules/manager/scheme"
@@ -501,12 +500,7 @@ func TestKongConsumer(t *testing.T) {
 			})).
 			Return(&sdkkonnectops.ListConsumerGroupsForConsumerResponse{}, nil)
 
-		cp = deploy.KonnectGatewayControlPlaneWithID(t, ctx, clientNamespaced, apiAuth,
-			func(obj client.Object) {
-				cpNew := obj.(*konnectv1alpha2.KonnectGatewayControlPlane)
-				cpNew.Name = cp.Name
-			},
-		)
+		cp = deploy.KonnectGatewayControlPlaneWithID(t, ctx, clientNamespaced, apiAuth)
 
 		t.Log("Patching KongConsumer to attach to new ControlPlane")
 		consumerToPatch := created.DeepCopy()


### PR DESCRIPTION
**What this PR does / why we need it**:

Don't reuse the same CP name in the test which would cause the upsert on consumer to not happen.

Example failure in CI: https://github.com/Kong/kong-operator/actions/runs/29257491748/job/86841652765?pr=4881

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
