### PR TITLE
test(e2e): add Chainsaw lifecycle test for AIGatewayDataPlane

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -850,6 +850,7 @@ test.e2e.chainsaw.prereq: ## Apply prerequisite fixtures for a chainsaw suite (u
 .PHONY: test.e2e.chainsaw
 test.e2e.chainsaw: chainsaw grpcurl ## Run chainsaw e2e tests.
 	GATEWAY_IMAGE=kong/kong-gateway:$(shell $(YQ) -ojson -r '.chainsaw.kong-ee' < $(TEST_DEPENDENCIES_FILE)) \
+	AIGW_DP_IMAGE=kong/kong-ai-gateway-dev:$(shell $(YQ) -ojson -r '.chainsaw.aigw-dp' < $(TEST_DEPENDENCIES_FILE)) \
 	GRPCURL_BIN=$(GRPCURL) \
 		$(CHAINSAW) test --config $(CHAINSAW_CONFIG) --quiet --test-dir $(CHAINSAW_TEST_DIR)
 

--- a/test/e2e/chainsaw/aigateway/ai-proxy/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/aigateway/ai-proxy/chainsaw-test.yaml
@@ -30,7 +30,7 @@ spec:
     - name: aigw_dp_name
       value: (join('-', [($test_name), 'dp']))
     - name: aigw_dp_image
-      value: (env('AIGW_DP_IMAGE') || 'kong/kong-ai-gateway-dev:2.0.1-rc.1')
+      value: (env('AIGW_DP_IMAGE'))
   steps:
     - name: Create-auth-secret
       use:

--- a/test/e2e/chainsaw/aigateway/aigatewaydataplane-lifecycle/03-aigatewaydataplane.yaml
+++ b/test/e2e/chainsaw/aigateway/aigatewaydataplane-lifecycle/03-aigatewaydataplane.yaml
@@ -1,0 +1,25 @@
+apiVersion: aigateway.konghq.com/v1alpha1
+kind: AIGatewayDataPlane
+metadata:
+  name: ($aigw_dp_name)
+  namespace: ($namespace)
+spec:
+  controlPlaneRef:
+    type: konnectNamespacedRef
+    konnectNamespacedRef:
+      name: ($aigw_cp_name)
+  deployment:
+    replicas: 1
+    podTemplateSpec:
+      spec:
+        containers:
+          - name: aigw
+            image: ($aigw_dp_image)
+  network:
+    services:
+      ingress:
+        type: LoadBalancer
+        ports:
+          - name: ingress
+            port: 443
+            targetPort: 8443

--- a/test/e2e/chainsaw/aigateway/aigatewaydataplane-lifecycle/03-assert-not-found.yaml
+++ b/test/e2e/chainsaw/aigateway/aigatewaydataplane-lifecycle/03-assert-not-found.yaml
@@ -1,0 +1,12 @@
+apiVersion: aigateway.konghq.com/v1alpha1
+kind: AIGatewayDataPlane
+metadata:
+  name: ($aigw_dp_name)
+  namespace: ($namespace)
+status:
+  (conditions[?type == 'KonnectAIGatewayResolved']):
+    - status: 'False'
+      reason: NotFound
+  (conditions[?type == 'Ready']):
+    - status: 'False'
+      reason: DependenciesNotReady

--- a/test/e2e/chainsaw/aigateway/aigatewaydataplane-lifecycle/05-assert-ready.yaml
+++ b/test/e2e/chainsaw/aigateway/aigatewaydataplane-lifecycle/05-assert-ready.yaml
@@ -1,0 +1,19 @@
+apiVersion: aigateway.konghq.com/v1alpha1
+kind: AIGatewayDataPlane
+metadata:
+  name: ($aigw_dp_name)
+  namespace: ($namespace)
+status:
+  (conditions[?type == 'KonnectAIGatewayResolved']):
+    - status: 'True'
+      reason: Resolved
+  (conditions[?type == 'CertificateProvisioned']):
+    - status: 'True'
+      reason: CertificateProvisioned
+  (conditions[?type == 'KonnectCertificateRegistered']):
+    - status: 'True'
+      reason: KonnectCertificateRegistered
+  (conditions[?type == 'Ready']):
+    - status: 'True'
+      reason: Ready
+  (readyReplicas > `0`): true

