### PR TITLE
test(e2e): Add chainsaw test for AIGatewayPolicy

### DIFF
--- a/test/e2e/chainsaw/aigateway/aigateway-policy/00-assert-aigateway-policy-programmed.yaml
+++ b/test/e2e/chainsaw/aigateway/aigateway-policy/00-assert-aigateway-policy-programmed.yaml
@@ -1,0 +1,14 @@
+# Assert the AIGatewayPolicy to be programmed.
+# Required bindings:
+#  - namespace: The namespace where the AIGatewayPolicy resource was created.
+#  - aigw_policy_name: The name of the AIGatewayPolicy resource to be asserted.
+
+apiVersion: konnect.konghq.com/v1alpha1
+kind: AIGatewayPolicy
+metadata:
+  name: ($aigw_policy_name)
+  namespace: ($namespace)
+status:
+  (conditions[?type == 'Programmed']):
+    - status: 'True'
+  (id != null): true

--- a/test/e2e/chainsaw/aigateway/aigateway-policy/01-aigateway-policy-inline-config.yaml
+++ b/test/e2e/chainsaw/aigateway/aigateway-policy/01-aigateway-policy-inline-config.yaml
@@ -1,0 +1,28 @@
+# An AIGatewayPolicy resource with inline config that adds a custom header to the response of an API.
+# Required bindings:
+#   - namespace: The namespace where the AIGatewayPolicy resource will be created.
+#   - aigw_cp_name: The name of the AIGateway control plane resource to which this policy will be applied. Should be in the same namespace as the AIGatewayPolicy resource.
+#   - aigw_policy_name: The name of the AIGatewayPolicy resource to be created.
+apiVersion: konnect.konghq.com/v1alpha1
+kind: AIGatewayPolicy
+metadata:
+  name: ($aigw_policy_name)
+  namespace: ($namespace)
+spec:
+  aiGatewayRef:
+    type: namespacedRef
+    namespacedRef:
+      name: ($aigw_cp_name)
+      namespace: ($namespace)
+  apiSpec:
+    type: response-transformer
+    displayName: "AIGateway Policy Response Transformer"
+    enabled: "Enabled"
+    global: "Disabled"
+    name: ($aigw_policy_name)
+    config:
+      type: inline
+      value:
+        add:
+          headers:
+            - "Modified-By:Kong-Operator-Chainsaw-Test"

--- a/test/e2e/chainsaw/aigateway/aigateway-policy/01-aigateway-policy-inline-config.yaml
+++ b/test/e2e/chainsaw/aigateway/aigateway-policy/01-aigateway-policy-inline-config.yaml
@@ -25,4 +25,4 @@ spec:
       value:
         add:
           headers:
-            - "Modified-By:Kong-Operator-Chainsaw-Test"
+            - "Modified-By-Policy-Inline:Kong-Operator-Chainsaw-Test"

--- a/test/e2e/chainsaw/aigateway/aigateway-policy/02-aigateway-policy-secretRef-config.yaml
+++ b/test/e2e/chainsaw/aigateway/aigateway-policy/02-aigateway-policy-secretRef-config.yaml
@@ -1,0 +1,43 @@
+# An AIGatewayPolicy resource with inline config that adds a custom header to the response of an API.
+# Required bindings:
+#   - namespace: The namespace where the AIGatewayPolicy resource will be created.
+#   - aigw_cp_name: The name of the AIGateway control plane resource to which this policy will be applied. Should be in the same namespace as the AIGatewayPolicy resource.
+#   - aigw_policy_name: The name of the AIGatewayPolicy resource to be created.
+#   - aigw_policy_secretref_name: The name of the secret resource that contains the config for this AIGatewayPolicy resource. Should be in the same namespace as the AIGatewayPolicy resource.
+apiVersion: konnect.konghq.com/v1alpha1
+kind: AIGatewayPolicy
+metadata:
+  name: ($aigw_policy_name)
+  namespace: ($namespace)
+spec:
+  aiGatewayRef:
+    type: namespacedRef
+    namespacedRef:
+      name: ($aigw_cp_name)
+      namespace: ($namespace)
+  apiSpec:
+    type: response-transformer
+    displayName: "AIGateway Policy Response Transformer"
+    enabled: "Enabled"
+    global: "Disabled"
+    name: ($aigw_policy_name)
+    config:
+      type: secretRef
+      secretRef:
+        name: ($aigw_policy_secretref_name)
+        key: config
+
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ($aigw_policy_secretref_name)
+  namespace: ($namespace)
+  labels:
+    konghq.com/secret: "true"
+type: Opaque
+stringData:
+  config: |
+    add:
+      headers:
+        - "Modified-By:Kong-Operator-Chainsaw-Test"

