### PR TITLE
fix(hybridgateway): merge hybrid-routes annotation atomically in SSA Apply

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -154,6 +154,15 @@
 
 ### Fixes
 
+- Hybridgateway: fix HTTPRoute/TLSRoute finalizer getting permanently stuck when
+  the Konnect controller updated a child resource (KongRoute, KongService,
+  KongUpstream) between Phase 4b's GET and its optimistic-lock PATCH, causing a
+  conflict error and requeue. If a route deletion event was processed before the
+  requeue fired, `HandleOrphanedResource` found the `hybrid-routes` annotation
+  absent and skipped cleanup, leaving the finalizer blocked indefinitely. The fix
+  bakes the annotation into the SSA Apply in Phase 4, eliminating the separate
+  Phase 4b PATCH and the race window it created.
+  [#4944](https://github.com/Kong/kong-operator/pull/4944)
 - AIGateway/EventGateway: fix `AIGatewayDataPlane` and `KegDataPlane` not setting
   `Ready=False` when a dependency condition is unmet. `ensureReadyStatus` was only
   called on the happy path, so early-return branches (e.g. referenced

--- a/controller/hybridgateway/controller.go
+++ b/controller/hybridgateway/controller.go
@@ -249,25 +249,6 @@ func (r *HybridGatewayReconciler[t, tPtr]) Reconcile(ctx context.Context, obj tP
 		return ctrl.Result{}, err
 	}
 
-	// Phase 4b: Atomically record this Route in the hybrid-routes annotation of every shared Kong
-	// resource. This runs regardless of whether enforceState applied or is waiting, so resources
-	// created in this (or an earlier) reconcile are tracked promptly and concurrent Routes sharing
-	// a resource do not clobber each other's entry.
-	annotationsMissing, err := reconcileSharedRouteAnnotations[t, tPtr](ctx, r.Client, logger, conv)
-	if err != nil {
-		if result, ok := requeueOnConflict(err, logger, "Hybrid-routes annotation sync conflicted, requeueing"); ok {
-			return result, nil
-		}
-		r.eventRecorder.Eventf(
-			obj,
-			corev1.EventTypeWarning,
-			eventconst.EventReasonStateEnforcementFailed,
-			"Hybrid-routes annotation sync failed: %v",
-			err,
-		)
-		return ctrl.Result{}, err
-	}
-
 	// Only emit success event if state was actually changed.
 	if applied {
 		r.eventRecorder.Eventf(
@@ -284,16 +265,6 @@ func (r *HybridGatewayReconciler[t, tPtr]) Reconcile(ctx context.Context, obj tP
 	// schedule a short requeue as a safety net in case watch events are delayed.
 	if waiting {
 		return ctrl.Result{RequeueAfter: requeueWhileWaiting}, nil
-	}
-
-	// In steady state (enforceState applied nothing and is not waiting) every desired Kong resource
-	// existed when enforceState ran. If the annotation sync above then found one missing, another
-	// Route deleted the shared resource in the window before this Route recorded itself. No watch
-	// event will re-trigger this Route (the delete event maps via the annotation, which no longer
-	// lists it), so requeue to let the next reconcile recreate the resource and re-record this Route.
-	if annotationsMissing {
-		log.Debug(logger, "Shared Kong resource missing during annotation sync, requeueing to recreate")
-		return ctrl.Result{RequeueAfter: ctrlconsts.RequeueWithoutBackoff}, nil
 	}
 
 	// Phase 4.5: Readiness gate before orphan cleanup.

--- a/controller/hybridgateway/metadata/annotation_sync.go
+++ b/controller/hybridgateway/metadata/annotation_sync.go
@@ -25,8 +25,7 @@ import (
 // To avoid that, the annotation is reconciled here with an optimistic-lock patch instead of
 // through server-side apply. Conflicts are surfaced to the reconciler, which requeues and
 // re-evaluates against the latest object. The desired objects applied by the reconciler
-// intentionally omit this annotation (see stripHybridRouteAnnotations) so that server-side apply
-// never owns or overwrites it.
+// include this annotation with the merged value so that server-side apply owns and persists it atomically.
 //
 // It is a no-op when the route kind is not tracked via the hybrid-routes annotation or when the
 // route is already present.

--- a/controller/hybridgateway/reconciler_utils.go
+++ b/controller/hybridgateway/reconciler_utils.go
@@ -3,6 +3,7 @@ package hybridgateway
 import (
 	"context"
 	"fmt"
+	"strings"
 
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
@@ -26,39 +27,9 @@ import (
 )
 
 // hybridGatewayStateFieldManager is intentionally distinct from the historical
-// gateway-operator manager so omitting hybrid-routes annotations from apply
-// payloads does not delete annotation fields that older reconciles owned.
+// gateway-operator manager so that annotation fields owned by older reconciles
+// are not lost during an upgrade.
 const hybridGatewayStateFieldManager = controllerpkgssa.FieldManager + "-hybridgateway"
-
-// hybridRouteAnnotationKeys are the annotation keys whose value accumulates Route references
-// across multiple owners (multiple Routes, or multiple rules of the same Route, that share a Kong
-// resource). They are reconciled out-of-band with an optimistic-lock read-modify-write (see
-// metadata.AnnotationManager.EnsureRouteInAnnotation) instead of through server-side apply, which
-// cannot merge concurrent writers of a single comma-separated value. They must therefore be
-// stripped from the desired object before applying so SSA never owns or clobbers them.
-var hybridRouteAnnotationKeys = []string{
-	consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation,
-	consts.GatewayOperatorHybridRoutesTLSRouteAnnotation,
-}
-
-// stripHybridRouteAnnotations removes the accumulated hybrid-routes annotations from obj so that
-// server-side apply does not manage them. See hybridRouteAnnotationKeys for the rationale.
-func stripHybridRouteAnnotations(obj *unstructured.Unstructured) {
-	anns := obj.GetAnnotations()
-	if len(anns) == 0 {
-		return
-	}
-	changed := false
-	for _, k := range hybridRouteAnnotationKeys {
-		if _, ok := anns[k]; ok {
-			delete(anns, k)
-			changed = true
-		}
-	}
-	if changed {
-		obj.SetAnnotations(anns)
-	}
-}
 
 // translate performs the full translation process using the provided APIConverter.
 // Returns an integer representing the number of translated resources, and an error if the translation fails.
@@ -107,6 +78,9 @@ func enforceState[t converter.RootObject](ctx context.Context, cl client.Client,
 	}
 
 	log.Debug(logger, "Retrieved desired objects for enforcement", "objectCount", len(desiredObjects))
+
+	// Compute the hybrid-routes annotation info for the root object once, outside the per-resource loop.
+	routeAnnotationKey, routeRef := hybridRouteAnnotationInfo(conv.GetRootObject())
 
 	// Build lookup maps once so that per-object gating checks are O(1) instead of O(n).
 	desiredUpstreamNames := make(map[string]struct{}, len(desiredObjects))
@@ -275,11 +249,6 @@ func enforceState[t converter.RootObject](ctx context.Context, cl client.Client,
 		}
 		log.Debug(logger, "Processing desired object", "index", i, "kind", desired.GetKind(), "name", desired.GetName())
 
-		// The hybrid-routes annotation is reconciled out-of-band with an optimistic-lock
-		// read-modify-write (see reconcileSharedRouteAnnotations); strip it here so server-side
-		// apply never owns or overwrites the shared, accumulated value.
-		stripHybridRouteAnnotations(&desired)
-
 		// Get the existing object by name from the API server.
 		existing := &unstructured.Unstructured{}
 		existing.SetGroupVersionKind(desired.GetObjectKind().GroupVersionKind())
@@ -288,6 +257,14 @@ func enforceState[t converter.RootObject](ctx context.Context, cl client.Client,
 			Namespace: desired.GetNamespace(),
 			Name:      desired.GetName(),
 		}, existing)
+
+		// Merge the hybrid-routes annotation from the live object into the desired state so that SSA
+		// owns and persists it atomically with the rest of the resource. When the object does not
+		// exist yet, existing carries no annotations and the annotation is initialised to just this
+		// route ref. Gateway converters (empty routeAnnotationKey) skip this step.
+		if routeAnnotationKey != "" {
+			mergeHybridRouteAnnotation(&desired, existing, routeAnnotationKey, routeRef)
+		}
 
 		namespacedNameDesired := client.ObjectKeyFromObject(&desired)
 		namespacedNameExisting := client.ObjectKeyFromObject(existing)
@@ -410,53 +387,39 @@ func upstreamTargetsProgrammed(ctx context.Context, cl client.Client, targets []
 	return true, nil
 }
 
-// reconcileSharedRouteAnnotations atomically ensures the root Route is recorded in the
-// hybrid-routes annotation of every Kong resource the converter currently desires.
-//
-// These annotations are intentionally not applied via server-side apply (see
-// stripHybridRouteAnnotations) because a single comma-separated value cannot be merged across
-// concurrent writers. Instead each entry is added here with an optimistic-lock read-modify-write
-// that is safe against Routes (or rules) sharing the same Kong resource reconciling concurrently.
-//
-// A desired resource that does not exist yet is reported back via the missing return value rather
-// than failing: on early reconciles enforceState has not created it yet, but in steady state
-// (enforceState applied nothing and is not waiting) a missing resource means another Route deleted
-// it concurrently before this Route recorded itself. The caller requeues in that case to recreate
-// it, because no watch event will re-trigger this Route on its own.
-func reconcileSharedRouteAnnotations[t converter.RootObject, tPtr converter.RootObjectPtr[t]](
-	ctx context.Context,
-	cl client.Client,
-	logger logr.Logger,
-	conv converter.APIConverter[t],
-) (missing bool, err error) {
-	logger = logger.WithValues("phase", "route-annotation-sync")
-
-	rootObj := conv.GetRootObject()
-	var rootObjPtr tPtr
-	switch v := any(&rootObj).(type) {
-	case tPtr:
-		rootObjPtr = v
-	default:
-		return false, fmt.Errorf("failed to convert root object to pointer type: got %T, expected %T", &rootObj, rootObjPtr)
+// hybridRouteAnnotationInfo returns the annotation key and route reference string for the given
+// root object. Returns empty strings for Gateway objects, which do not use hybrid-routes annotations.
+func hybridRouteAnnotationInfo[t converter.RootObject](obj t) (annotationKey, routeRef string) {
+	switch o := any(obj).(type) {
+	case gwtypes.HTTPRoute:
+		return consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation, o.Namespace + "/" + o.Name
+	case gwtypes.TLSRoute:
+		return consts.GatewayOperatorHybridRoutesTLSRouteAnnotation, o.Namespace + "/" + o.Name
 	}
+	return "", ""
+}
 
-	desiredObjects, err := conv.GetOutputStore(ctx, logger)
-	if err != nil {
-		return false, fmt.Errorf("failed to get desired objects from converter for annotation sync: %w", err)
+// mergeHybridRouteAnnotation merges routeRef into the hybrid-routes annotation on desired,
+// seeding from existing's annotation to preserve other routes' entries.
+func mergeHybridRouteAnnotation(desired, existing *unstructured.Unstructured, annotationKey, routeRef string) {
+	current := ""
+	if anns := existing.GetAnnotations(); len(anns) > 0 {
+		current = anns[annotationKey]
 	}
-
-	am := metadata.NewAnnotationManager(logger)
-	for _, desired := range desiredObjects {
-		objMissing, err := am.EnsureRouteInAnnotation(
-			ctx, cl, desired.GroupVersionKind(), client.ObjectKeyFromObject(&desired), rootObjPtr,
-		)
-		if err != nil {
-			return false, fmt.Errorf("failed to ensure hybrid-routes annotation on %s %s: %w",
-				desired.GetKind(), client.ObjectKeyFromObject(&desired), err)
+	merged := current
+	if !strings.Contains(","+current+",", ","+routeRef+",") {
+		if current != "" {
+			merged = current + "," + routeRef
+		} else {
+			merged = routeRef
 		}
-		missing = missing || objMissing
 	}
-	return missing, nil
+	anns := desired.GetAnnotations()
+	if anns == nil {
+		anns = make(map[string]string)
+	}
+	anns[annotationKey] = merged
+	desired.SetAnnotations(anns)
 }
 
 // enforceStatus updates the status of the root object managed by the provided APIConverter.

--- a/controller/hybridgateway/reconciler_utils_test.go
+++ b/controller/hybridgateway/reconciler_utils_test.go
@@ -2335,91 +2335,103 @@ func TestRemoveFinalizerIfNotManaged_Gateway(t *testing.T) {
 	}
 }
 
-func TestStripHybridRouteAnnotations(t *testing.T) {
+func TestHybridRouteAnnotationInfo(t *testing.T) {
 	tests := []struct {
-		name string
-		in   map[string]string
-		want map[string]string
+		name    string
+		wantKey string
+		wantRef string
+		runFn   func() (string, string)
 	}{
 		{
-			name: "removes hybrid-routes keys, keeps others",
-			in: map[string]string{
-				consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "ns/r1,ns/r2",
-				consts.GatewayOperatorHybridRoutesTLSRouteAnnotation:  "ns/t1",
-				consts.GatewayOperatorHybridGatewaysAnnotation:        "ns/gw",
-				"unrelated": "keep",
-			},
-			want: map[string]string{
-				consts.GatewayOperatorHybridGatewaysAnnotation: "ns/gw",
-				"unrelated": "keep",
+			name:    "HTTPRoute returns HTTPRoute annotation key and ns/name",
+			wantKey: consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation,
+			wantRef: "ns/route-a",
+			runFn: func() (string, string) {
+				return hybridRouteAnnotationInfo(gwtypes.HTTPRoute{
+					ObjectMeta: metav1.ObjectMeta{Name: "route-a", Namespace: "ns"},
+				})
 			},
 		},
 		{
-			name: "no annotations is a no-op",
-			in:   nil,
-			want: nil,
+			name:    "TLSRoute returns TLSRoute annotation key and ns/name",
+			wantKey: consts.GatewayOperatorHybridRoutesTLSRouteAnnotation,
+			wantRef: "ns/tls-route",
+			runFn: func() (string, string) {
+				return hybridRouteAnnotationInfo(gwtypes.TLSRoute{
+					ObjectMeta: metav1.ObjectMeta{Name: "tls-route", Namespace: "ns"},
+				})
+			},
+		},
+		{
+			name:    "Gateway returns empty strings",
+			wantKey: "",
+			wantRef: "",
+			runFn: func() (string, string) {
+				return hybridRouteAnnotationInfo(gwtypes.Gateway{
+					ObjectMeta: metav1.ObjectMeta{Name: "gw", Namespace: "ns"},
+				})
+			},
 		},
 	}
-
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			obj := &unstructured.Unstructured{}
-			obj.SetGroupVersionKind(schema.GroupVersionKind{Group: "configuration.konghq.com", Version: "v1alpha1", Kind: "KongUpstream"})
-			if tt.in != nil {
-				obj.SetAnnotations(tt.in)
-			}
-			stripHybridRouteAnnotations(obj)
-			assert.Equal(t, tt.want, obj.GetAnnotations())
+			key, ref := tt.runFn()
+			assert.Equal(t, tt.wantKey, key)
+			assert.Equal(t, tt.wantRef, ref)
 		})
 	}
 }
 
-func TestReconcileSharedRouteAnnotations(t *testing.T) {
-	ctx := context.Background()
-	logger := logr.Discard()
+func TestMergeHybridRouteAnnotation(t *testing.T) {
 	upstreamGVK := schema.GroupVersionKind{Group: "configuration.konghq.com", Version: "v1alpha1", Kind: "KongUpstream"}
+	annotationKey := consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation
+	routeRef := "ns/route-a"
 
-	root := gwtypes.HTTPRoute{
-		TypeMeta: metav1.TypeMeta{Kind: "HTTPRoute", APIVersion: "gateway.networking.k8s.io/v1"},
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      "route-a",
-			Namespace: "ns",
+	tests := []struct {
+		name           string
+		existingAnns   map[string]string
+		desiredAnns    map[string]string
+		wantAnnotation string
+	}{
+		{
+			name:           "empty existing sets annotation to routeRef",
+			existingAnns:   nil,
+			desiredAnns:    nil,
+			wantAnnotation: "ns/route-a",
+		},
+		{
+			name:           "existing has other routes, appends routeRef",
+			existingAnns:   map[string]string{annotationKey: "ns/other-route"},
+			desiredAnns:    nil,
+			wantAnnotation: "ns/other-route,ns/route-a",
+		},
+		{
+			name:           "routeRef already present, annotation is unchanged",
+			existingAnns:   map[string]string{annotationKey: "ns/other-route,ns/route-a"},
+			desiredAnns:    nil,
+			wantAnnotation: "ns/other-route,ns/route-a",
+		},
+		{
+			name:           "desired already has unrelated annotations, only hybrid-routes key is set",
+			existingAnns:   nil,
+			desiredAnns:    map[string]string{"unrelated": "keep"},
+			wantAnnotation: "ns/route-a",
 		},
 	}
-	routeKey := client.ObjectKeyFromObject(&root).String()
-
-	// Desired KongUpstream (without the hybrid-routes annotation, as applied by enforceState).
-	desired := newUnstructured("ns", "up-1", upstreamGVK, nil)
-
-	// One shared upstream already exists with another Route recorded; the absent upstream is not
-	// created here but is reported back via the missing return value so the reconciler can requeue.
-	existing := newUnstructured("ns", "up-1", upstreamGVK, nil)
-	existing.SetAnnotations(map[string]string{
-		consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "ns/other-route",
-	})
-
-	missingDesired := newUnstructured("ns", "up-missing", upstreamGVK, nil)
-
-	cl := fake.NewClientBuilder().WithScheme(scheme.Get()).WithObjects(&existing).Build()
-	fakeConv := &fakeHTTPRouteConverter{
-		root:    root,
-		desired: []unstructured.Unstructured{desired, missingDesired},
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			desired := newUnstructured("ns", "up-1", upstreamGVK, nil)
+			if tt.desiredAnns != nil {
+				desired.SetAnnotations(tt.desiredAnns)
+			}
+			existing := newUnstructured("ns", "up-1", upstreamGVK, nil)
+			if tt.existingAnns != nil {
+				existing.SetAnnotations(tt.existingAnns)
+			}
+			mergeHybridRouteAnnotation(&desired, &existing, annotationKey, routeRef)
+			assert.Equal(t, tt.wantAnnotation, desired.GetAnnotations()[annotationKey])
+		})
 	}
-
-	annotationsMissing, err := reconcileSharedRouteAnnotations[gwtypes.HTTPRoute, *gwtypes.HTTPRoute](ctx, cl, logger, fakeConv)
-	require.NoError(t, err)
-	assert.True(t, annotationsMissing, "absent desired upstream must be reported missing so the reconciler requeues")
-
-	got := &unstructured.Unstructured{}
-	got.SetGroupVersionKind(upstreamGVK)
-	require.NoError(t, cl.Get(ctx, client.ObjectKey{Namespace: "ns", Name: "up-1"}, got))
-	assert.Equal(t, "ns/other-route,"+routeKey, got.GetAnnotations()[consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation])
-
-	// The missing upstream must not have been created.
-	missing := &unstructured.Unstructured{}
-	missing.SetGroupVersionKind(upstreamGVK)
-	err = cl.Get(ctx, client.ObjectKey{Namespace: "ns", Name: "up-missing"}, missing)
-	assert.True(t, apierrors.IsNotFound(err))
 }
 
 func TestRequeueOnConflict(t *testing.T) {


### PR DESCRIPTION




**What this PR does / why we need it**:

The hybrid-routes annotation was previously written in a separate Phase 4b step using an optimistic-lock PATCH (MergeFromWithOptimisticLock) after the SSA Apply. This opened a race window: the Konnect controller would update the just-created KongRoute between Phase 4b's GET and PATCH, bumping its resource version and causing a conflict error. On the deletion path, if the HTTPRoute deletion event was processed before the requeue fired, handleDeletion ran with no annotation on the KongRoute, causing HandleOrphanedResource to skip-delete it and leaving the route stuck with a deletionTimestamp indefinitely.

Instead of stripping hybrid-routes annotations from the desired state and patching them separately, enforceState now reads the live object's annotation, merges the current route ref in, and includes the merged value in the SSA Apply payload. SSA field ownership semantics mean the Konnect controller's updates (Konnect IDs, status) cannot conflict with the annotation field, so the race window is eliminated.

Phase 4b (reconcileSharedRouteAnnotations) and stripHybridRouteAnnotations are removed. Two new helpers replace them: hybridRouteAnnotationInfo (computes the annotation key and route ref from the root object type) and mergeHybridRouteAnnotation (merges a route ref into the annotation seeded from the live object to preserve other routes' entries).

**Which issue this PR fixes**

Fixes #4943 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