--- a/test/e2e/chainsaw/aigateway/aigatewaydataplane-lifecycle/07-assert-degraded.yaml
+++ b/test/e2e/chainsaw/aigateway/aigatewaydataplane-lifecycle/07-assert-degraded.yaml
@@ -1,0 +1,23 @@
+#
+# ponytail: finalizer gap (ref #16) — KonnectAIGateway can be deleted while
+# AIGatewayDataPlane still references it. A referencing finalizer on KonnectAIGateway
+# gated on an AIGatewayDataPlane list lookup would prevent orphaning. Add when
+# cross-resource protection is implemented in controller/aigateway/dataplane/controller.go.
+apiVersion: aigateway.konghq.com/v1alpha1
+kind: AIGatewayDataPlane
+metadata:
+  name: ($aigw_dp_name)
+  namespace: ($namespace)
+status:
+  (conditions[?type == 'KonnectAIGatewayResolved']):
+    - status: 'False'
+      reason: NotFound
+  (conditions[?type == 'CertificateProvisioned']):
+    - status: 'True'
+      reason: CertificateProvisioned
+  (conditions[?type == 'KonnectCertificateRegistered']):
+    - status: 'True'
+      reason: KonnectCertificateRegistered
+  (conditions[?type == 'Ready']):
+    - status: 'False'
+      reason: DependenciesNotReady

--- a/test/e2e/chainsaw/aigateway/aigatewaydataplane-lifecycle/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/aigateway/aigatewaydataplane-lifecycle/chainsaw-test.yaml
@@ -31,7 +31,7 @@ spec:
     - name: aigw_dp_name
       value: (join('-', [($test_name), 'dp']))
     - name: aigw_dp_image
-      value: (env('AIGW_DP_IMAGE') || 'kong/kong-ai-gateway-dev:2.0.1-rc.1')
+      value: (env('AIGW_DP_IMAGE'))
   steps:
     - name: Create-auth-secret
       use:

--- a/test/e2e/chainsaw/aigateway/aigatewaydataplane-lifecycle/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/aigateway/aigatewaydataplane-lifecycle/chainsaw-test.yaml
@@ -1,0 +1,83 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: aigatewaydataplane-lifecycle
+spec:
+  description: |
+    Lifecycle test for AIGatewayDataPlane cross-reference, condition correctness,
+    and watch reconciliation.
+    1. Creates DataPlane before its KonnectAIGateway → asserts KonnectAIGatewayResolved=False/NotFound.
+    2. Creates KonnectAIGateway → asserts watch fires → DataPlane reaches Ready=True.
+    3. Deletes KonnectAIGateway → asserts DataPlane conditions degrade
+  bindings:
+    - name: test_name
+      value: ($namespace)
+    - name: konnect_token
+      value: (env('KONNECT_TOKEN'))
+    - name: konnect_url
+      value: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
+    - name: auth_secret_name
+      value: (join('-', [($test_name), 'konnect-auth-secret']))
+    - name: auth_secret_namespace
+      value: ($namespace)
+    - name: konnect_auth_name
+      value: (join('-', [($test_name), 'konnect-api-auth']))
+    - name: konnect_auth_namespace
+      value: ($namespace)
+    - name: aigw_cp_name
+      value: (join('-', [($test_name), 'cp']))
+    - name: aigw_cp_namespace
+      value: ($namespace)
+    - name: aigw_dp_name
+      value: (join('-', [($test_name), 'dp']))
+    - name: aigw_dp_image
+      value: (env('AIGW_DP_IMAGE') || 'kong/kong-ai-gateway-dev:2.0.1-rc.1')
+  steps:
+    - name: Create-auth-secret
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAuthSecret.yaml
+    - name: Create-konnect-api-auth
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration-secretref.yaml
+    - name: Create-dataplane-before-parent
+      try:
+        - apply:
+            file: 03-aigatewaydataplane.yaml
+        - assert:
+            file: 03-assert-not-found.yaml
+    - name: Create-konnect-aigateway
+      bindings:
+        - name: auth_name
+          value: ($konnect_auth_name)
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAIGateway.yaml
+    - name: Assert-watch-fired
+      try:
+        - assert:
+            file: 05-assert-ready.yaml
+    - name: Delete-konnect-aigateway
+      bindings:
+        - name: resource_type
+          value: konnectaigateway
+        - name: resource_name
+          value: ($aigw_cp_name)
+        - name: resource_namespace
+          value: ($aigw_cp_namespace)
+      use:
+        template: ../../common/_step_templates/delete-resource-non-blocking.yaml
+    - name: Assert-dataplane-degraded
+      try:
+        - assert:
+            file: 07-assert-degraded.yaml
+  catch:
+    - description: Capture debug snapshot on test failure.
+      script:
+        env:
+          - name: TEST_NAME
+            value: aigatewaydataplane-lifecycle
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: OPERATOR_NAMESPACE
+            value: kong-system
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh

--- a/test/e2e/chainsaw/common/scripts/debug_snapshot.sh
+++ b/test/e2e/chainsaw/common/scripts/debug_snapshot.sh
@@ -96,13 +96,13 @@ for ns in ${ALL_NAMESPACES}; do
   capture_resource_group "${RESOURCES_FILE}" "${ns}" "Gateway API Resources" \
     "gateway-api"
 
-  # Kong Configuration resources
+  # Kong Configuration resources (base Kong gateway config only)
   capture_resource_group "${RESOURCES_FILE}" "${ns}" "Kong Configuration Resources" \
     "kongcertificates.configuration.konghq.com,kongsnis.configuration.konghq.com,kongroutes.configuration.konghq.com,kongservices.configuration.konghq.com,kongupstreams.configuration.konghq.com,kongtargets.configuration.konghq.com,kongreferencegrants.configuration.konghq.com,kongplugins.configuration.konghq.com,kongclusterplugins.configuration.konghq.com,kongconsumers.configuration.konghq.com,kongconsumergroups.configuration.konghq.com,kongupstreampolicies.configuration.konghq.com"
 
-  # Konnect resources (excluding KonnectAPIAuthConfiguration - captured separately with redaction)
+  # Konnect resources (base only - excluding KonnectAPIAuthConfiguration captured separately with redaction)
   capture_resource_group "${RESOURCES_FILE}" "${ns}" "Konnect Resources" \
-    "konnectgatewaycontrolplanes.konnect.konghq.com,konnectextensions.konnect.konghq.com,konnecteventgateways.konnect.konghq.com"
+    "konnectgatewaycontrolplanes.konnect.konghq.com,konnectextensions.konnect.konghq.com"
 
   # KonnectAPIAuthConfiguration with token redaction
   {
@@ -126,9 +126,13 @@ for ns in ${ALL_NAMESPACES}; do
   capture_resource_group "${RESOURCES_FILE}" "${ns}" "Gateway Operator Resources" \
     "gatewayconfigurations.gateway-operator.konghq.com,controlplanes.gateway-operator.konghq.com,dataplanes.gateway-operator.konghq.com,aigateways.gateway-operator.konghq.com,dataplanemetricsextensions.gateway-operator.konghq.com"
 
-  # Event Gateway resources
+  # Event Gateway resources (all related resources regardless of API group)
   capture_resource_group "${RESOURCES_FILE}" "${ns}" "Event Gateway Resources" \
-    "eventgatewaydataplanecertificates.configuration.konghq.com,kegdataplanes.eventgateway.konghq.com,eventgatewaybackendclusters.configuration.konghq.com,eventgatewayvirtualclusters.configuration.konghq.com,eventgatewaylisteners.configuration.konghq.com,eventgatewaylistenerpolicies.configuration.konghq.com,eventgatewayvirtualclusterconsumepolicies.configuration.konghq.com"
+    "kegdataplanes.eventgateway.konghq.com,konnecteventgateways.konnect.konghq.com,eventgatewaydataplanecertificates.configuration.konghq.com,eventgatewaybackendclusters.configuration.konghq.com,eventgatewayvirtualclusters.configuration.konghq.com,eventgatewaylisteners.configuration.konghq.com,eventgatewaylistenerpolicies.configuration.konghq.com,eventgatewayvirtualclusterconsumepolicies.configuration.konghq.com"
+
+  # AI Gateway resources (all related resources regardless of API group)
+  capture_resource_group "${RESOURCES_FILE}" "${ns}" "AI Gateway Resources" \
+    "aigatewaydataplanes.aigateway.konghq.com,konnectaigateways.konnect.konghq.com,aigatewaydataplanecertificates.configuration.konghq.com,aigatewaymodelproviders.konnect.konghq.com,aigatewaymodels.konnect.konghq.com,aigatewaypolicies.konnect.konghq.com,aigatewayconsumers.konnect.konghq.com,aigatewayconsumercredentials.konnect.konghq.com,aigatewayconsumergroups.konnect.konghq.com,aigatewayagents.konnect.konghq.com,aigatewaymcpservers.konnect.konghq.com,aigatewayidentityproviders.konnect.konghq.com"
 
   # Core Kubernetes resources
   capture_resource_group "${RESOURCES_FILE}" "${ns}" "Core Kubernetes Resources" \
@@ -181,7 +185,7 @@ for ns in ${ALL_NAMESPACES}; do
     echo ""
   } >> "${DESCRIBED_FILE}"
 