--- a/test/e2e/chainsaw/aigateway/aigateway-policy/02-aigateway-policy-secretRef-config.yaml
+++ b/test/e2e/chainsaw/aigateway/aigateway-policy/02-aigateway-policy-secretRef-config.yaml
@@ -40,4 +40,4 @@ stringData:
   config: |
     add:
       headers:
-        - "Modified-By:Kong-Operator-Chainsaw-Test"
+        - "Modified-By-Policy-Secretref:Kong-Operator-Chainsaw-Test"

--- a/test/e2e/chainsaw/aigateway/aigateway-policy/03-aigateway-model-referencing-the-policy.yaml
+++ b/test/e2e/chainsaw/aigateway/aigateway-policy/03-aigateway-model-referencing-the-policy.yaml
@@ -1,0 +1,72 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openai-provider-credentials
+  namespace: ($namespace)
+  labels:
+    konghq.com/secret: "true"
+type: Opaque
+stringData:
+  apikey: test-ai-gateway-key
+---
+apiVersion: konnect.konghq.com/v1alpha1
+kind: AIGatewayModelProvider
+metadata:
+  name: openai-provider
+  namespace: ($namespace)
+spec:
+  aiGatewayRef:
+    type: namespacedRef
+    namespacedRef:
+      name: ($aigw_cp_name)
+  apiSpec:
+    type: openai
+    openai:
+      name: openai-provider
+      displayName: OpenAI (mock)
+      config:
+        auth:
+          headers:
+            - name: apikey
+              value:
+                type: secretRef
+                secretRef:
+                  name: openai-provider-credentials
+                  key: apikey
+---
+apiVersion: konnect.konghq.com/v1alpha1
+kind: AIGatewayModel
+metadata:
+  name: aigw11-model
+  namespace: ($namespace)
+spec:
+  aiGatewayRef:
+    type: namespacedRef
+    namespacedRef:
+      name: ($aigw_cp_name)
+  apiSpec:
+    type: model
+    model:
+      name: aigw11-model
+      displayName: AI GW 1.1 mock model
+      enabled: Enabled
+      formats:
+        - type: openai
+      capabilities:
+        - generate
+      config:
+        model:
+          alias: qwen2.5:0.5b
+          nameHeader: Enabled
+          policies:
+            - ($aigw_policy_name)
+        route:
+          paths:
+            - /aigw11/chat
+      targets:
+        - name: qwen2.5:0.5b
+          provider: openai-provider
+          config:
+            type: openai
+            openai:
+              upstreamURL: http://kong-mock.kong-aigateway-mock.svc.cluster.local:8000/provider-a

--- a/test/e2e/chainsaw/aigateway/aigateway-policy/03-aigateway-model-referencing-the-policy.yaml
+++ b/test/e2e/chainsaw/aigateway/aigateway-policy/03-aigateway-model-referencing-the-policy.yaml
@@ -66,7 +66,9 @@ spec:
           namespace: ($namespace)
       targets:
         - name: qwen2.5:0.5b
-          provider: openai-provider
+          provider:
+            name: openai-provider
+            namespace: ($namespace)
           config:
             type: openai
             openai:

--- a/test/e2e/chainsaw/aigateway/aigateway-policy/03-aigateway-model-referencing-the-policy.yaml
+++ b/test/e2e/chainsaw/aigateway/aigateway-policy/03-aigateway-model-referencing-the-policy.yaml
@@ -58,11 +58,12 @@ spec:
         model:
           alias: qwen2.5:0.5b
           nameHeader: Enabled
-          policies:
-            - ($aigw_policy_name)
         route:
           paths:
             - /aigw11/chat
+      policies:
+        - name: ($aigw_policy_name)
+          namespace: ($namespace)
       targets:
         - name: qwen2.5:0.5b
           provider: openai-provider

