### PR TITLE
chore: add cleanup for konnectaigateway

### DIFF
--- a/hack/cleanup/README.md
+++ b/hack/cleanup/README.md
@@ -13,6 +13,16 @@ The script will delete Konnect Control Planes that meet **all** of the following
 
 **Warning**: All Control Planes managed by Kong Operator (with label `k8s-kind:KonnectGatewayControlPlane`) in the configured Konnect organization will be pruned by this script.
 
+## Konnect AI Gateways Cleanup
+
+The script will delete Konnect AI Gateways that meet **all** of the following conditions:
+
+1. Has the label `k8s-kind:KonnectAIGateway` (automatically added by Kong Operator)
+2. Has a `test` label set
+3. Was created more than 1 hour ago
+
+**Warning**: All Konnect AI Gateways managed by Kong Operator (with label `k8s-kind:KonnectAIGateway`) and a `test` label in the configured Konnect organization will be pruned by this script.
+
 ## Usage
 
 ```bash

--- a/hack/cleanup/konnect_aigateways.go
+++ b/hack/cleanup/konnect_aigateways.go
@@ -75,10 +75,10 @@ func findOrphanedAIGateways(
 			log.Info("AIGateway has no creation timestamp, skipping", "name", aiGateway.Name)
 			continue
 		}
-		orphanedAfter := aiGateway.CreatedAt.Add(timeUntilControlPlaneOrphaned)
-		if !time.Now().After(orphanedAfter) {
+		orphanedTime := aiGateway.CreatedAt.Add(timeUntilControlPlaneOrphaned)
+		if orphanedTime.After(time.Now()) {
 			log.Info("AIGateway is not old enough to be considered orphaned, skipping",
-				"name", aiGateway.Name, "created_at", aiGateway.CreatedAt,
+				"name", aiGateway.Name, "id", aiGateway.ID, "created_at", aiGateway.CreatedAt,
 			)
 			continue
 		}

--- a/hack/cleanup/konnect_aigateways.go
+++ b/hack/cleanup/konnect_aigateways.go
@@ -1,0 +1,111 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"time"
+
+	sdkkonnectgo "github.com/Kong/sdk-konnect-go"
+	"github.com/go-logr/logr"
+
+	"github.com/kong/kong-operator/v2/controller/konnect/ops"
+)
+
+const (
+	konnectAIGatewaysLimit = int64(100)
+
+	k8sKindKonnectAIGateway = "KonnectAIGateway"
+)
+
+// cleanupKonnectAIGateways deletes orphaned AI Gateways created by the tests.
+func cleanupKonnectAIGateways(sdk *sdkkonnectgo.SDK) func(ctx context.Context, log logr.Logger) error {
+	return func(ctx context.Context, log logr.Logger) error {
+		orphanedAIGateways, err := findOrphanedAIGateways(ctx, log, sdk.AIGateways)
+		if err != nil {
+			return fmt.Errorf("failed to find orphaned AI Gateways: %w", err)
+		}
+		if err := deleteAIGateways(ctx, log, sdk.AIGateways, orphanedAIGateways); err != nil {
+			return fmt.Errorf("failed to delete AI Gateways: %w", err)
+		}
+		return nil
+	}
+}
+
+// findOrphanedAIGateways finds AI Gateways that were created by Kong Operator (e.g. from e2e tests)
+// and are older than timeUntilControlPlaneOrphaned.
+func findOrphanedAIGateways(
+	ctx context.Context,
+	log logr.Logger,
+	sdk *sdkkonnectgo.AIGateways,
+) ([]string, error) {
+	seenAIGatewayIDs := make(map[string]struct{})
+	var orphanedAIGateways []string
+
+	response, err := sdk.ListAiGateways(ctx, new(konnectAIGatewaysLimit), nil)
+	if err != nil {
+		return nil, fmt.Errorf("failed to list AI Gateways: %w", err)
+	}
+	if response.ListAIGatewaysResponse == nil {
+		body, err := io.ReadAll(response.RawResponse.Body)
+		if err != nil {
+			body = []byte(err.Error())
+		}
+		return nil, fmt.Errorf("failed to list AI Gateways, status: %d, body: %s", response.GetStatusCode(), body)
+	}
+
+	for _, aiGateway := range response.ListAIGatewaysResponse.Data {
+		// Skip if we've already processed this AI Gateway.
+		if _, seen := seenAIGatewayIDs[aiGateway.ID]; seen {
+			continue
+		}
+		seenAIGatewayIDs[aiGateway.ID] = struct{}{}
+
+		if aiGateway.Labels[ops.KubernetesKindLabelKey] != k8sKindKonnectAIGateway {
+			log.Info("AIGateway not managed by Kong Operator, skipping", "name", aiGateway.Name)
+			continue
+		}
+		if aiGateway.Labels["test"] == "" {
+			log.Info("AIGateway has no test label, skipping", "name", aiGateway.Name)
+			continue
+		}
+
+		if aiGateway.CreatedAt.IsZero() {
+			log.Info("AIGateway has no creation timestamp, skipping", "name", aiGateway.Name)
+			continue
+		}
+		orphanedAfter := aiGateway.CreatedAt.Add(timeUntilControlPlaneOrphaned)
+		if !time.Now().After(orphanedAfter) {
+			log.Info("AIGateway is not old enough to be considered orphaned, skipping",
+				"name", aiGateway.Name, "created_at", aiGateway.CreatedAt,
+			)
+			continue
+		}
+		orphanedAIGateways = append(orphanedAIGateways, aiGateway.ID)
+	}
+
+	return orphanedAIGateways, nil
+}
+
+// deleteAIGateways deletes AI Gateways by their IDs.
+func deleteAIGateways(
+	ctx context.Context,
+	log logr.Logger,
+	sdk *sdkkonnectgo.AIGateways,
+	aiGatewayIDs []string,
+) error {
+	if len(aiGatewayIDs) < 1 {
+		log.Info("No AI Gateways to clean up")
+		return nil
+	}
+
+	var errs []error
+	for _, id := range aiGatewayIDs {
+		log.Info("Deleting AI Gateway", "ID", id)
+		if _, err := sdk.DeleteAiGateway(ctx, id); err != nil {
+			errs = append(errs, fmt.Errorf("failed to delete AI Gateway %s: %w", id, err))
+		}
+	}
+	return errors.Join(errs...)
+}

--- a/hack/cleanup/main.go
+++ b/hack/cleanup/main.go
@@ -13,6 +13,11 @@
 // 1. It has a label `created_in_tests` with value `true`.
 // 2. It was created more than 1h ago.
 //
+// An AI Gateway is considered orphaned when all conditions are satisfied:
+// 1. It has a label `k8s-kind` with value `KonnectAIGateway` (automatically added by Kong Operator).
+// 2. It has a `test` label set.
+// 3. It was created more than 1h ago.
+//
 // A system account is considered orphaned when all conditions are satisfied:
 // 1. It is not managed by Konnect.
 // 2. It was created more than 1h ago.
@@ -135,6 +140,7 @@ func resolveCleanupFuncs(mode string) ([]func(context.Context, logr.Logger) erro
 
 		return []func(context.Context, logr.Logger) error{
 			cleanupKonnectEventGateways(sdk),
+			cleanupKonnectAIGateways(sdk),
 			cleanupKonnectControlPlanes(sdk),
 			cleanupKonnectSystemAccounts(sdk),
 		}, nil
@@ -147,6 +153,7 @@ func resolveCleanupFuncs(mode string) ([]func(context.Context, logr.Logger) erro
 		return []func(context.Context, logr.Logger) error{
 			cleanupGKEClusters,
 			cleanupKonnectEventGateways(sdk),
+			cleanupKonnectAIGateways(sdk),
 			cleanupKonnectControlPlanes(sdk),
 			cleanupKonnectSystemAccounts(sdk),
 		}, nil

--- a/test/e2e/chainsaw/common/_step_templates/apply-assert-konnectAIGateway.yaml
+++ b/test/e2e/chainsaw/common/_step_templates/apply-assert-konnectAIGateway.yaml
@@ -4,6 +4,8 @@
 #   - aigw_cp_name: Name of the KonnectAIGateway to create.
 #   - aigw_cp_namespace: Namespace where the KonnectAIGateway will be created.
 #   - auth_name: Name of the KonnectAPIAuthConfiguration to reference (same namespace).
+#   - test_name: Identifier used for the "test" label so the hack/cleanup script can find and
+#     prune this AI Gateway from Konnect if it's left behind by a cancelled/crashed test run.
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: StepTemplate
 metadata:
@@ -22,6 +24,8 @@ spec:
               name: ($aigw_cp_name)
               displayName: ($aigw_cp_name)
               description: AIGateway chainsaw e2e control plane
+              labels:
+                test: ($test_name)
             konnect:
               authRef:
                 name: ($auth_name)

--- a/test/e2e/chainsaw/konnect/konnectaigateway_cross-namespace/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/konnect/konnectaigateway_cross-namespace/chainsaw-test.yaml
@@ -75,6 +75,8 @@ spec:
                 apiSpec:
                   name: ($aigw0_name)
                   displayName: ($aigw0_name)
+                  labels:
+                    test: konnectaigateway-cross-namespace
                 konnect:
                   authRef:
                     name: ($auth0_name)
@@ -151,6 +153,8 @@ spec:
                 apiSpec:
                   name: ($aigw_name)
                   displayName: ($aigw_name)
+                  labels:
+                    test: konnectaigateway-cross-namespace
                 konnect:
                   authRef:
                     name: ($auth_name)


### PR DESCRIPTION
**What this PR does / why we need it**:

There are AI Gateway control plane orphaned in Konnect when e2e tests cancelled.
This PR added a `test` label for all places applying KonnectAIGateway, implemented cleaning KonnectAIGateway in Konnect. The clean up is a part of cleanup workflow (once a hour).

**Which issue this PR fixes**

Fixes #4938 

**Special notes for your reviewer**:

Konnect AI Gateways that meet **all** of the following conditions will be deleted
1. Has the label `k8s-kind:KonnectAIGateway` (automatically added by Kong Operator)
2. Has a `test` label set
3. Was created more than 1 hour ago

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