-  safe_kubectl "${DESCRIBED_FILE}" describe konnectgatewaycontrolplanes,konnectextensions,konnecteventgateways -n "${ns}"
+  safe_kubectl "${DESCRIBED_FILE}" describe konnectgatewaycontrolplanes,konnectextensions -n "${ns}"
 
   # Describe KonnectAPIAuthConfigurations with token redaction
   {
@@ -212,7 +216,15 @@ for ns in ${ALL_NAMESPACES}; do
     echo ""
   } >> "${DESCRIBED_FILE}"
 
-  safe_kubectl "${DESCRIBED_FILE}" describe kegdataplanes.eventgateway.konghq.com,eventgatewaybackendclusters,eventgatewayvirtualclusters,eventgatewaylisteners,eventgatewaylistenerpolicies,eventgatewayvirtualclusterconsumepolicies -n "${ns}"
+  safe_kubectl "${DESCRIBED_FILE}" describe kegdataplanes.eventgateway.konghq.com,konnecteventgateways,eventgatewaydataplanecertificates,eventgatewaybackendclusters,eventgatewayvirtualclusters,eventgatewaylisteners,eventgatewaylistenerpolicies,eventgatewayvirtualclusterconsumepolicies -n "${ns}"
+
+  {
+    echo ""
+    echo "=== AI Gateway Resources in ${ns} ==="
+    echo ""
+  } >> "${DESCRIBED_FILE}"
+
+  safe_kubectl "${DESCRIBED_FILE}" describe aigatewaydataplanes.aigateway.konghq.com,konnectaigateways,aigatewaydataplanecertificates,aigatewaymodelproviders,aigatewaymodels,aigatewaypolicies,aigatewayconsumers,aigatewayconsumercredentials,aigatewayconsumergroups,aigatewayagents,aigatewaymcpservers,aigatewayidentityproviders -n "${ns}"
 done
 
 # 3. Capture events in test namespaces

--- a/test/test_dependencies.yaml
+++ b/test/test_dependencies.yaml
@@ -28,3 +28,5 @@ envtests:
 chainsaw:
   # renovate: datasource=docker depName=kong/kong-gateway versioning=docker
   kong-ee: '3.14.0.9'
+  # renovate: datasource=docker depName=kong/kong-ai-gateway-dev versioning=docker
+  aigw-dp: '2.0.1-rc.1'


### PR DESCRIPTION


**What this PR does / why we need it**:

Covers the full lifecycle: DataPlane created before its KonnectAIGateway exists (Ready=False/DependenciesNotReady), becomes Ready once all dependencies are in place, then degrades back to Ready=False when the KonnectAIGateway is deleted.

Also adds missing AIGateway and EventGateway resources to the debug snapshot script, grouped by feature domain so all related resources appear together in failure artifacts.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