--- a/test/e2e/chainsaw/aigateway/aigateway-policy/04-update-secret-for-aigateway-policy-secretRef-config.yaml
+++ b/test/e2e/chainsaw/aigateway/aigateway-policy/04-update-secret-for-aigateway-policy-secretRef-config.yaml
@@ -1,0 +1,13 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: ($aigw_policy_secretref_name)
+  namespace: ($namespace)
+  labels:
+    konghq.com/secret: "true"
+type: Opaque
+stringData:
+  config: |
+    add:
+      headers:
+        - "Modified-By-Policy-Secretref-Updated:Kong-Operator-Chainsaw-Test"

--- a/test/e2e/chainsaw/aigateway/aigateway-policy/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/aigateway/aigateway-policy/chainsaw-test.yaml
@@ -1,0 +1,64 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: aigateway-policy
+spec:
+  description: |
+    Konnect AIGateway - Policy. Stands up the Konnect AIGateway control plane
+    and creates policies to test the AIGatewayPolicy CRD. Then check for the policies
+    on Konnect to validate that they were created successfully.
+  bindings:
+    - name: test_name
+      value: ($namespace)
+    - name: konnect_token
+      value: (env('KONNECT_TOKEN'))
+    - name: konnect_url
+      value: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
+    - name: auth_secret_name
+      value: (join('-', [($test_name), 'konnect-auth-secret']))
+    - name: auth_secret_namespace
+      value: ($namespace)
+    - name: konnect_auth_name
+      value: (join('-', [($test_name), 'konnect-api-auth']))
+    - name: konnect_auth_namespace
+      value: ($namespace)
+    - name: aigw_cp_name
+      value: (join('-', [($test_name), 'cp']))
+    - name: aigw_cp_namespace
+      value: ($namespace)
+  steps:
+    - name: Create-auth-secret
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAuthSecret.yaml
+    - name: Create-konnect-api-auth
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration-secretref.yaml
+    - name: Create-konnect-aigateway
+      bindings:
+        - name: auth_name
+          value: ($konnect_auth_name)
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAIGateway.yaml
+    - name: Create-aigateway-policy
+      bindings:
+        - name: aigw_policy_name
+          value: (join('-', [($test_name), 'policy-inline-config']))
+      try:
+        - apply:
+            file: 01-aigateway-policy-inline-config.yaml
+        - assert:
+            file: 00-assert-aigateway-policy-programmed.yaml
+    # TODO: Add a step to attach the policy to an API and verify that the policy is applied correctly.
+    - name: Create-aigateway-policy-secretRef-config.yaml
+      bindings:
+        - name: aigw_policy_name
+          value: (join('-', [($test_name), 'policy-secretref-config']))
+        - name: aigw_policy_secretref_name
+          value: (join('-', [($test_name), 'policy-secretref-config-secret']))
+      try:
+        - apply:
+            file: 02-aigateway-policy-secretRef-config.yaml
+        - assert:
+            file: 00-assert-aigateway-policy-programmed.yaml
+     # TODO: Add a step to attach the policy to an API and verify that the policy is applied correctly.
+     # TODO: Add a step to update the SecretRef config and verify that the policy is updated correctly.

--- a/test/e2e/chainsaw/aigateway/aigateway-policy/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/aigateway/aigateway-policy/chainsaw-test.yaml
@@ -26,6 +26,10 @@ spec:
       value: (join('-', [($test_name), 'cp']))
     - name: aigw_cp_namespace
       value: ($namespace)
+    - name: aigw_dp_name
+      value: (join('-', [($test_name), 'dp']))
+    - name: aigw_dp_image
+      value: (env('AIGW_DP_IMAGE'))
   steps:
     - name: Create-auth-secret
       use:
@@ -39,6 +43,12 @@ spec:
           value: ($konnect_auth_name)
       use:
         template: ../../common/_step_templates/apply-assert-konnectAIGateway.yaml
+    - name: Create-aigateway-dataplane
+      bindings:
+        - name: namespace
+          value: ($namespace)
+      use:
+        template: ../../common/_step_templates/apply-assert-aigatewayDataPlane.yaml
     - name: Create-aigateway-policy
       bindings:
         - name: aigw_policy_name
@@ -48,7 +58,29 @@ spec:
             file: 01-aigateway-policy-inline-config.yaml
         - assert:
             file: 00-assert-aigateway-policy-programmed.yaml
