### PR TITLE
chore: bump default AI GW to 2.0.1-rc.3

### DIFF
--- a/.github/workflows/__crdvalidation_tests.yaml
+++ b/.github/workflows/__crdvalidation_tests.yaml
@@ -17,7 +17,8 @@ env:
 
 jobs:
   crd-validation-tests:
-    timeout-minutes: ${{ fromJSON(vars.GHA_DEFAULT_TIMEOUT || 10) }}
+    # NOTE: This job can take longer than the default timeout so we bump it to 15 minutes.
+    timeout-minutes: ${{ fromJSON(vars.GHA_EXTENDED_TIMEOUT_MINUTES || 15) }}
     runs-on: ubuntu-latest
     name: ${{ matrix.crd_validation_test.name }} - ${{ matrix.cluster_version }}
     strategy:

--- a/pkg/consts/aigateway.go
+++ b/pkg/consts/aigateway.go
@@ -47,9 +47,11 @@ const (
 	RelatedImageAIGatewayDataPlaneEnvVar = "RELATED_IMAGE_AIGW"
 
 	// DefaultAIGatewayDataPlaneBaseImage is the base image name for the AI Gateway container.
-	DefaultAIGatewayDataPlaneBaseImage = "kong/kong-ai-gateway"
+	// The current AI GW 2.0 is in Beta, so we will temporarily use this registry.
+	// Once the GA version is released, we will switch back to kong/kong-ai-gateway.
+	DefaultAIGatewayDataPlaneBaseImage = "kong/kong-ai-gateway-dev"
 	// DefaultAIGatewayDataPlaneTag is the default image tag for the AI Gateway container.
-	DefaultAIGatewayDataPlaneTag = "2.0.0" // renovate: datasource=docker depName=kong/kong-ai-gateway
+	DefaultAIGatewayDataPlaneTag = "2.0.1-rc.3" // renovate: datasource=docker depName=kong/kong-ai-gateway-dev
 	// DefaultAIGatewayDataPlaneImage is the full default image reference for the AI Gateway container.
 	DefaultAIGatewayDataPlaneImage = DefaultAIGatewayDataPlaneBaseImage + ":" + DefaultAIGatewayDataPlaneTag
 )

--- a/test/test_dependencies.yaml
+++ b/test/test_dependencies.yaml
@@ -29,4 +29,4 @@ chainsaw:
   # renovate: datasource=docker depName=kong/kong-gateway versioning=docker
   kong-ee: '3.14.0.9'
   # renovate: datasource=docker depName=kong/kong-ai-gateway-dev versioning=docker
-  aigw-dp: '2.0.1-rc.2'
+  aigw-dp: '2.0.1-rc.3'


### PR DESCRIPTION
**What this PR does / why we need it**:

The current AI GW 2.0 is in Beta, so we will temporarily use this registry.
Once the GA version is released, we will switch back to `kong/kong-ai-gateway`.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