-    # TODO: Add a step to attach the policy to an API and verify that the policy is applied correctly.
+    - name: Create-aigateway-model-provider-referencing-the-policy
+      bindings:
+        - name: aigw_policy_name
+          value: (join('-', [($test_name), 'policy-inline-config']))
+      try:
+        - apply:
+            file: 03-aigateway-model-referencing-the-policy.yaml
+    - name: Verify-aigateway-policy-inline-config-is-applied
+      try:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+              - name: DP_SVC
+                value: (join('', [($aigw_dp_name), '-ingress']))
+              - name: ROUTE_PATH
+                value: /aigw11/chat
+              - name: MODEL_ALIAS
+                value: qwen2.5:0.5b
+              - name: EXPECT_HEADER
+                value: "Modified-By-Policy-Inline"
+            content: |
+              bash ../../common/scripts/aigw_chat_completion.sh
     - name: Create-aigateway-policy-secretRef-config.yaml
       bindings:
         - name: aigw_policy_name
@@ -60,5 +92,61 @@ spec:
             file: 02-aigateway-policy-secretRef-config.yaml
         - assert:
             file: 00-assert-aigateway-policy-programmed.yaml
-     # TODO: Add a step to attach the policy to an API and verify that the policy is applied correctly.
-     # TODO: Add a step to update the SecretRef config and verify that the policy is updated correctly.
+    - name: Update-aigateway-model-to-reference-the-new-policy
+      bindings:
+        - name: aigw_policy_name
+          value: (join('-', [($test_name), 'policy-secretref-config']))
+      try:
+        - apply:
+            file: 03-aigateway-model-referencing-the-policy.yaml
+    - name: Verify-aigateway-policy-secretRef-config-is-applied
+      try:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+              - name: DP_SVC
+                value: (join('', [($aigw_dp_name), '-ingress']))
+              - name: ROUTE_PATH
+                value: /aigw11/chat
+              - name: MODEL_ALIAS
+                value: qwen2.5:0.5b
+              - name: EXPECT_HEADER
+                value: "Modified-By-Policy-Secretref"
+            content: |
+              bash ../../common/scripts/aigw_chat_completion.sh
+    - name: Update-secret-to-change-the-policy-config
+      bindings:
+        - name: aigw_policy_secretref_name
+          value: (join('-', [($test_name), 'policy-secretref-config-secret']))
+      try:
+        - apply:
+            file: 04-update-secret-for-aigateway-policy-secretRef-config.yaml
+    - name: Verify-aigateway-policy-secretRef-config-is-applied-after-secret-update
+      try:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+              - name: DP_SVC
+                value: (join('', [($aigw_dp_name), '-ingress']))
+              - name: ROUTE_PATH
+                value: /aigw11/chat
+              - name: MODEL_ALIAS
+                value: qwen2.5:0.5b
+              - name: EXPECT_HEADER
+                value: "Modified-By-Policy-Secretref-Updated"
+            content: |
+              bash ../../common/scripts/aigw_chat_completion.sh
+  catch:
+    - description: Capture debug snapshot on test failure.
+      script:
+        env:
+          - name: TEST_NAME
+            value: aigateway-ai-policy
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: OPERATOR_NAMESPACE
+            value: kong-system
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh

--- a/test/e2e/chainsaw/aigateway/aigateway-policy/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/aigateway/aigateway-policy/chainsaw-test.yaml
@@ -49,7 +49,8 @@ spec:
           value: ($namespace)
       use:
         template: ../../common/_step_templates/apply-assert-aigatewayDataPlane.yaml
-    - name: Create-aigateway-policy
+    - name: Create-aigateway-policy-with-inline-config
+      description: Create an AIGatewayPolicy resource with inline config that adds a custom header to the response of an API.
       bindings:
         - name: aigw_policy_name
           value: (join('-', [($test_name), 'policy-inline-config']))
@@ -58,7 +59,8 @@ spec:
             file: 01-aigateway-policy-inline-config.yaml
         - assert:
             file: 00-assert-aigateway-policy-programmed.yaml
-    - name: Create-aigateway-model-provider-referencing-the-policy
+    - name: Create-aigateway-model-referencing-the-policy
+      description: Create an AIGatewayModel that references the AIGatewayPolicy created in the previous step.
       bindings:
         - name: aigw_policy_name
           value: (join('-', [($test_name), 'policy-inline-config']))
@@ -66,6 +68,7 @@ spec:
         - apply:
             file: 03-aigateway-model-referencing-the-policy.yaml
     - name: Verify-aigateway-policy-inline-config-is-applied
+      description: Verify that the AIGatewayPolicy with inline config is applied by checking for the custom header in the response of an API.
       try:
         - script:
             env:
@@ -81,7 +84,8 @@ spec:
                 value: "Modified-By-Policy-Inline"
             content: |
               bash ../../common/scripts/aigw_chat_completion.sh
-    - name: Create-aigateway-policy-secretRef-config.yaml
+    - name: Create-aigateway-policy-secretRef-config
+      description: Create an AIGatewayPolicy resource with secretRef config that adds a custom header to the response of an API.
       bindings:
         - name: aigw_policy_name
           value: (join('-', [($test_name), 'policy-secretref-config']))
@@ -100,6 +104,7 @@ spec:
         - apply:
             file: 03-aigateway-model-referencing-the-policy.yaml
     - name: Verify-aigateway-policy-secretRef-config-is-applied
+      description: Verify that the AIGatewayPolicy with secretRef config is applied by checking for the custom header in the response of an API.
       try:
         - script:
             env:
@@ -116,6 +121,7 @@ spec:
             content: |
               bash ../../common/scripts/aigw_chat_completion.sh
     - name: Update-secret-to-change-the-policy-config
+      description: Update the secret referenced by the AIGatewayPolicy with secretRef config to change the custom header value in the response of an API.
       bindings:
         - name: aigw_policy_secretref_name
           value: (join('-', [($test_name), 'policy-secretref-config-secret']))
@@ -123,6 +129,7 @@ spec:
         - apply:
             file: 04-update-secret-for-aigateway-policy-secretRef-config.yaml
     - name: Verify-aigateway-policy-secretRef-config-is-applied-after-secret-update
+      description: Verify that the AIGatewayPolicy with secretRef config is applied after the secret update by checking for the updated custom header in the response of an API.
       try:
         - script:
             env:

--- a/test/e2e/chainsaw/aigateway/aigateway-policy/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/aigateway/aigateway-policy/chainsaw-test.yaml
@@ -138,6 +138,60 @@ spec:
                 value: "Modified-By-Policy-Secretref-Updated"
             content: |
               bash ../../common/scripts/aigw_chat_completion.sh
+    - name: Delete-aigateway-model-and-policies-and-wait-for-konnect-cleanup
+      description: |
+        Explicitly delete the AIGatewayModel first (it references both policies
+        and the provider by name), then the provider and both AIGatewayPolicy
+        resources, waiting for each to be fully removed (Konnect-side finalizer
+        cleared) before the implicit end-of-test cleanup runs. Doing this inside
+        try: - in referrer-before-referee order - instead of relying on
+        chainsaw's default reverse-creation-order cleanup avoids deleting a
+        policy/provider while the model still references it, and ensures the
+        top-level catch: fires and captures a debug snapshot if any Konnect-side
+        deletion hangs.
+      try:
+        - delete:
+            ref:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: AIGatewayModel
+              name: aigw11-model
+              namespace: ($namespace)
+        - error:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: AIGatewayModel
+              metadata:
+                namespace: ($namespace)
+        - delete:
+            ref:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: AIGatewayModelProvider
+              name: openai-provider
+              namespace: ($namespace)
+        - delete:
+            ref:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: AIGatewayPolicy
+              name: (join('-', [($test_name), 'policy-inline-config']))
+              namespace: ($namespace)
+        - delete:
+            ref:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: AIGatewayPolicy
+              name: (join('-', [($test_name), 'policy-secretref-config']))
+              namespace: ($namespace)
+        - error:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: AIGatewayModelProvider
+              metadata:
+                namespace: ($namespace)
+        - error:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha1
+              kind: AIGatewayPolicy
+              metadata:
+                namespace: ($namespace)
   catch:
     - description: Capture debug snapshot on test failure.
       script:


### PR DESCRIPTION
**What this PR does / why we need it**:

Add e2e chainsw tests for `AIGatewayPolicy`:

- Create an `AIGatewayPolicy` with inline config and wait for it programmed
- Create an `AIGatewayModel` using the policy and verify that the policy is applied
- Create another `AIGatewayPolicy` with secretRef config and wait for it programmed
- Update the `AIGatewayModel` to reference the new policy and verify that the new policy applied
- Update the referenced `Secret` and verify that the change of the policy is applied
- Delete the resources in refernce order

**Which issue this PR fixes**

Fixes #4935 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
