### PR TITLE
chore(changelog): automate backport-safe changelog via per-PR fragments

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,8 +6,10 @@ Fixes #
 
 **Special notes for your reviewer**:
 
-**PR Readiness Checklist**:
+## Changelog
 
-Complete these before marking the PR as `ready to review`:
+- [ ] This PR has a changelog fragment, or is exempt (non-releasable type, or `skip-changelog` label).
 
-- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
+The changelog bot adds `changelog/unreleased/kong-operator/<PR>.yaml` automatically
+from your Conventional Commit title. Edit it if the one-line title is not enough.
+Do **not** edit `CHANGELOG.md` directly. See `changelog/README.md`.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -10,6 +10,6 @@ Fixes #
 
 - [ ] This PR has a changelog fragment, or is exempt (non-releasable type, or `skip-changelog` label).
 
-The changelog bot adds `changelog/unreleased/kong-operator/<PR>.yaml` automatically
+The changelog bot adds `changelog/unreleased/kong-operator/<PR>.yml` automatically
 from your Conventional Commit title. Edit it if the one-line title is not enough.
 Do **not** edit `CHANGELOG.md` directly. See `changelog/README.md`.

--- a/.github/workflows/__release-workflow.yaml
+++ b/.github/workflows/__release-workflow.yaml
@@ -285,6 +285,13 @@ jobs:
       - name: Update version in chart and its tests
         run: make test.charts.golden.update
 
+      # Assemble CHANGELOG.md from unreleased fragments and archive them.
+      - name: Generate changelog from fragments
+        env:
+          GITHUB_TOKEN: ${{ secrets.gh-pat }}
+        run: |
+          make changelog VERSION=${{ needs.semver.outputs.fullversion }}
+
       # The generated bundle is part of the release PR.
       # This is done locally in this job, to avoid including unintended changes.
       # If anything needs to be fixed before the release, it should be done on the base branch
@@ -319,6 +326,8 @@ jobs:
             VERSION
             config
             charts
+            CHANGELOG.md
+            changelog
           commit-message: "${{ env.MSG }}"
           committer: Kong's Team k8s bot <team-k8s+github-bot@konghq.com>
           author: Kong's Team k8s bot <team-k8s+github-bot@konghq.com>

--- a/.github/workflows/__verify.yaml
+++ b/.github/workflows/__verify.yaml
@@ -40,6 +40,10 @@ jobs:
             make-target: verify.crd-breaking-changes
             fetch_depth: 0
             lint-cache: false
+          - name: changelog
+            make-target: verify.changelog
+            fetch_depth: 1
+            lint-cache: false
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0

--- a/.github/workflows/__verify.yaml
+++ b/.github/workflows/__verify.yaml
@@ -41,7 +41,7 @@ jobs:
             fetch_depth: 0
             lint-cache: false
           - name: changelog
-            make-target: verify.changelog
+            make-target: test.changelog
             fetch_depth: 1
             lint-cache: false
     steps:

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,7 +38,10 @@ jobs:
           fetch-depth: 50
       - id: check-files
         name: Check if only documentation files changed
-        run: ./scripts/check-docs-only-changes.sh ${{ github.event.pull_request.base.sha || 'HEAD~1' }} ${{ github.sha }}
+        # merge_group.base_sha fallback: in a merge-queue group with several PRs, the
+        # branch is base + one squash commit per PR, so HEAD~1..HEAD would only see the
+        # LAST PR's diff and could wrongly mark the whole group as docs-only/skippable.
+        run: ./scripts/check-docs-only-changes.sh ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || 'HEAD~1' }} ${{ github.sha }}
 
   build:
     needs: [check-docs-only]
@@ -68,17 +71,8 @@ jobs:
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
-      - name: Check if docs-only changes
-        run: |
-          if [[ "${{ needs.check-docs-only.outputs.docs_only }}" == "true" ]]; then
-            echo "Only documentation files were changed, skipping build"
-            exit 0
-          fi
-
-      - name: Check build result
-        if: ${{ needs.check-docs-only.outputs.docs_only != 'true' }}
+      - name: Check results
         run: |
           if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
-            echo "Build job failed or was cancelled."
-            exit 1
+            echo "Some jobs failed or were cancelled."; exit 1
           fi

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -64,7 +64,11 @@ jobs:
   # This job exists to satisfy the required check when only docs change
   passed:
     runs-on: ubuntu-latest
-    needs: [check-docs-only]
+    # `build` was missing here (pre-existing bug): with only `check-docs-only`
+    # in `needs`, `contains(needs.*.result, 'failure')` below can never see a
+    # build failure, so `passed` could go green while the actual build job
+    # failed.
+    needs: [check-docs-only, build]
     if: always()
     steps:
       - name: Harden Runner

--- a/.github/workflows/changelog-fragment.yaml
+++ b/.github/workflows/changelog-fragment.yaml
@@ -1,0 +1,144 @@
+name: Changelog fragment
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited, labeled, unlabeled]
+
+permissions:
+  contents: read
+
+jobs:
+  scaffold:
+    name: Scaffold changelog fragment
+    runs-on: ubuntu-latest
+    # Skip forks: the bot cannot push to a fork's head branch.
+    if: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+    permissions:
+      contents: write
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          token: ${{ secrets.PAT_GITHUB }}
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Compute fragment from PR title
+        id: frag
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const pr = context.payload.pull_request;
+            const labels = (pr.labels || []).map(l => l.name);
+            if (labels.includes('skip-changelog')) {
+              core.info('skip-changelog label present; skipping');
+              core.setOutput('create', 'false');
+              return;
+            }
+            const title = pr.title || '';
+            const m = title.match(/^(\w+)(?:\(([^)]*)\))?(!)?:\s*(.+)$/);
+            if (!m) {
+              core.info('PR title is not conventional; leaving to verify gate');
+              core.setOutput('create', 'false');
+              return;
+            }
+            const [, ccType, ccScope, bang, subject] = m;
+            const body = pr.body || '';
+            const typeMap = { feat: 'feature', fix: 'bugfix', perf: 'performance' };
+            const skip = ['docs','test','chore','ci','refactor','style','build'];
+            let type = typeMap[ccType];
+            if ((ccScope || '').split(',').map(s=>s.trim()).includes('deps')) type = 'dependency';
+            if (bang || /BREAKING CHANGE/.test(body)) type = 'breaking_change';
+            if (!type) {
+              if (skip.includes(ccType)) { core.info(`non-releasable type '${ccType}'`); }
+              else { core.info(`unmapped type '${ccType}'`); }
+              core.setOutput('create', 'false');
+              return;
+            }
+            const allowedScopes = ['dataplane','controlplane','gateway','hybridgateway','konnect','aigateway','eventgateway','crd','deps'];
+            const scope = (ccScope && allowedScopes.includes(ccScope)) ? ccScope : '';
+            core.setOutput('create', 'true');
+            core.setOutput('number', String(pr.number));
+            core.setOutput('type', type);
+            core.setOutput('scope', scope);
+            core.setOutput('message', subject);
+
+      - name: Write and push fragment if missing
+        if: ${{ steps.frag.outputs.create == 'true' }}
+        env:
+          NUM: ${{ steps.frag.outputs.number }}
+          TYPE: ${{ steps.frag.outputs.type }}
+          SCOPE: ${{ steps.frag.outputs.scope }}
+          MESSAGE: ${{ steps.frag.outputs.message }}
+        run: |
+          set -euo pipefail
+          dir="changelog/unreleased/kong-operator"
+          file="${dir}/${NUM}.yaml"
+          if [ -f "$file" ]; then
+            echo "Fragment $file already exists; leaving author edits intact."
+            exit 0
+          fi
+          mkdir -p "$dir"
+          {
+            printf 'message: %s\n' "$MESSAGE"
+            printf 'type: %s\n' "$TYPE"
+            if [ -n "$SCOPE" ]; then printf 'scope: %s\n' "$SCOPE"; fi
+          } > "$file"
+          git config user.name "Kong's Team k8s bot"
+          git config user.email "team-k8s+github-bot@konghq.com"
+          git add "$file"
+          git commit -m "chore(changelog): add fragment for #${NUM}"
+          git push origin "HEAD:${GITHUB_HEAD_REF}"
+
+  changelog-present:
+    name: changelog-present
+    runs-on: ubuntu-latest
+    needs: scaffold
+    # Always evaluate the gate (also on forks, where scaffold is skipped).
+    if: ${{ always() }}
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+
+      - name: Require a fragment unless exempt
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
+        with:
+          script: |
+            const { execSync } = require('child_process');
+            const pr = context.payload.pull_request;
+            const labels = (pr.labels || []).map(l => l.name);
+            if (labels.includes('skip-changelog')) {
+              core.info('skip-changelog label present; gate passes');
+              return;
+            }
+            const title = pr.title || '';
+            const m = title.match(/^(\w+)(?:\(([^)]*)\))?(!)?:\s*(.+)$/);
+            if (!m) {
+              core.setFailed("PR title is not a Conventional Commit (e.g. 'fix(dataplane): ...'). Fix the title or add the 'skip-changelog' label.");
+              return;
+            }
+            const ccType = m[1];
+            const skip = ['docs','test','chore','ci','refactor','style','build'];
+            if (skip.includes(ccType)) {
+              core.info(`non-releasable type '${ccType}'; gate passes`);
+              return;
+            }
+            const out = execSync('ls changelog/unreleased/kong-operator/ 2>/dev/null || true').toString();
+            const hasFragment = out.split('\n').some(n => /\.ya?ml$/.test(n) && n !== 'CHANGELOG_TEMPLATE.yaml');
+            if (!hasFragment) {
+              core.setFailed("No changelog fragment found. The bot adds one automatically for in-repo PRs; fork authors must add changelog/unreleased/kong-operator/<PR>.yaml, or apply the 'skip-changelog' label.");
+              return;
+            }
+            core.info('changelog fragment present; gate passes');

--- a/.github/workflows/changelog-fragment.yaml
+++ b/.github/workflows/changelog-fragment.yaml
@@ -81,11 +81,15 @@ jobs:
             exit 0
           fi
           mkdir -p "$dir"
-          {
-            printf 'message: %s\n' "$MESSAGE"
-            printf 'type: %s\n' "$TYPE"
-            if [ -n "$SCOPE" ]; then printf 'scope: %s\n' "$SCOPE"; fi
-          } > "$file"
+          # Build the fragment with yq so the PR-title-derived MESSAGE is safely
+          # YAML-escaped (raw printf interpolation broke on titles containing ": "
+          # or " #123", producing invalid or silently truncated YAML).
+          yq -n '
+            .message = strenv(MESSAGE) |
+            .type = strenv(TYPE) |
+            .scope = strenv(SCOPE) |
+            del(.scope | select(. == ""))
+          ' > "$file"
           git config user.name "Kong's Team k8s bot"
           git config user.email "team-k8s+github-bot@konghq.com"
           git add "$file"
@@ -129,10 +133,19 @@ jobs:
               core.setFailed("PR title is not a Conventional Commit (e.g. 'fix(dataplane): ...'). Fix the title or add the 'skip-changelog' label.");
               return;
             }
-            const ccType = m[1];
+            // Mirror scaffold's "Compute fragment from PR title" step exactly: the raw
+            // conventional-commit type is only exempt from the fragment requirement if
+            // none of scaffold's overrides (deps-scope -> dependency, !/BREAKING CHANGE
+            // -> breaking_change) would have forced a fragment to be created.
+            const [, ccType, ccScope, bang, subject] = m;
+            const body = pr.body || '';
+            const typeMap = { feat: 'feature', fix: 'bugfix', perf: 'performance' };
             const skip = ['docs','test','chore','ci','refactor','style','build'];
-            if (skip.includes(ccType)) {
-              core.info(`non-releasable type '${ccType}'; gate passes`);
+            let type = typeMap[ccType];
+            if ((ccScope || '').split(',').map(s=>s.trim()).includes('deps')) type = 'dependency';
+            if (bang || /BREAKING CHANGE/.test(body)) type = 'breaking_change';
+            if (!type) {
+              core.info(`non-releasable type '${ccType}' (no override fired); gate passes`);
               return;
             }
             const out = execSync('ls changelog/unreleased/kong-operator/ 2>/dev/null || true').toString();

--- a/.github/workflows/changelog-fragment.yaml
+++ b/.github/workflows/changelog-fragment.yaml
@@ -75,7 +75,7 @@ jobs:
         run: |
           set -euo pipefail
           dir="changelog/unreleased/kong-operator"
-          file="${dir}/${NUM}.yaml"
+          file="${dir}/${NUM}.yml"
           if [ -f "$file" ]; then
             echo "Fragment $file already exists; leaving author edits intact."
             exit 0
@@ -151,7 +151,7 @@ jobs:
             const out = execSync('ls changelog/unreleased/kong-operator/ 2>/dev/null || true').toString();
             const hasFragment = out.split('\n').some(n => /\.ya?ml$/.test(n) && n !== 'CHANGELOG_TEMPLATE.yaml');
             if (!hasFragment) {
-              core.setFailed("No changelog fragment found. The bot adds one automatically for in-repo PRs; fork authors must add changelog/unreleased/kong-operator/<PR>.yaml, or apply the 'skip-changelog' label.");
+              core.setFailed("No changelog fragment found. The bot adds one automatically for in-repo PRs; fork authors must add changelog/unreleased/kong-operator/<PR>.yml, or apply the 'skip-changelog' label.");
               return;
             }
             core.info('changelog fragment present; gate passes');

--- a/.github/workflows/changelog-fragment.yaml
+++ b/.github/workflows/changelog-fragment.yaml
@@ -25,50 +25,24 @@ jobs:
           token: ${{ secrets.PAT_GITHUB }}
           ref: ${{ github.event.pull_request.head.ref }}
 
-      - name: Compute fragment from PR title
-        id: frag
+      - name: Resolve PR payload to JSON
+        id: pr_json
         uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
-            const pr = context.payload.pull_request;
-            const labels = (pr.labels || []).map(l => l.name);
-            if (labels.includes('skip-changelog')) {
-              core.info('skip-changelog label present; skipping');
-              core.setOutput('create', 'false');
-              return;
-            }
-            const title = pr.title || '';
-            const m = title.match(/^(\w+)(?:\(([^)]*)\))?(!)?:\s*(.+)$/);
-            if (!m) {
-              core.info('PR title is not conventional; leaving to verify gate');
-              core.setOutput('create', 'false');
-              return;
-            }
-            const [, ccType, ccScope, bang, subject] = m;
-            const body = pr.body || '';
-            const typeMap = { feat: 'feature', fix: 'bugfix', perf: 'performance' };
-            const skip = ['docs','test','chore','ci','refactor','style','build'];
-            let type = typeMap[ccType];
-            if ((ccScope || '').split(',').map(s=>s.trim()).includes('deps')) type = 'dependency';
-            if (bang || /BREAKING CHANGE/.test(body)) type = 'breaking_change';
-            if (!type) {
-              if (skip.includes(ccType)) { core.info(`non-releasable type '${ccType}'`); }
-              else { core.info(`unmapped type '${ccType}'`); }
-              core.setOutput('create', 'false');
-              return;
-            }
-            const allowedScopes = ['dataplane','controlplane','gateway','hybridgateway','konnect','aigateway','eventgateway','crd','deps'];
-            const scope = (ccScope && allowedScopes.includes(ccScope)) ? ccScope : '';
-            core.setOutput('create', 'true');
-            core.setOutput('number', String(pr.number));
-            core.setOutput('type', type);
-            core.setOutput('scope', scope);
-            core.setOutput('message', subject);
+            const fs = require('fs');
+            fs.writeFileSync(process.env.RUNNER_TEMP + '/pr.json', JSON.stringify(context.payload.pull_request));
+
+      - name: Compute fragment from PR title
+        id: frag
+        env:
+          PR_JSON_FILE: ${{ runner.temp }}/pr.json
+        run: scripts/changelog/pr-fragment-status.sh
 
       - name: Write and push fragment if missing
-        if: ${{ steps.frag.outputs.create == 'true' }}
+        if: ${{ steps.frag.outputs.status == 'required' }}
         env:
-          NUM: ${{ steps.frag.outputs.number }}
+          NUM: ${{ github.event.pull_request.number }}
           TYPE: ${{ steps.frag.outputs.type }}
           SCOPE: ${{ steps.frag.outputs.scope }}
           MESSAGE: ${{ steps.frag.outputs.message }}
@@ -95,63 +69,3 @@ jobs:
           git add "$file"
           git commit -m "chore(changelog): add fragment for #${NUM}"
           git push origin "HEAD:${GITHUB_HEAD_REF}"
-
-  changelog-present:
-    name: changelog-present
-    runs-on: ubuntu-latest
-    needs: scaffold
-    # Always evaluate the gate (also on forks, where scaffold is skipped).
-    if: ${{ always() }}
-    permissions:
-      contents: read
-      pull-requests: read
-    steps:
-      - name: Harden Runner
-        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
-        with:
-          egress-policy: audit
-
-      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
-        with:
-          ref: ${{ github.event.pull_request.head.ref }}
-          repository: ${{ github.event.pull_request.head.repo.full_name }}
-
-      - name: Require a fragment unless exempt
-        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
-        with:
-          script: |
-            const { execSync } = require('child_process');
-            const pr = context.payload.pull_request;
-            const labels = (pr.labels || []).map(l => l.name);
-            if (labels.includes('skip-changelog')) {
-              core.info('skip-changelog label present; gate passes');
-              return;
-            }
-            const title = pr.title || '';
-            const m = title.match(/^(\w+)(?:\(([^)]*)\))?(!)?:\s*(.+)$/);
-            if (!m) {
-              core.setFailed("PR title is not a Conventional Commit (e.g. 'fix(dataplane): ...'). Fix the title or add the 'skip-changelog' label.");
-              return;
-            }
-            // Mirror scaffold's "Compute fragment from PR title" step exactly: the raw
-            // conventional-commit type is only exempt from the fragment requirement if
-            // none of scaffold's overrides (deps-scope -> dependency, !/BREAKING CHANGE
-            // -> breaking_change) would have forced a fragment to be created.
-            const [, ccType, ccScope, bang, subject] = m;
-            const body = pr.body || '';
-            const typeMap = { feat: 'feature', fix: 'bugfix', perf: 'performance' };
-            const skip = ['docs','test','chore','ci','refactor','style','build'];
-            let type = typeMap[ccType];
-            if ((ccScope || '').split(',').map(s=>s.trim()).includes('deps')) type = 'dependency';
-            if (bang || /BREAKING CHANGE/.test(body)) type = 'breaking_change';
-            if (!type) {
-              core.info(`non-releasable type '${ccType}' (no override fired); gate passes`);
-              return;
-            }
-            const out = execSync('ls changelog/unreleased/kong-operator/ 2>/dev/null || true').toString();
-            const hasFragment = out.split('\n').some(n => /\.ya?ml$/.test(n) && n !== 'CHANGELOG_TEMPLATE.yaml');
-            if (!hasFragment) {
-              core.setFailed("No changelog fragment found. The bot adds one automatically for in-repo PRs; fork authors must add changelog/unreleased/kong-operator/<PR>.yml, or apply the 'skip-changelog' label.");
-              return;
-            }
-            core.info('changelog fragment present; gate passes');

--- a/.github/workflows/changelog-fragment.yaml
+++ b/.github/workflows/changelog-fragment.yaml
@@ -43,18 +43,27 @@ jobs:
         if: ${{ steps.frag.outputs.status == 'required' }}
         env:
           NUM: ${{ github.event.pull_request.number }}
+          # Consume the script's own fragment_path output rather than
+          # re-deriving "changelog/unreleased/kong-operator/${NUM}.yml" by
+          # hand here: that was a second hardcoded copy of the exact path
+          # changelog-gate's "Enforce changelog fragment requirement" step
+          # (tests.yaml) compares against, and the two could silently drift.
+          FRAGMENT_PATH: ${{ steps.frag.outputs.fragment_path }}
           TYPE: ${{ steps.frag.outputs.type }}
           SCOPE: ${{ steps.frag.outputs.scope }}
           MESSAGE: ${{ steps.frag.outputs.message }}
         run: |
           set -euo pipefail
-          dir="changelog/unreleased/kong-operator"
-          file="${dir}/${NUM}.yml"
+          file="${FRAGMENT_PATH}"
+          if [ -z "$file" ]; then
+            echo "::error::pr-fragment-status.sh returned status=required but no fragment_path (missing PR number)."
+            exit 1
+          fi
           if [ -f "$file" ]; then
             echo "Fragment $file already exists; leaving author edits intact."
             exit 0
           fi
-          mkdir -p "$dir"
+          mkdir -p "$(dirname "$file")"
           # Build the fragment with yq so the PR-title-derived MESSAGE is safely
           # YAML-escaped (raw printf interpolation broke on titles containing ": "
           # or " #123", producing invalid or silently truncated YAML).

--- a/.github/workflows/charts-tests.yaml
+++ b/.github/workflows/charts-tests.yaml
@@ -53,7 +53,10 @@ jobs:
           fetch-depth: 50
       - id: check-files
         name: Check if only documentation files changed
-        run: ./scripts/check-docs-only-changes.sh ${{ github.event.pull_request.base.sha || 'HEAD~1' }} ${{ github.sha }}
+        # merge_group.base_sha fallback: in a merge-queue group with several PRs, the
+        # branch is base + one squash commit per PR, so HEAD~1..HEAD would only see the
+        # LAST PR's diff and could wrongly mark the whole group as docs-only/skippable.
+        run: ./scripts/check-docs-only-changes.sh ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || 'HEAD~1' }} ${{ github.sha }}
 
   generate:
     timeout-minutes: 10
@@ -214,15 +217,8 @@ jobs:
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
-      - name: Check if docs-only changes
+      - name: Check results
         run: |
-          if [[ "${{ needs.check-docs-only.outputs.docs_only }}" == "true" ]]; then
-            echo "Only documentation files were changed, skipping charts tests"
-            exit 0
+          if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
+            echo "Some jobs failed or were cancelled."; exit 1
           fi
-
-      - name: Check test results
-        if: ${{ needs.check-docs-only.outputs.docs_only != 'true' && (contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled')) }}
-        run: |
-          echo "Some jobs failed or were cancelled."
-          exit 1

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -110,6 +110,11 @@ jobs:
   # nothing to the critical path.
   changelog-gate:
     runs-on: ubuntu-latest
+    # Config-only job (checkout + a couple of API/script calls); it takes
+    # seconds, not the 360-minute default. Matches the short-job convention
+    # used for similarly small jobs elsewhere (e.g. charts-tests.yaml's
+    # lint/docs jobs use timeout-minutes: 10).
+    timeout-minutes: 10
     permissions:
       contents: read
       pull-requests: read
@@ -140,6 +145,15 @@ jobs:
       # a payload-based gate would keep failing after the author fixes the
       # title or a maintainer adds the skip-changelog label. Fetching live
       # means a plain "Re-run all jobs" is enough to pick up either fix.
+      # Retried (3 attempts, linear backoff) so a transient `gh api` blip
+      # doesn't fail the gate outright -- that would skip all 10 heavy jobs
+      # and redden `passed` for a problem that has nothing to do with the
+      # PR. This step deliberately never itself exits non-zero: on
+      # persistent failure it leaves no pr.json behind, so the next step's
+      # `pr-fragment-status.sh` degrades to status=error (its documented
+      # contract for a missing/unreadable PR_JSON_FILE), and the "Enforce"
+      # step below gives that its own actionable message rather than the
+      # generic "unexpected status" branch.
       - name: Resolve PR data
         if: ${{ github.event_name == 'pull_request' }}
         id: pr
@@ -147,8 +161,20 @@ jobs:
           GH_TOKEN: ${{ github.token }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
         run: |
-          set -euo pipefail
-          gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" > "${RUNNER_TEMP}/pr.json"
+          set -uo pipefail
+          max_attempts=3
+          for attempt in $(seq 1 "${max_attempts}"); do
+            if gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" > "${RUNNER_TEMP}/pr.json"; then
+              exit 0
+            fi
+            rm -f "${RUNNER_TEMP}/pr.json"
+            if [ "${attempt}" -lt "${max_attempts}" ]; then
+              backoff=$((attempt * 5))
+              echo "::warning::gh api call failed (attempt ${attempt}/${max_attempts}); retrying in ${backoff}s."
+              sleep "${backoff}"
+            fi
+          done
+          echo "::warning::gh api call failed after ${max_attempts} attempts; leaving no PR data so pr-fragment-status.sh reports status=error."
 
       # Never interpolate the PR title/body into a `run:` block -- that is a
       # script-injection vector. Pass the JSON file through instead; the
@@ -169,6 +195,16 @@ jobs:
         run: |
           set -euo pipefail
           case "${STATUS}" in
+            error)
+              # Distinct from the generic "unexpected status" branch below:
+              # this is the gh-api-couldn't-be-reached case (see the
+              # "Resolve PR data" step), not a title/label problem. Fail
+              # closed (this gate must never let expensive jobs start
+              # without having actually checked), but say so plainly so a
+              # maintainer doesn't waste time editing the PR title.
+              echo "::error::${REASON} This is an infrastructure failure (the gh api call to fetch PR data did not succeed after retries), not a problem with the PR itself -- re-run this job."
+              exit 1
+              ;;
             exempt)
               echo "Exempt: ${REASON}"
               ;;
@@ -615,6 +651,7 @@ jobs:
       - lint-markdownlint
       - govulncheck
       - verify
+      - matrix_k8s_node_versions
       - samples
       - install-with-kustomize
       - build

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -91,7 +91,10 @@ jobs:
           fetch-depth: 50
       - id: check-files
         name: Check if only documentation files changed
-        run: ./scripts/check-docs-only-changes.sh ${{ github.event.pull_request.base.sha || 'HEAD~1' }} ${{ github.sha }}
+        # merge_group.base_sha fallback: in a merge-queue group with several PRs, the
+        # branch is base + one squash commit per PR, so HEAD~1..HEAD would only see the
+        # LAST PR's diff and could wrongly mark the whole group as docs-only/skippable.
+        run: ./scripts/check-docs-only-changes.sh ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || 'HEAD~1' }} ${{ github.sha }}
 
   ensure-actions-sha-pin:
     runs-on: ubuntu-latest
@@ -497,17 +500,8 @@ jobs:
         uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
         with:
           egress-policy: audit
-      - name: Check if docs-only changes
-        run: |
-          if [[ "${{ needs.check-docs-only.outputs.docs_only }}" == "true" ]]; then
-            echo "Only documentation files were changed, skipping tests"
-            exit 0
-          fi
-
-      - name: Check test results
-        if: ${{ needs.check-docs-only.outputs.docs_only != 'true' }}
+      - name: Check results
         run: |
           if [[ "${{ contains(needs.*.result, 'failure') || contains(needs.*.result, 'cancelled') }}" == "true" ]]; then
-            echo "Some jobs failed or were cancelled."
-            exit 1
+            echo "Some jobs failed or were cancelled."; exit 1
           fi

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -44,7 +44,13 @@ env:
 jobs:
   build-e2e-image:
     runs-on: ubuntu-latest
-    needs: [check-docs-only]
+    # NOTE: changelog-gate is listed here (and on every job below that
+    # depends, directly or transitively, on it) to fail the changelog
+    # fragment requirement. Adding `always()` to any of these jobs' `if:`
+    # would silently defeat that gate by running the job even when
+    # changelog-gate failed -- do not do that without re-reading why this
+    # comment exists.
+    needs: [check-docs-only, changelog-gate]
     if: ${{ needs.check-docs-only.outputs.docs_only != 'true' }}
     env:
       IMG: kong-operator
@@ -95,6 +101,110 @@ jobs:
         # branch is base + one squash commit per PR, so HEAD~1..HEAD would only see the
         # LAST PR's diff and could wrongly mark the whole group as docs-only/skippable.
         run: ./scripts/check-docs-only-changes.sh ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || 'HEAD~1' }} ${{ github.sha }}
+
+  # Gates the expensive jobs below on a PR having either a changelog fragment
+  # (changelog/unreleased/kong-operator/<PR>.yml) or a documented exemption
+  # (skip-changelog label, or a non-releasable Conventional Commit type).
+  #
+  # No `needs:` on purpose: it runs in parallel with check-docs-only and adds
+  # nothing to the critical path.
+  changelog-gate:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - name: Harden Runner
+        uses: step-security/harden-runner@bf7454d06d71f1098171f2acdf0cd4708d7b5920 # v2.20.0
+        with:
+          egress-policy: audit
+      - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
+
+      # merge_group/push/tag/workflow_dispatch runs have no PR payload, and any
+      # PR entering the merge queue already passed this gate on its last
+      # pull_request run. This step only logs; it never fails the job, so the
+      # job reports `success` (not `skipped`) on those events -- `passed`
+      # needs this job unconditionally and a `skipped` result there would
+      # read as "did not run" rather than "nothing to check", and would also
+      # leave a merge-queue run's gate row looking incomplete.
+      - name: No-op on non pull_request events
+        if: ${{ github.event_name != 'pull_request' }}
+        env:
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          echo "event=${EVENT_NAME}: not a pull_request run, skipping fragment check (a PR already passed this gate before reaching this event)."
+
+      # Resolve PR data live via the API rather than reading
+      # github.event.pull_request from the (possibly stale) stored payload:
+      # re-running a workflow replays the payload from the original push, so
+      # a payload-based gate would keep failing after the author fixes the
+      # title or a maintainer adds the skip-changelog label. Fetching live
+      # means a plain "Re-run all jobs" is enough to pick up either fix.
+      - name: Resolve PR data
+        if: ${{ github.event_name == 'pull_request' }}
+        id: pr
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          gh api "repos/${GITHUB_REPOSITORY}/pulls/${PR_NUMBER}" > "${RUNNER_TEMP}/pr.json"
+
+      # Never interpolate the PR title/body into a `run:` block -- that is a
+      # script-injection vector. Pass the JSON file through instead; the
+      # script itself never touches git/gh/the filesystem beyond that file.
+      - name: Compute fragment status
+        if: ${{ github.event_name == 'pull_request' }}
+        id: frag
+        env:
+          PR_JSON_FILE: ${{ runner.temp }}/pr.json
+        run: scripts/changelog/pr-fragment-status.sh
+
+      - name: Enforce changelog fragment requirement
+        if: ${{ github.event_name == 'pull_request' }}
+        env:
+          STATUS: ${{ steps.frag.outputs.status }}
+          REASON: ${{ steps.frag.outputs.reason }}
+          FRAGMENT_PATH: ${{ steps.frag.outputs.fragment_path }}
+        run: |
+          set -euo pipefail
+          case "${STATUS}" in
+            exempt)
+              echo "Exempt: ${REASON}"
+              ;;
+            invalid_title)
+              echo "::error::${REASON} Fix the PR title (e.g. 'fix(dataplane): ...' or 'feat(gateway)!: ...'), or add the 'skip-changelog' label if this change needs no changelog entry. After either fix, this gate reads live PR state, so a maintainer clicking \"Re-run all jobs\" on the tests workflow is enough -- no new commit is required."
+              exit 1
+              ;;
+            required)
+              if [ -z "${FRAGMENT_PATH}" ]; then
+                echo "::error::Could not resolve a fragment path (missing PR number)."
+                exit 1
+              fi
+              if [ -f "${FRAGMENT_PATH}" ]; then
+                echo "Fragment present: ${FRAGMENT_PATH} (${REASON})"
+              else
+                yaml_sibling="${FRAGMENT_PATH%.yml}.yaml"
+                if [ -f "${yaml_sibling}" ]; then
+                  echo "::error::Found ${yaml_sibling}, but the fragment generator only recognises the '.yml' extension. Rename it to ${FRAGMENT_PATH}."
+                else
+                  echo "::error::Missing changelog fragment ${FRAGMENT_PATH} (${REASON}). On same-repo PRs the scaffolding bot should push it automatically after the title is valid; on forks, add it by hand. If this change needs no changelog entry, add the 'skip-changelog' label instead."
+                fi
+                echo "::notice::After adding the fragment or the 'skip-changelog' label, this gate reads live PR state -- someone with write access must click \"Re-run all jobs\" on the tests workflow once; no new commit is needed."
+                exit 1
+              fi
+              ;;
+            *)
+              echo "::error::Unexpected status '${STATUS}' from pr-fragment-status.sh."
+              exit 1
+              ;;
+          esac
+
+      # Ungated by check-docs-only/docs_only, so this is what keeps a
+      # malformed fragment (e.g. `type: bogus`) from shipping once
+      # fragment-only PRs start skipping the heavy suite.
+      - name: Lint changelog fragment schema
+        run: ./scripts/changelog/verify.sh changelog/unreleased/kong-operator
 
   ensure-actions-sha-pin:
     runs-on: ubuntu-latest
@@ -196,8 +306,10 @@ jobs:
 
   samples:
     runs-on: ubuntu-latest
+    # See the changelog-gate comment on build-e2e-image: keep this if: as-is.
     needs:
     - check-docs-only
+    - changelog-gate
     - matrix_k8s_node_versions
     if: ${{ needs.check-docs-only.outputs.docs_only != 'true' }}
     steps:
@@ -241,8 +353,10 @@ jobs:
 
   install-with-kustomize:
     runs-on: ubuntu-latest
+    # See the changelog-gate comment on build-e2e-image: keep this if: as-is.
     needs:
     - check-docs-only
+    - changelog-gate
     - build-e2e-image
     - matrix_k8s_node_versions
     if: ${{ needs.check-docs-only.outputs.docs_only != 'true' }}
@@ -368,8 +482,10 @@ jobs:
     secrets: inherit
 
   CRDs:
+    # See the changelog-gate comment on build-e2e-image: keep this if: as-is.
     needs:
     - check-docs-only
+    - changelog-gate
     - matrix_k8s_node_versions
     if: ${{ needs.check-docs-only.outputs.docs_only != 'true' }}
     uses: ./.github/workflows/__crdvalidation_tests.yaml
@@ -378,8 +494,10 @@ jobs:
       cluster_versions: ${{ needs.matrix_k8s_node_versions.outputs.matrix }}
 
   envtest-tests:
+    # See the changelog-gate comment on build-e2e-image: keep this if: as-is.
     needs:
     - check-docs-only
+    - changelog-gate
     - matrix_k8s_node_versions
     if: ${{ needs.check-docs-only.outputs.docs_only != 'true' }}
     uses: ./.github/workflows/__envtest_tests.yaml
@@ -388,20 +506,24 @@ jobs:
       cluster_version: ${{ needs.matrix_k8s_node_versions.outputs.latest }}
   
   kongintegration-tests:
-    needs: [check-docs-only]
+    # See the changelog-gate comment on build-e2e-image: keep this if: as-is.
+    needs: [check-docs-only, changelog-gate]
     if: ${{ needs.check-docs-only.outputs.docs_only != 'true' }}
     uses: ./.github/workflows/__kongintegration_tests.yaml
     secrets: inherit
 
   conformance-tests:
-    needs: [check-docs-only]
+    # See the changelog-gate comment on build-e2e-image: keep this if: as-is.
+    needs: [check-docs-only, changelog-gate]
     if: ${{ needs.check-docs-only.outputs.docs_only != 'true' }}
     uses: ./.github/workflows/__conformance_tests.yaml
     secrets: inherit
 
   integration-tests:
+    # See the changelog-gate comment on build-e2e-image: keep this if: as-is.
     needs:
       - check-docs-only
+      - changelog-gate
       - matrix_k8s_node_versions
     if: ${{ needs.check-docs-only.outputs.docs_only != 'true' }}
     uses: ./.github/workflows/__integration_tests.yaml
@@ -410,8 +532,12 @@ jobs:
       cluster_version: ${{ needs.matrix_k8s_node_versions.outputs.latest }}
 
   e2e-tests:
+    # changelog-gate is also listed explicitly here even though it would
+    # skip transitively via build-e2e-image -- see the changelog-gate
+    # comment on build-e2e-image; keep this if: as-is.
     needs:
       - check-docs-only
+      - changelog-gate
       - build-e2e-image
       - matrix_k8s_node_versions
     if: ${{ needs.check-docs-only.outputs.docs_only != 'true' }}
@@ -419,8 +545,12 @@ jobs:
     secrets: inherit
 
   e2e-tests-chainsaw:
+    # changelog-gate is also listed explicitly here even though it would
+    # skip transitively via build-e2e-image -- see the changelog-gate
+    # comment on build-e2e-image; keep this if: as-is.
     needs:
       - check-docs-only
+      - changelog-gate
       - build-e2e-image
       - matrix_k8s_node_versions
     if: ${{ needs.check-docs-only.outputs.docs_only != 'true' }}
@@ -432,12 +562,17 @@ jobs:
   buildpulse-report:
     needs:
       - check-docs-only
+      - changelog-gate
       - unit-tests
       - envtest-tests
       - integration-tests
       - conformance-tests
       - e2e-tests
-    if: ${{ always() && needs.check-docs-only.outputs.docs_only != 'true' }}
+    # if: always() means this job would otherwise run (and fail noisily, with
+    # no test artifacts to upload) when changelog-gate failed and the test
+    # jobs above were skipped as a result. Require changelog-gate to have
+    # actually succeeded.
+    if: ${{ always() && needs.check-docs-only.outputs.docs_only != 'true' && needs.changelog-gate.result == 'success' }}
     runs-on: ubuntu-latest
     steps:
       - name: Harden Runner
@@ -473,6 +608,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - check-docs-only
+      - changelog-gate
       - ensure-actions-sha-pin
       - ossf-scorecard
       - lint

--- a/.tools_versions.yaml
+++ b/.tools_versions.yaml
@@ -55,3 +55,5 @@ cert-manager: "1.21.0"
 chainsaw: "v0.2.15"
 # renovate: datasource=github-releases depName=fullstorydev/grpcurl
 grpcurl: "v1.9.3"
+# renovate: datasource=github-tags depName=Kong/gateway-changelog
+changelog: "v2.0.3"

--- a/.tools_versions.yaml
+++ b/.tools_versions.yaml
@@ -55,5 +55,5 @@ cert-manager: "1.21.0"
 chainsaw: "v0.2.15"
 # renovate: datasource=github-releases depName=fullstorydev/grpcurl
 grpcurl: "v1.9.3"
-# renovate: datasource=github-tags depName=Kong/gateway-changelog
+# renovate: datasource=github-releases depName=Kong/gateway-changelog
 changelog: "v2.0.3"

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -226,7 +226,11 @@ branch and catch incompatible schema changes before CI does.
    make verify.crd-breaking-changes
    ```
 
-6. **Update CHANGELOG.md** - For significant changes, add release notes
+6. **Add a changelog fragment** - Do NOT edit `CHANGELOG.md` directly. PRs carry a
+   per-PR fragment at `changelog/unreleased/kong-operator/<PR>.yaml`; the changelog
+   bot scaffolds it from your Conventional Commit title. Edit it for richer prose.
+   Exempt with the `skip-changelog` label or a non-releasable type. `CHANGELOG.md`
+   is generated at release time via `make changelog`. See `changelog/README.md`.
 
 ### Verify Before Commit
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -227,7 +227,7 @@ branch and catch incompatible schema changes before CI does.
    ```
 
 6. **Add a changelog fragment** - Do NOT edit `CHANGELOG.md` directly. PRs carry a
-   per-PR fragment at `changelog/unreleased/kong-operator/<PR>.yaml`; the changelog
+   per-PR fragment at `changelog/unreleased/kong-operator/<PR>.yml`; the changelog
    bot scaffolds it from your Conventional Commit title. Edit it for richer prose.
    Exempt with the `skip-changelog` label or a non-releasable type. `CHANGELOG.md`
    is generated at release time via `make changelog`. See `changelog/README.md`.

--- a/Makefile
+++ b/Makefile
@@ -134,6 +134,12 @@ CRDIFY = $(PROJECT_DIR)/bin/installs/go-sigs-k8s-io-crdify/$(CRDIFY_VERSION)/bin
 crdify: mise yq ## Download crdify locally if necessary.
 	$(MAKE) mise-install DEP_VER=go:sigs.k8s.io/crdify@v$(CRDIFY_VERSION)
 
+CHANGELOG_VERSION = $(shell $(YQ) -r '.changelog' < $(TOOLS_VERSIONS_FILE))
+CHANGELOG_BIN = $(PROJECT_DIR)/bin/installs/github-kong-gateway-changelog/$(CHANGELOG_VERSION:v%=%)/changelog
+.PHONY: changelog-tool
+changelog-tool: mise yq ## Download the gateway-changelog generator locally if necessary.
+	$(MAKE) mise-install DEP_VER=github:Kong/gateway-changelog@$(CHANGELOG_VERSION)
+
 SKAFFOLD_VERSION = $(shell $(YQ) -r '.skaffold' < $(TOOLS_VERSIONS_FILE))
 SKAFFOLD = $(PROJECT_DIR)/bin/installs/github-google-container-tools-skaffold/$(SKAFFOLD_VERSION)/skaffold
 .PHONY: skaffold

--- a/Makefile
+++ b/Makefile
@@ -140,6 +140,11 @@ CHANGELOG_BIN = $(PROJECT_DIR)/bin/installs/github-kong-gateway-changelog/$(CHAN
 changelog-tool: mise yq ## Download the gateway-changelog generator locally if necessary.
 	$(MAKE) mise-install DEP_VER=github:Kong/gateway-changelog@$(CHANGELOG_VERSION)
 
+.PHONY: changelog
+changelog: changelog-tool ## Assemble CHANGELOG.md for a release from fragments. Usage: make changelog VERSION=vX.Y.Z
+	@test -n "$(VERSION)" || (echo "VERSION is required, e.g. make changelog VERSION=v2.4.0" && exit 1)
+	CHANGELOG_BIN="$(CHANGELOG_BIN)" REPO="Kong/kong-operator" ./scripts/changelog/generate.sh "$(VERSION)"
+
 SKAFFOLD_VERSION = $(shell $(YQ) -r '.skaffold' < $(TOOLS_VERSIONS_FILE))
 SKAFFOLD = $(PROJECT_DIR)/bin/installs/github-google-container-tools-skaffold/$(SKAFFOLD_VERSION)/skaffold
 .PHONY: skaffold

--- a/Makefile
+++ b/Makefile
@@ -145,6 +145,17 @@ changelog: changelog-tool ## Assemble CHANGELOG.md for a release from fragments.
 	@test -n "$(VERSION)" || (echo "VERSION is required, e.g. make changelog VERSION=v2.4.0" && exit 1)
 	CHANGELOG_BIN="$(CHANGELOG_BIN)" REPO="Kong/kong-operator" ./scripts/changelog/generate.sh "$(VERSION)"
 
+.PHONY: changelog.verify
+changelog.verify: yq ## Schema-lint changelog fragments in the unreleased dir.
+	YQ="$(YQ)" ./scripts/changelog/verify.sh changelog/unreleased/kong-operator
+
+.PHONY: test.changelog
+test.changelog: ## Run the changelog script golden tests.
+	./scripts/changelog/tests/run.sh
+
+.PHONY: verify.changelog
+verify.changelog: changelog.verify test.changelog ## Verify changelog fragments and scripts.
+
 SKAFFOLD_VERSION = $(shell $(YQ) -r '.skaffold' < $(TOOLS_VERSIONS_FILE))
 SKAFFOLD = $(PROJECT_DIR)/bin/installs/github-google-container-tools-skaffold/$(SKAFFOLD_VERSION)/skaffold
 .PHONY: skaffold

--- a/Makefile
+++ b/Makefile
@@ -308,6 +308,13 @@ lint.actions: download.actionlint download.shellcheck
 	SHELLCHECK_OPTS='--exclude=SC2086,SC2155,SC2046' \
 	$(ACTIONLINT) -shellcheck $(SHELLCHECK) \
 		./.github/workflows/*
+# actionlint's -shellcheck only lints the inline `run:` blocks above, not
+# standalone scripts invoked BY those blocks. The changelog gate/classifier
+# scripts decide whether expensive CI jobs run at all, so lint them directly
+# too.
+	$(SHELLCHECK) \
+		scripts/changelog/*.sh \
+		scripts/check-docs-only-changes.sh
 
 .PHONY: lint.markdownlint
 lint.markdownlint: download.markdownlint-cli2

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -7,7 +7,7 @@ edit `CHANGELOG.md` directly in feature PRs.**
 
 1. Open a PR with a [Conventional Commits](https://www.conventionalcommits.org/)
    title, e.g. `fix(dataplane): stop false-positive env warnings`.
-2. The changelog bot commits `changelog/unreleased/kong-operator/<PR-number>.yaml`
+2. The changelog bot commits `changelog/unreleased/kong-operator/<PR-number>.yml`
    to your branch, pre-filled from the title.
 3. Edit that file if the one-line title does not capture the change. Rich,
    multi-line `message` prose is encouraged.

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -1,0 +1,43 @@
+# Changelog fragments
+
+We generate `CHANGELOG.md` at release time from per-PR fragment files. **Do not
+edit `CHANGELOG.md` directly in feature PRs.**
+
+## How it works
+
+1. Open a PR with a [Conventional Commits](https://www.conventionalcommits.org/)
+   title, e.g. `fix(dataplane): stop false-positive env warnings`.
+2. The changelog bot commits `changelog/unreleased/kong-operator/<PR-number>.yaml`
+   to your branch, pre-filled from the title.
+3. Edit that file if the one-line title does not capture the change. Rich,
+   multi-line `message` prose is encouraged.
+4. CI fails if no fragment is present. Exempt a PR with the `skip-changelog`
+   label, or use a non-releasable type (`docs`, `test`, `chore`, `ci`,
+   `refactor`, `style`, `build`).
+
+## Fragment schema
+
+See `unreleased/kong-operator/CHANGELOG_TEMPLATE.yaml`.
+
+- `message` (required): description, may be multi-line.
+- `type` (required): `feature`, `bugfix`, `dependency`, `deprecation`,
+  `breaking_change`, `performance`.
+- `scope` (optional): `dataplane`, `controlplane`, `gateway`, `hybridgateway`,
+  `konnect`, `aigateway`, `eventgateway`, `crd`, `deps`.
+
+## Conventional-commit → type mapping
+
+| PR title prefix | fragment `type` |
+|---|---|
+| `feat` | `feature` |
+| `fix` | `bugfix` |
+| `perf` | `performance` |
+| any `!` / body `BREAKING CHANGE` | `breaking_change` |
+| `deps` scope, renovate/dependabot | `dependency` |
+| `docs`,`test`,`chore`,`ci`,`refactor`,`style`,`build` | no fragment |
+
+## Generating (release time only)
+
+`make changelog VERSION=vX.Y.Z` — assembles the version section into
+`CHANGELOG.md` and moves consumed fragments to `changelog/<version>/`.
+The release workflow runs this automatically.

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -15,7 +15,10 @@ edit `CHANGELOG.md` directly in feature PRs.**
    label, or use a non-releasable type (`docs`, `test`, `chore`, `ci`,
    `refactor`, `style`, `build`).
 5. The fragment must be named `<PR-number>.yml` (a `.yaml` sibling is not
-   recognized by the generator or the CI gate).
+   recognized by the generator or the CI gate — `changelog-gate` still
+   schema-lints any `.yaml` file it finds, so a malformed one still fails
+   CI, but the release-time generator silently skips it, so a `.yaml`
+   fragment never actually makes it into `CHANGELOG.md`).
 6. A PR that only touches its own changelog fragment skips the expensive
    test suite (kind/e2e jobs) entirely — the `changelog-gate` job still
    schema-lints the fragment, so a malformed fragment (e.g. an invalid
@@ -25,6 +28,16 @@ edit `CHANGELOG.md` directly in feature PRs.**
    the `skip-changelog` label, no new commit is needed: someone with write
    access can click "Re-run all jobs" on the `tests` workflow once and the
    gate re-evaluates against the current PR state.
+8. Backport/cherry-pick PRs (title starting `[Backport ...]` or
+   `[cherry-pick]`) and PRs authored by a known bot (`renovate[bot]`,
+   `dependabot[bot]`, or any `*[bot]` GitHub App) are exempt — a
+   backport/cherry-pick PR's fragment travels with the original PR's
+   cherry-picked commit, so a second one would just duplicate the entry at
+   release time; bot PRs get the exemption as a safety net for titles that
+   don't parse as a Conventional Commit, since there's no human on the
+   other end to fix an unmergeable title. A bot PR whose title *does* parse
+   (e.g. a Renovate `chore(deps): ...` title) is classified normally and
+   still needs a fragment like any other PR.
 
 ## Fragment schema
 

--- a/changelog/README.md
+++ b/changelog/README.md
@@ -14,6 +14,17 @@ edit `CHANGELOG.md` directly in feature PRs.**
 4. CI fails if no fragment is present. Exempt a PR with the `skip-changelog`
    label, or use a non-releasable type (`docs`, `test`, `chore`, `ci`,
    `refactor`, `style`, `build`).
+5. The fragment must be named `<PR-number>.yml` (a `.yaml` sibling is not
+   recognized by the generator or the CI gate).
+6. A PR that only touches its own changelog fragment skips the expensive
+   test suite (kind/e2e jobs) entirely — the `changelog-gate` job still
+   schema-lints the fragment, so a malformed fragment (e.g. an invalid
+   `type`) still fails CI even on a fragment-only PR.
+7. `changelog-gate` reads the PR's live title/body/labels, not the payload
+   from when the workflow was triggered. So after fixing the title or adding
+   the `skip-changelog` label, no new commit is needed: someone with write
+   access can click "Re-run all jobs" on the `tests` workflow once and the
+   gate re-evaluates against the current PR state.
 
 ## Fragment schema
 

--- a/changelog/unreleased/kong-operator/CHANGELOG_TEMPLATE.yaml
+++ b/changelog/unreleased/kong-operator/CHANGELOG_TEMPLATE.yaml
@@ -1,4 +1,4 @@
-# Copy this file to <your-PR-number>.yaml and fill it in.
+# Copy this file to <your-PR-number>.yml and fill it in.
 # In practice the changelog bot pre-fills it from your PR title; edit only if
 # the one-line title does not capture the change well.
 

--- a/changelog/unreleased/kong-operator/CHANGELOG_TEMPLATE.yaml
+++ b/changelog/unreleased/kong-operator/CHANGELOG_TEMPLATE.yaml
@@ -1,0 +1,15 @@
+# Copy this file to <your-PR-number>.yaml and fill it in.
+# In practice the changelog bot pre-fills it from your PR title; edit only if
+# the one-line title does not capture the change well.
+
+# Required. Human-readable description. May span multiple lines for rich prose.
+message: |
+  Short description of the change. Prefer complete sentences; include
+  migration notes here when behaviour changes.
+
+# Required. One of: feature, bugfix, dependency, deprecation, breaking_change, performance
+type: bugfix
+
+# Optional. One of: dataplane, controlplane, gateway, hybridgateway, konnect,
+# aigateway, eventgateway, crd, deps. Omit when there is no meaningful scope.
+scope: dataplane

--- a/renovate.json
+++ b/renovate.json
@@ -25,6 +25,14 @@
     "fileMatch": ["^Dockerfile$", "^debug\\.Dockerfile$"]
   },
   "automerge": false,
+  // Emit Conventional Commit titles (e.g. "chore(deps): update ...")
+  // instead of the "auto" default, which flapped between Conventional and
+  // bare titles depending on the underlying manager. changelog-gate parses
+  // the PR title, so a flapping/non-Conventional title used to hard-block
+  // Renovate PRs (see the bot-author exemption in
+  // scripts/changelog/pr-fragment-status.sh, kept as a safety net for the
+  // transition and for Dependabot, which has no equivalent setting here).
+  "semanticCommits": "enabled",
   "separateMinorPatch": true,
   "labels": [
     "dependencies"

--- a/scripts/changelog/generate.sh
+++ b/scripts/changelog/generate.sh
@@ -48,6 +48,17 @@ raw="$(mktemp)"
 
 section="$(mktemp)"
 "$here/normalize-section.sh" "$raw" "$version" "$release_date" > "$section"
+
+# Guard against a tool run that silently produced no entries (e.g. all
+# fragments were skipped because of an unrecognized file extension). Merging
+# an empty section and then archiving the fragments anyway would look like a
+# successful release but silently drop every change. Fail loudly instead.
+if ! grep -qE '^- ' "$section"; then
+  echo "ERROR: generated section for ${version} has no entries — refusing to archive fragments; check fragment file extensions and tool output" >&2
+  rm -f "$raw" "$section"
+  exit 1
+fi
+
 "$here/merge-changelog.sh" "$changelog" "$section" "$version"
 rm -f "$raw" "$section"
 

--- a/scripts/changelog/generate.sh
+++ b/scripts/changelog/generate.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+# Assemble the changelog section for a release from unreleased fragments,
+# prepend it into CHANGELOG.md, and archive consumed fragments.
+# Usage: generate.sh <version>
+# Env: CHANGELOG_BIN (path to gateway-changelog binary, default `changelog`),
+#      REPO (default Kong/kong-operator), RELEASE_DATE (default today UTC).
+set -euo pipefail
+
+version="${1:?usage: generate.sh <version>}"
+here="$(cd "$(dirname "$0")" && pwd)"
+frag_dir="changelog/unreleased/kong-operator"
+archive_dir="changelog/${version}"
+changelog="CHANGELOG.md"
+bin="${CHANGELOG_BIN:-changelog}"
+repo="${REPO:-Kong/kong-operator}"
+release_date="${RELEASE_DATE:-$(date -u +%Y-%m-%d)}"
+
+shopt -s nullglob
+frags=("$frag_dir"/*.yaml "$frag_dir"/*.yml)
+# Exclude the template from the fragment set.
+# Note: array expansions are guarded by a length check because bash 3.2
+# (macOS's default /bin/bash) treats "${arr[@]}" on an empty array as an
+# unbound-variable error under `set -u`.
+tmp_frags=()
+if [ "${#frags[@]}" -gt 0 ]; then
+  for f in "${frags[@]}"; do
+    case "$(basename "$f")" in CHANGELOG_TEMPLATE.yaml) ;; *) tmp_frags+=("$f") ;; esac
+  done
+fi
+frags=()
+if [ "${#tmp_frags[@]}" -gt 0 ]; then
+  frags=("${tmp_frags[@]}")
+fi
+
+if [ "${#frags[@]}" -eq 0 ]; then
+  echo "No changelog fragments in ${frag_dir}; nothing to generate."
+  exit 0
+fi
+
+raw="$(mktemp)"
+"$bin" generate \
+  --repo-path . \
+  --changelog-paths "$frag_dir" \
+  --title "$version" \
+  --github-issue-repo "$repo" \
+  --github-api-repo "$repo" \
+  > "$raw"
+
+section="$(mktemp)"
+"$here/normalize-section.sh" "$raw" "$version" "$release_date" > "$section"
+"$here/merge-changelog.sh" "$changelog" "$section" "$version"
+rm -f "$raw" "$section"
+
+mkdir -p "$archive_dir"
+for f in "${frags[@]}"; do
+  git mv "$f" "$archive_dir/" 2>/dev/null || mv "$f" "$archive_dir/"
+done
+
+echo "Generated ${version} section from ${#frags[@]} fragment(s); archived to ${archive_dir}."

--- a/scripts/changelog/merge-changelog.sh
+++ b/scripts/changelog/merge-changelog.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Prepend a version section + TOC entry into CHANGELOG.md, in place.
+# Usage: merge-changelog.sh <changelog-file> <section-file> <version>
+set -euo pipefail
+
+changelog="${1:?changelog file}"
+section="${2:?section file}"
+version="${3:?version}"
+
+# GitHub heading anchor: lowercase, drop chars other than [a-z0-9 _-], spaces->'-'
+anchor="$(printf '%s' "$version" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9 _-]//g' | tr ' ' '-')"
+toc_line="- [${version}](#${anchor})"
+
+tmp="$(mktemp)"
+awk -v toc="$toc_line" -v secfile="$section" '
+  BEGIN { toc_done=0; sec_done=0 }
+  /^## Table of Contents$/ && !toc_done {
+    print               # heading
+    getline; print      # blank line after heading
+    print toc           # new entry, above existing list
+    toc_done=1
+    next
+  }
+  /^## \[/ && !sec_done {
+    while ((getline line < secfile) > 0) print line
+    print ""
+    sec_done=1
+  }
+  { print }
+' "$changelog" > "$tmp"
+mv "$tmp" "$changelog"

--- a/scripts/changelog/normalize-section.sh
+++ b/scripts/changelog/normalize-section.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+# Normalize gateway-changelog output to the repo's canonical section format.
+# Usage: normalize-section.sh <raw-file> <version> <date>  (prints to stdout)
+set -euo pipefail
+
+raw="${1:?raw file}"
+version="${2:?version}"
+date="${3:?date}"
+
+awk -v ver="## [${version}]" -v dline="> Release date: ${date}" '
+  BEGIN { started=0; afterheading=0 }
+  !started && $0 ~ /^[[:space:]]*$/ { next }          # skip leading blank lines
+  !started {
+    started=1
+    print ver; print ""; print dline; print ""
+    if ($0 ~ /^#/) { afterheading=1; next }            # drop tool heading line
+    print                                              # non-heading first line: keep body
+    next
+  }
+  afterheading && $0 ~ /^[[:space:]]*$/ { next }        # skip blank line(s) right after dropped heading
+  { afterheading=0; print }
+' "$raw"

--- a/scripts/changelog/pr-fragment-status.sh
+++ b/scripts/changelog/pr-fragment-status.sh
@@ -10,16 +10,18 @@
 #
 # Inputs (env only):
 #   PR_JSON_FILE   Path to a GitHub PR JSON object (.title, .body,
-#                  .labels[].name, .number). Used by CI, since it avoids
-#                  passing a multiline PR body through a shell env var.
-#                  If set, PR_TITLE/PR_BODY/PR_LABELS/PR_NUMBER are ignored.
-#                  An unreadable file or invalid JSON is reported as
-#                  status=error (see below), not a non-zero exit -- a
-#                  transient `gh api` hiccup must not abort the caller.
+#                  .labels[].name, .number, .user.login). Used by CI, since
+#                  it avoids passing a multiline PR body through a shell env
+#                  var. If set, PR_TITLE/PR_BODY/PR_LABELS/PR_NUMBER/PR_AUTHOR
+#                  are ignored. An unreadable file or invalid JSON is
+#                  reported as status=error (see below), not a non-zero
+#                  exit -- a transient `gh api` hiccup must not abort the
+#                  caller.
 #   PR_TITLE       PR title. Used directly when PR_JSON_FILE is unset.
 #   PR_BODY        PR body (default "").
 #   PR_LABELS      Newline-separated label names (default "").
 #   PR_NUMBER      PR number (default "").
+#   PR_AUTHOR      PR author login (default ""), e.g. "renovate[bot]".
 #   FRAGMENT_DIR   Fragment directory (default changelog/unreleased/kong-operator).
 #
 # Outputs: `key=value` lines on stdout, and appended to $GITHUB_OUTPUT when
@@ -79,11 +81,13 @@ if [ -n "${PR_JSON_FILE:-}" ]; then
   body="$(jq -r '.body // ""' <<< "$pr_json")"
   labels="$(jq -r '.labels[]?.name // empty' <<< "$pr_json")"
   number="$(jq -r '.number // "" | tostring' <<< "$pr_json")"
+  author="$(jq -r '.user.login // ""' <<< "$pr_json")"
 else
   title="${PR_TITLE:-}"
   body="${PR_BODY:-}"
   labels="${PR_LABELS:-}"
   number="${PR_NUMBER:-}"
+  author="${PR_AUTHOR:-}"
 fi
 
 fragment_path=""
@@ -107,6 +111,34 @@ while IFS= read -r label; do
     exit 0
   fi
 done <<< "$labels"
+
+# Backport/cherry-pick PRs always win too, regardless of what follows the
+# bracket (a backport title like "[Backport release/2.2.x] fix: x" would
+# otherwise parse as a normal Conventional Commit). A backport/cherry-pick
+# PR cherry-picks a commit that already carries the *original* PR's
+# changelog fragment (changelog/unreleased/kong-operator/<originalPR>.yml).
+# Requiring a second fragment named after the backport/cherry-pick PR number
+# is simply wrong: generate.sh would drain both at release time and the same
+# change would appear twice in the release-branch CHANGELOG. These PRs are
+# also bot-created (tibdex/backport, or the cherry-pick job in
+# release-bot.yaml) with no human on the other end able to fix an
+# unmergeable title, so there is no self-healing path if we block them.
+# Anchored (^...) so a human PR merely mentioning "backport" mid-title
+# doesn't slip through -- it must be the literal start of the title. (Not
+# using a trailing \b word-boundary: glibc's regex treats it as a GNU
+# extension, but BSD/macOS regex -- used when running these tests locally on
+# macOS -- does not, so [[ =~ ]] silently fails to match at all there. The
+# anchor alone already rules out mid-title matches, which is the actual
+# requirement; every real title has a space or "]" right after "ackport"
+# anyway.)
+backport_re='^\[[Bb]ackport'
+cherry_pick_re='^\[cherry-pick\]'
+if [[ "$title" =~ $backport_re ]] || [[ "$title" =~ $cherry_pick_re ]]; then
+  emit status exempt
+  emit reason "backport/cherry-pick PR: the original PR's changelog fragment travels with the cherry-picked commit"
+  emit fragment_path "$fragment_path"
+  exit 0
+fi
 
 # JS: /^(\w+)(?:\(([^)]*)\))?(!)?:\s*(.+)$/
 # ERE translation: the non-capturing (?:...) becomes capturing, shifting
@@ -132,6 +164,27 @@ done <<< "$labels"
 # JS is more surgical and self-documenting at the point of use.
 title_re=$'^([A-Za-z0-9_]+)(\\(([^)]*)\\))?(!)?:[ \t\n\r\f\v]*(.+)$'
 if [[ ! "$title" =~ $title_re ]]; then
+  # Known-bot safety net, deliberately scoped to *this* branch only (titles
+  # that fail Conventional Commit parsing), not applied unconditionally
+  # before the regex above. Renovate/Dependabot frequently produce
+  # non-Conventional or flapping titles (e.g. renovate.json's
+  # semanticCommits default of "auto" before this fix, and Dependabot's bare
+  # "Bump x from a to b" -- dependabot.yml sets no commit-message.prefix) and
+  # there is no human on a bot-authored PR to fix an unmergeable title.
+  # Scoping it to the invalid_title branch (rather than checking $author
+  # first) means a bot PR whose title DOES parse -- e.g. Renovate's
+  # "chore(deps): ..." once semanticCommits is "enabled" -- still goes
+  # through normal classification below and still requires a fragment (the
+  # deps-scope override maps it to type=dependency); the exemption never
+  # becomes a blanket bypass for bot authors.
+  case "$author" in
+    renovate\[bot\]|dependabot\[bot\]|*'[bot]')
+      emit status exempt
+      emit reason "PR author '$author' is a known bot and its title is not a Conventional Commit"
+      emit fragment_path "$fragment_path"
+      exit 0
+      ;;
+  esac
   emit status invalid_title
   emit reason "PR title is not a Conventional Commit (e.g. 'fix(dataplane): ...'). Fix the title or add the 'skip-changelog' label."
   emit fragment_path "$fragment_path"
@@ -162,7 +215,19 @@ if [ -n "$cc_scope" ]; then
 fi
 
 # "!" or a "BREAKING CHANGE" body marker overrides everything else.
-if [ -n "$bang" ] || printf '%s' "$body" | grep -q "BREAKING CHANGE"; then
+#
+# Deliberately a pure-bash substring test, not `printf ... | grep -q`: under
+# `set -o pipefail` (this script's shebang line), `grep -q` exits as soon as
+# it finds its first match and closes its end of the pipe; `printf` then
+# gets SIGPIPE (exit 141) writing the rest of a body that hasn't been fully
+# consumed yet, so the pipeline's exit status is non-zero even though grep
+# DID match, and this `if` reads false. That is only reachable once the body
+# is larger than the pipe buffer (64 KiB) and the match is early in it --
+# GitHub's PR body limit is 65536 chars, so it is reachable in production.
+# Confirmed: a ~200KB body with "BREAKING CHANGE" on line 1 silently yielded
+# type=bugfix instead of type=breaking_change. `[[ ... == *...* ]]` never
+# forks a subprocess or opens a pipe, so there is nothing to SIGPIPE.
+if [ -n "$bang" ] || [[ "$body" == *"BREAKING CHANGE"* ]]; then
   type="breaking_change"
 fi
 

--- a/scripts/changelog/pr-fragment-status.sh
+++ b/scripts/changelog/pr-fragment-status.sh
@@ -13,6 +13,9 @@
 #                  .labels[].name, .number). Used by CI, since it avoids
 #                  passing a multiline PR body through a shell env var.
 #                  If set, PR_TITLE/PR_BODY/PR_LABELS/PR_NUMBER are ignored.
+#                  An unreadable file or invalid JSON is reported as
+#                  status=error (see below), not a non-zero exit -- a
+#                  transient `gh api` hiccup must not abort the caller.
 #   PR_TITLE       PR title. Used directly when PR_JSON_FILE is unset.
 #   PR_BODY        PR body (default "").
 #   PR_LABELS      Newline-separated label names (default "").
@@ -20,23 +23,62 @@
 #   FRAGMENT_DIR   Fragment directory (default changelog/unreleased/kong-operator).
 #
 # Outputs: `key=value` lines on stdout, and appended to $GITHUB_OUTPUT when
-# that env var is set.
-#   status         required | exempt | invalid_title
+# that env var is set (multiline-safe: a value containing a newline is
+# written with the `key<<DELIM` heredoc form instead of `key=value`).
+#   status         required | exempt | invalid_title | error
 #   reason         human string, safe to reuse verbatim in logs/errors
 #   type           only when status=required: feature|bugfix|performance|
 #                  dependency|breaking_change
 #   scope          only when status=required (may be empty)
 #   message        only when status=required: the commit subject
-#   fragment_path  <FRAGMENT_DIR>/<PR_NUMBER>.yml (empty if PR_NUMBER unset)
+#   fragment_path  <FRAGMENT_DIR>/<PR_NUMBER>.yml (empty if PR_NUMBER unset,
+#                  including for status=error, which never resolves a
+#                  PR number)
 set -euo pipefail
 
 fragment_dir="${FRAGMENT_DIR:-changelog/unreleased/kong-operator}"
 
+emit() { # key value
+  local key="$1" value="$2"
+  printf '%s=%s\n' "$key" "$value"
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    if [[ "$value" == *$'\n'* ]]; then
+      # Multiline-safe form. Every value emitted today is single-line (PR
+      # titles can't contain newlines), but this makes that an enforced
+      # invariant rather than a silent assumption a future edit could break.
+      local delim="EOF_${RANDOM}_${RANDOM}"
+      {
+        printf '%s<<%s\n' "$key" "$delim"
+        printf '%s\n' "$value"
+        printf '%s\n' "$delim"
+      } >> "$GITHUB_OUTPUT"
+    else
+      printf '%s=%s\n' "$key" "$value" >> "$GITHUB_OUTPUT"
+    fi
+  fi
+}
+
 if [ -n "${PR_JSON_FILE:-}" ]; then
-  title="$(jq -r '.title // ""' "$PR_JSON_FILE")"
-  body="$(jq -r '.body // ""' "$PR_JSON_FILE")"
-  labels="$(jq -r '.labels[]?.name // empty' "$PR_JSON_FILE")"
-  number="$(jq -r '.number // "" | tostring' "$PR_JSON_FILE")"
+  if [ ! -r "${PR_JSON_FILE}" ]; then
+    emit status error
+    emit reason "PR_JSON_FILE '${PR_JSON_FILE}' does not exist or is not readable"
+    emit fragment_path ""
+    exit 0
+  fi
+  # Validate + parse in one step so a malformed PR_JSON_FILE degrades to
+  # status=error instead of aborting the script under `set -e` (jq's
+  # non-zero exit on a parse error would otherwise kill the whole process
+  # mid-run, e.g. because of a transient/malformed `gh api` response).
+  if ! pr_json="$(jq -e -c '.' "${PR_JSON_FILE}" 2>/dev/null)"; then
+    emit status error
+    emit reason "PR_JSON_FILE '${PR_JSON_FILE}' is not valid JSON"
+    emit fragment_path ""
+    exit 0
+  fi
+  title="$(jq -r '.title // ""' <<< "$pr_json")"
+  body="$(jq -r '.body // ""' <<< "$pr_json")"
+  labels="$(jq -r '.labels[]?.name // empty' <<< "$pr_json")"
+  number="$(jq -r '.number // "" | tostring' <<< "$pr_json")"
 else
   title="${PR_TITLE:-}"
   body="${PR_BODY:-}"
@@ -48,13 +90,6 @@ fragment_path=""
 if [ -n "$number" ]; then
   fragment_path="${fragment_dir}/${number}.yml"
 fi
-
-emit() { # key value
-  printf '%s=%s\n' "$1" "$2"
-  if [ -n "${GITHUB_OUTPUT:-}" ]; then
-    printf '%s=%s\n' "$1" "$2" >> "$GITHUB_OUTPUT"
-  fi
-}
 
 trim() {
   local s="$1"
@@ -77,7 +112,25 @@ done <<< "$labels"
 # ERE translation: the non-capturing (?:...) becomes capturing, shifting
 # indices -- group 2 is "(scope)" (with parens), group 3 is the scope
 # content, group 4 is the "!" bang, group 5 is the subject.
-title_re='^([[:alnum:]_]+)(\(([^)]*)\))?(!)?:[[:space:]]*(.+)$'
+#
+# Deliberately NOT [[:alnum:]_] / [[:space:]]: those POSIX classes are
+# locale-sensitive under bash's [[ =~ ]] (glibc regex), so under a UTF-8
+# locale (e.g. C.UTF-8 or en_US.UTF-8 -- both common GitHub Actions runner
+# defaults) [[:alnum:]] matches non-ASCII letters too, e.g. a title starting
+# "féat:" would match and get classified exempt/required instead of
+# invalid_title. JS's \w is always ASCII-only regardless of locale/flags, so
+# matching it exactly means hard-coding ASCII ranges here rather than
+# depending on the runtime locale. The whitespace class is spelled out as
+# literal ASCII space/tab/newline/CR/FF/VT (via $'...' quoting) for the same
+# reason, rather than [[:space:]].
+#
+# A script-wide `export LC_ALL=C` was considered instead (simpler: one line
+# up top instead of a hand-spelled class here) but rejected: it would also
+# silently change trim()'s [[:space:]] and any future [[ =~ ]]/glob added to
+# this file, which is exactly the kind of implicit, easy-to-forget behaviour
+# this fix is trying to eliminate. Pinning the one regex that must match the
+# JS is more surgical and self-documenting at the point of use.
+title_re=$'^([A-Za-z0-9_]+)(\\(([^)]*)\\))?(!)?:[ \t\n\r\f\v]*(.+)$'
 if [[ ! "$title" =~ $title_re ]]; then
   emit status invalid_title
   emit reason "PR title is not a Conventional Commit (e.g. 'fix(dataplane): ...'). Fix the title or add the 'skip-changelog' label."

--- a/scripts/changelog/pr-fragment-status.sh
+++ b/scripts/changelog/pr-fragment-status.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# Decide whether a PR needs a changelog fragment, based on its Conventional
+# Commit title (plus body/labels overrides). Pure function: no git, no `gh`,
+# no filesystem access beyond an optional PR_JSON_FILE. Always exits 0 --
+# policy (failing a check, etc.) belongs to callers.
+#
+# Ports (verbatim in behaviour) the JS that used to be duplicated across two
+# inline `actions/github-script` blocks in
+# .github/workflows/changelog-fragment.yaml.
+#
+# Inputs (env only):
+#   PR_JSON_FILE   Path to a GitHub PR JSON object (.title, .body,
+#                  .labels[].name, .number). Used by CI, since it avoids
+#                  passing a multiline PR body through a shell env var.
+#                  If set, PR_TITLE/PR_BODY/PR_LABELS/PR_NUMBER are ignored.
+#   PR_TITLE       PR title. Used directly when PR_JSON_FILE is unset.
+#   PR_BODY        PR body (default "").
+#   PR_LABELS      Newline-separated label names (default "").
+#   PR_NUMBER      PR number (default "").
+#   FRAGMENT_DIR   Fragment directory (default changelog/unreleased/kong-operator).
+#
+# Outputs: `key=value` lines on stdout, and appended to $GITHUB_OUTPUT when
+# that env var is set.
+#   status         required | exempt | invalid_title
+#   reason         human string, safe to reuse verbatim in logs/errors
+#   type           only when status=required: feature|bugfix|performance|
+#                  dependency|breaking_change
+#   scope          only when status=required (may be empty)
+#   message        only when status=required: the commit subject
+#   fragment_path  <FRAGMENT_DIR>/<PR_NUMBER>.yml (empty if PR_NUMBER unset)
+set -euo pipefail
+
+fragment_dir="${FRAGMENT_DIR:-changelog/unreleased/kong-operator}"
+
+if [ -n "${PR_JSON_FILE:-}" ]; then
+  title="$(jq -r '.title // ""' "$PR_JSON_FILE")"
+  body="$(jq -r '.body // ""' "$PR_JSON_FILE")"
+  labels="$(jq -r '.labels[]?.name // empty' "$PR_JSON_FILE")"
+  number="$(jq -r '.number // "" | tostring' "$PR_JSON_FILE")"
+else
+  title="${PR_TITLE:-}"
+  body="${PR_BODY:-}"
+  labels="${PR_LABELS:-}"
+  number="${PR_NUMBER:-}"
+fi
+
+fragment_path=""
+if [ -n "$number" ]; then
+  fragment_path="${fragment_dir}/${number}.yml"
+fi
+
+emit() { # key value
+  printf '%s=%s\n' "$1" "$2"
+  if [ -n "${GITHUB_OUTPUT:-}" ]; then
+    printf '%s=%s\n' "$1" "$2" >> "$GITHUB_OUTPUT"
+  fi
+}
+
+trim() {
+  local s="$1"
+  s="${s#"${s%%[![:space:]]*}"}"
+  s="${s%"${s##*[![:space:]]}"}"
+  printf '%s' "$s"
+}
+
+# skip-changelog label always wins, regardless of title.
+while IFS= read -r label; do
+  if [ "$label" = "skip-changelog" ]; then
+    emit status exempt
+    emit reason "skip-changelog label present"
+    emit fragment_path "$fragment_path"
+    exit 0
+  fi
+done <<< "$labels"
+
+# JS: /^(\w+)(?:\(([^)]*)\))?(!)?:\s*(.+)$/
+# ERE translation: the non-capturing (?:...) becomes capturing, shifting
+# indices -- group 2 is "(scope)" (with parens), group 3 is the scope
+# content, group 4 is the "!" bang, group 5 is the subject.
+title_re='^([[:alnum:]_]+)(\(([^)]*)\))?(!)?:[[:space:]]*(.+)$'
+if [[ ! "$title" =~ $title_re ]]; then
+  emit status invalid_title
+  emit reason "PR title is not a Conventional Commit (e.g. 'fix(dataplane): ...'). Fix the title or add the 'skip-changelog' label."
+  emit fragment_path "$fragment_path"
+  exit 0
+fi
+
+cc_type="${BASH_REMATCH[1]}"
+cc_scope="${BASH_REMATCH[3]}"
+bang="${BASH_REMATCH[4]}"
+subject="${BASH_REMATCH[5]}"
+
+type=""
+case "$cc_type" in
+  feat) type="feature" ;;
+  fix) type="bugfix" ;;
+  perf) type="performance" ;;
+esac
+
+# deps scope (comma-separated, trimmed) overrides the mapped type.
+if [ -n "$cc_scope" ]; then
+  scope_parts=()
+  IFS=',' read -ra scope_parts <<< "$cc_scope"
+  for part in "${scope_parts[@]}"; do
+    if [ "$(trim "$part")" = "deps" ]; then
+      type="dependency"
+    fi
+  done
+fi
+
+# "!" or a "BREAKING CHANGE" body marker overrides everything else.
+if [ -n "$bang" ] || printf '%s' "$body" | grep -q "BREAKING CHANGE"; then
+  type="breaking_change"
+fi
+
+if [ -z "$type" ]; then
+  skip_types="docs test chore ci refactor style build"
+  is_skip=""
+  for s in $skip_types; do
+    [ "$cc_type" = "$s" ] && is_skip=1
+  done
+  emit status exempt
+  if [ -n "$is_skip" ]; then
+    emit reason "non-releasable commit type '$cc_type'"
+  else
+    emit reason "unmapped commit type '$cc_type'"
+  fi
+  emit fragment_path "$fragment_path"
+  exit 0
+fi
+
+allowed_scopes="dataplane controlplane gateway hybridgateway konnect aigateway eventgateway crd deps"
+scope=""
+for s in $allowed_scopes; do
+  [ "$cc_scope" = "$s" ] && scope="$cc_scope"
+done
+
+emit status required
+emit reason "conventional commit type '$cc_type' requires a changelog fragment (type=$type)"
+emit type "$type"
+emit scope "$scope"
+emit message "$subject"
+emit fragment_path "$fragment_path"

--- a/scripts/changelog/tests/run.sh
+++ b/scripts/changelog/tests/run.sh
@@ -25,4 +25,43 @@ scripts/changelog/normalize-section.sh "$here/normalize/raw.md" "v2.4.0" "2026-0
 check "normalize-section" "$out" "$here/normalize/expected.md"
 rm -f "$out"
 
+# --- generate test (uses stub tool + isolated work dir) ---
+work="$(mktemp -d)"
+mkdir -p "$work/changelog/unreleased/kong-operator"
+cat > "$work/CHANGELOG.md" <<'EOF'
+# Changelog
+
+## Table of Contents
+
+- [v2.3.0](#v230)
+
+## [v2.3.0]
+
+> Release date: 2026-07-01
+
+### Fixes
+
+- Old fix.
+  [#1](https://github.com/Kong/kong-operator/pull/1)
+EOF
+cat > "$work/changelog/unreleased/kong-operator/99.yaml" <<'EOF'
+message: Stub feature entry.
+type: feature
+EOF
+repo_root="$PWD"
+(
+  cd "$work"
+  CHANGELOG_BIN="$repo_root/scripts/changelog/tests/stub-changelog" \
+  RELEASE_DATE="2026-08-01" \
+  "$repo_root/scripts/changelog/generate.sh" "v2.4.0"
+)
+# fragment archived
+[ -f "$work/changelog/v2.4.0/99.yaml" ] && echo "ok   - generate: fragment archived" || { echo "FAIL - generate: fragment not archived"; fail=1; }
+[ -z "$(ls -A "$work/changelog/unreleased/kong-operator" | grep -v '^\.gitkeep$' || true)" ] && echo "ok   - generate: unreleased drained" || { echo "FAIL - generate: unreleased not drained"; fail=1; }
+# section + TOC present
+grep -q '^- \[v2.4.0\](#v240)$' "$work/CHANGELOG.md" && echo "ok   - generate: toc entry" || { echo "FAIL - generate: no toc entry"; fail=1; }
+grep -q '^## \[v2.4.0\]$' "$work/CHANGELOG.md" && echo "ok   - generate: section heading" || { echo "FAIL - generate: no section heading"; fail=1; }
+grep -q '^> Release date: 2026-08-01$' "$work/CHANGELOG.md" && echo "ok   - generate: release date" || { echo "FAIL - generate: no release date"; fail=1; }
+rm -rf "$work"
+
 exit "$fail"

--- a/scripts/changelog/tests/run.sh
+++ b/scripts/changelog/tests/run.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+cd "$(dirname "$0")/../../.." # repo root
+here="scripts/changelog/tests/testdata"
+fail=0
+
+check() { # name actual expected
+  if diff -u "$3" "$2" >/dev/null; then
+    echo "ok   - $1"
+  else
+    echo "FAIL - $1"; diff -u "$3" "$2" || true; fail=1
+  fi
+}
+
+# --- merge test ---
+tmp="$(mktemp)"
+cp "$here/merge/input-changelog.md" "$tmp"
+scripts/changelog/merge-changelog.sh "$tmp" "$here/merge/section.md" "v2.4.0"
+check "merge-changelog" "$tmp" "$here/merge/expected-changelog.md"
+rm -f "$tmp"
+
+exit "$fail"

--- a/scripts/changelog/tests/run.sh
+++ b/scripts/changelog/tests/run.sh
@@ -64,4 +64,16 @@ grep -q '^## \[v2.4.0\]$' "$work/CHANGELOG.md" && echo "ok   - generate: section
 grep -q '^> Release date: 2026-08-01$' "$work/CHANGELOG.md" && echo "ok   - generate: release date" || { echo "FAIL - generate: no release date"; fail=1; }
 rm -rf "$work"
 
+# --- verify test ---
+if scripts/changelog/verify.sh "$here/verify/good" >/dev/null 2>&1; then
+  echo "ok   - verify: accepts good fragments"
+else
+  echo "FAIL - verify: rejected good fragments"; fail=1
+fi
+if scripts/changelog/verify.sh "$here/verify/bad" >/dev/null 2>&1; then
+  echo "FAIL - verify: accepted bad fragment"; fail=1
+else
+  echo "ok   - verify: rejects bad fragments"
+fi
+
 exit "$fail"

--- a/scripts/changelog/tests/run.sh
+++ b/scripts/changelog/tests/run.sh
@@ -19,4 +19,10 @@ scripts/changelog/merge-changelog.sh "$tmp" "$here/merge/section.md" "v2.4.0"
 check "merge-changelog" "$tmp" "$here/merge/expected-changelog.md"
 rm -f "$tmp"
 
+# --- normalize test ---
+out="$(mktemp)"
+scripts/changelog/normalize-section.sh "$here/normalize/raw.md" "v2.4.0" "2026-08-01" > "$out"
+check "normalize-section" "$out" "$here/normalize/expected.md"
+rm -f "$out"
+
 exit "$fail"

--- a/scripts/changelog/tests/run.sh
+++ b/scripts/changelog/tests/run.sh
@@ -64,6 +64,102 @@ grep -q '^## \[v2.4.0\]$' "$work/CHANGELOG.md" && echo "ok   - generate: section
 grep -q '^> Release date: 2026-08-01$' "$work/CHANGELOG.md" && echo "ok   - generate: release date" || { echo "FAIL - generate: no release date"; fail=1; }
 rm -rf "$work"
 
+# --- generate: empty-section guard test (uses a stub that emits no entries,
+# mimicking the real tool when every fragment gets skipped e.g. due to a
+# wrong file extension) ---
+work="$(mktemp -d)"
+mkdir -p "$work/changelog/unreleased/kong-operator"
+cat > "$work/CHANGELOG.md" <<'EOF'
+# Changelog
+
+## Table of Contents
+
+- [v2.3.0](#v230)
+
+## [v2.3.0]
+
+> Release date: 2026-07-01
+
+### Fixes
+
+- Old fix.
+  [#1](https://github.com/Kong/kong-operator/pull/1)
+EOF
+cp "$work/CHANGELOG.md" "$work/CHANGELOG.md.orig"
+cat > "$work/changelog/unreleased/kong-operator/100.yaml" <<'EOF'
+message: Entry the empty stub will not surface.
+type: feature
+EOF
+repo_root="$PWD"
+set +e
+(
+  cd "$work"
+  CHANGELOG_BIN="$repo_root/scripts/changelog/tests/stub-changelog-empty" \
+  RELEASE_DATE="2026-08-01" \
+  "$repo_root/scripts/changelog/generate.sh" "v2.4.0"
+) >"$work/generate.out" 2>"$work/generate.err"
+rc=$?
+set -e
+if [ "$rc" -ne 0 ] && grep -q "refusing to archive fragments" "$work/generate.err"; then
+  echo "ok   - generate: empty section guard fails loudly"
+else
+  echo "FAIL - generate: empty section guard did not fail as expected (rc=$rc)"; cat "$work/generate.err"; fail=1
+fi
+[ -f "$work/changelog/unreleased/kong-operator/100.yaml" ] && echo "ok   - generate: guard leaves fragment un-archived" || { echo "FAIL - generate: guard archived fragment despite empty section"; fail=1; }
+[ ! -d "$work/changelog/v2.4.0" ] && echo "ok   - generate: guard creates no archive dir" || { echo "FAIL - generate: guard created archive dir despite empty section"; fail=1; }
+diff -u "$work/CHANGELOG.md.orig" "$work/CHANGELOG.md" >/dev/null && echo "ok   - generate: guard leaves CHANGELOG.md untouched" || { echo "FAIL - generate: guard modified CHANGELOG.md"; fail=1; }
+rm -rf "$work"
+
+# --- real-tool extension filter test ---
+# The pinned gateway-changelog binary only recognizes *.yml fragments and
+# silently skips *.yaml ones (a debug-level "Skipping file" log line, no
+# error, no warning at normal verbosity). The stub used above ignores file
+# content/extension entirely, so it structurally cannot catch this. Exercise
+# the real installed binary directly to pin this behavior down.
+changelog_version=""
+if command -v yq >/dev/null 2>&1; then
+  changelog_version="$(yq -r '.changelog' .tools_versions.yaml 2>/dev/null | sed 's/^v//')"
+fi
+default_changelog_bin="$PWD/bin/installs/github-kong-gateway-changelog/${changelog_version:-unknown}/changelog"
+real_bin="${CHANGELOG_BIN:-$default_changelog_bin}"
+
+if [ -z "${GITHUB_TOKEN:-}" ]; then
+  echo "skip - real-tool: extension filter (GITHUB_TOKEN not set)"
+elif [ ! -x "$real_bin" ]; then
+  echo "skip - real-tool: extension filter (binary not found at $real_bin; run 'make changelog-tool')"
+else
+  ext_dir=".changelog-realtool-test-$$"
+  rm -rf "$ext_dir"
+  mkdir -p "$ext_dir"
+
+  # .yaml fragment: must be silently skipped, never reach processing/output.
+  printf 'message: Realtool yaml marker should not appear.\ntype: bugfix\n' > "$ext_dir/1.yaml"
+  yaml_out="$("$real_bin" --debug generate --repo-path . --changelog-paths "$ext_dir" \
+    --title "vRealToolTest" --github-issue-repo Kong/kong-operator --github-api-repo Kong/kong-operator 2>&1)"
+  if echo "$yaml_out" | grep -q "Realtool yaml marker"; then
+    echo "FAIL - real-tool: .yaml fragment was processed (expected silent skip)"; fail=1
+  elif echo "$yaml_out" | grep -q "Skipping file: 1.yaml"; then
+    echo "ok   - real-tool: .yaml fragment silently skipped"
+  else
+    echo "FAIL - real-tool: unexpected output for .yaml fragment"; echo "$yaml_out"; fail=1
+  fi
+  rm -f "$ext_dir"/*.yaml
+
+  # .yml fragment: must reach the processing path. A "no commits found" error
+  # is expected and fine here (this file is untracked scratch data) -- it
+  # proves the file got past the extension filter and into processing.
+  printf 'message: Realtool yml marker should be processed.\ntype: bugfix\n' > "$ext_dir/1.yml"
+  yml_out="$("$real_bin" --debug generate --repo-path . --changelog-paths "$ext_dir" \
+    --title "vRealToolTest" --github-issue-repo Kong/kong-operator --github-api-repo Kong/kong-operator 2>&1)"
+  if echo "$yml_out" | grep -q "processing changelog file: 1.yml"; then
+    echo "ok   - real-tool: .yml fragment reaches processing path"
+  else
+    echo "FAIL - real-tool: .yml fragment did not reach processing path"; echo "$yml_out"; fail=1
+  fi
+
+  rm -rf "$ext_dir"
+fi
+
 # --- verify test ---
 if scripts/changelog/verify.sh "$here/verify/good" >/dev/null 2>&1; then
   echo "ok   - verify: accepts good fragments"

--- a/scripts/changelog/tests/run.sh
+++ b/scripts/changelog/tests/run.sh
@@ -173,16 +173,32 @@ else
 fi
 
 # --- pr-fragment-status: table-driven golden tests ---
-# Columns: name | PR_TITLE | PR_BODY | PR_LABELS | expected status | expected type | expected scope
-pfs_check() { # name title body labels expect_status expect_type expect_scope
-  local name="$1" title="$2" body="$3" labels="$4" exp_status="$5" exp_type="${6:-}" exp_scope="${7:-}"
-  local out status type scope
-  out="$(PR_TITLE="$title" PR_BODY="$body" PR_LABELS="$labels" PR_NUMBER=1 scripts/changelog/pr-fragment-status.sh)"
+# Columns: name | PR_TITLE | PR_BODY | PR_LABELS | expected status | expected
+# type | expected scope | expected author (optional, default "")
+#
+# Every call also asserts fragment_path against the default
+# FRAGMENT_DIR/1.yml (PR_NUMBER is always 1 here) -- this is I3's fix: a
+# reviewer once changed the script's `${number}.yml` to `${number}.yaml` and
+# the whole suite still passed because nothing pinned fragment_path, even
+# though that's the exact value the changelog-gate CI job compares against
+# an on-disk file. Asserting it on every row (not just a dedicated case)
+# means any future edit to fragment_path construction is caught everywhere,
+# not just in one narrow test.
+pfs_check() { # name title body labels expect_status expect_type expect_scope expect_author
+  local name="$1" title="$2" body="$3" labels="$4" exp_status="$5" exp_type="${6:-}" exp_scope="${7:-}" author="${8:-}"
+  local out status type scope fragment_path exp_fragment_path
+  exp_fragment_path="changelog/unreleased/kong-operator/1.yml"
+  out="$(PR_TITLE="$title" PR_BODY="$body" PR_LABELS="$labels" PR_NUMBER=1 PR_AUTHOR="$author" scripts/changelog/pr-fragment-status.sh)"
   status="$(echo "$out" | sed -n 's/^status=//p')"
   type="$(echo "$out" | sed -n 's/^type=//p')"
   scope="$(echo "$out" | sed -n 's/^scope=//p')"
+  fragment_path="$(echo "$out" | sed -n 's/^fragment_path=//p')"
   if [ "$status" != "$exp_status" ]; then
     echo "FAIL - pr-fragment-status: $name (status got '$status' want '$exp_status')"; echo "$out"; fail=1
+    return
+  fi
+  if [ "$fragment_path" != "$exp_fragment_path" ]; then
+    echo "FAIL - pr-fragment-status: $name (fragment_path got '$fragment_path' want '$exp_fragment_path')"; echo "$out"; fail=1
     return
   fi
   if [ "$exp_status" = "required" ]; then
@@ -214,6 +230,55 @@ pfs_check "multi-scope with deps still maps to dependency, scope blanked" \
   "fix(deps,ci): x" "" "" required dependency ""
 pfs_check "bang on a non-releasable type still forces breaking_change" \
   "docs!: x" "" "" required breaking_change ""
+
+# --- pr-fragment-status: P0 exemptions (bot-authored/backport PRs must not
+# hard-block, but the gate must stay meaningful for humans) ---
+pfs_check "backport PR title is exempt regardless of the inner commit type" \
+  "[Backport release/2.2.x] fix: fix reconcile compare bugs" "" "" exempt
+pfs_check "backport PR title is exempt (non-releasable inner type too)" \
+  "[Backport release/2.2.x] test(envtest): stabilize config error envtest event assertions" "" "" exempt
+pfs_check "cherry-pick PR title is exempt" \
+  "[cherry-pick] v2.4.0 - abc123def456789" "" "" exempt
+pfs_check "a human title merely mentioning backport mid-title is NOT exempt (anchored, no mid-title match)" \
+  "fix: revert accidental backport regression" "" "" required bugfix ""
+pfs_check "renovate[bot] with today's bare, non-Conventional title is exempt" \
+  "Update module github.com/kong/go-kong to v0.78.0 (main)" "" "" exempt "" "" "renovate[bot]"
+pfs_check "dependabot[bot] with a bare, non-Conventional title is exempt" \
+  "Bump github.com/foo/bar from 1.0.0 to 1.0.1" "" "" exempt "" "" "dependabot[bot]"
+pfs_check "any other GitHub App bot ('*[bot]') with a bare title is exempt" \
+  "Automated update" "" "" exempt "" "" "github-actions[bot]"
+pfs_check "a HUMAN with a non-Conventional title is still invalid_title -- the gate is not toothless" \
+  "not a conventional title" "" "" invalid_title "" "" "octocat"
+pfs_check "renovate[bot] with a parseable deps title (post semanticCommits:enabled) still requires a fragment" \
+  "chore(deps): update module github.com/kong/go-kong to v0.78.0" "" "" required dependency deps "renovate[bot]"
+
+# --- pr-fragment-status: SIGPIPE misclassification on a large body (I6) ---
+# Reproduces the real bug: `printf '%s' "$body" | grep -q "BREAKING CHANGE"`
+# under `set -o pipefail` -- grep exits as soon as it finds the match and
+# closes its end of the pipe, printf gets SIGPIPE (141) because it hasn't
+# finished writing a body bigger than the 64 KiB pipe buffer, and the `if`
+# reads that non-zero pipeline status as "not found". GitHub's PR body limit
+# (65536 chars) exceeds the pipe buffer, so this was reachable in
+# production. Confirmed manually: with the old grep-pipe pattern this exact
+# body classifies as bugfix; with the pure-bash `[[ == *...* ]]` fix it
+# correctly classifies as breaking_change.
+big_body="$(printf 'BREAKING CHANGE: this changes the wire format.\n'; head -c 70000 /dev/zero | tr '\0' 'x')"
+out="$(PR_TITLE="fix: x" PR_BODY="$big_body" PR_LABELS="" PR_NUMBER=1 scripts/changelog/pr-fragment-status.sh)"
+type="$(echo "$out" | sed -n 's/^type=//p')"
+if [ "$type" = "breaking_change" ]; then
+  echo "ok   - pr-fragment-status: BREAKING CHANGE detected in a >64KiB body (I6 SIGPIPE regression)"
+else
+  echo "FAIL - pr-fragment-status: BREAKING CHANGE not detected in a >64KiB body (type got '$type' want 'breaking_change')"; fail=1
+fi
+
+# --- pr-fragment-status: fragment_path honours a FRAGMENT_DIR override (I3) ---
+out="$(FRAGMENT_DIR="custom/dir" PR_TITLE="fix: x" PR_BODY="" PR_LABELS="" PR_NUMBER=7 scripts/changelog/pr-fragment-status.sh)"
+fragment_path="$(echo "$out" | sed -n 's/^fragment_path=//p')"
+if [ "$fragment_path" = "custom/dir/7.yml" ]; then
+  echo "ok   - pr-fragment-status: FRAGMENT_DIR override is reflected in fragment_path"
+else
+  echo "FAIL - pr-fragment-status: FRAGMENT_DIR override (fragment_path got '$fragment_path' want 'custom/dir/7.yml')"; fail=1
+fi
 
 # --- pr-fragment-status: PR_JSON_FILE mode ---
 # The PR_TITLE-mode cases above never touch the jq/PR_JSON_FILE code path,
@@ -254,6 +319,8 @@ pfs_json_check "missing PR_JSON_FILE degrades to error, not a crash" \
   "__MISSING__" error
 pfs_json_check "malformed PR_JSON_FILE degrades to error, not a crash" \
   'not json at all {{{' error
+pfs_json_check "bot author (.user.login) read from PR_JSON_FILE exempts a bare renovate title" \
+  '{"title":"Update module github.com/kong/go-kong to v0.78.0 (main)","body":"","labels":[],"number":1,"user":{"login":"renovate[bot]"}}' exempt
 
 # --- pr-fragment-status: locale-independence of the title regex ---
 # [[:alnum:]]/[[:space:]] are locale-sensitive under bash's [[ =~ ]]; under a
@@ -261,6 +328,11 @@ pfs_json_check "malformed PR_JSON_FILE degrades to error, not a crash" \
 # non-ASCII letters, diverging from the JS this script replaces (\w is
 # always ASCII-only). Assert the ASCII-only title_re now agrees with the JS
 # regardless of locale.
+# Returns 2 specifically when skipped (locale unavailable), so the caller
+# can tell "skip" apart from "ran and passed/failed" (see locale_exercised
+# below, I8's fix) -- otherwise this whole block can go green on a machine
+# that has neither locale installed, without ever re-exercising the
+# regression fixed in 0a0d4afd3.
 pfs_locale_check() { # name locale title expect_status
   local name="$1" loc="$2" title="$3" exp_status="$4"
   local out status
@@ -270,21 +342,39 @@ pfs_locale_check() { # name locale title expect_status
   # "not available". The subshell keeps that relaxation local to this check.
   if ! ( set +o pipefail; locale -a 2>/dev/null | grep -qx "$loc" ); then
     echo "skip - pr-fragment-status(locale): $name (locale '$loc' not available on this machine)"
-    return
+    return 2
   fi
   out="$(LC_ALL="$loc" PR_TITLE="$title" PR_BODY="" PR_LABELS="" PR_NUMBER=1 scripts/changelog/pr-fragment-status.sh)"
   status="$(echo "$out" | sed -n 's/^status=//p')"
   if [ "$status" != "$exp_status" ]; then
     echo "FAIL - pr-fragment-status(locale): $name [$loc] (status got '$status' want '$exp_status')"; echo "$out"; fail=1
-    return
+    return 0
   fi
   echo "ok   - pr-fragment-status(locale): $name [$loc]"
+  return 0
 }
 
+# I8: if neither locale is available anywhere on this machine, every case in
+# the loop below prints "skip" and (before this fix) the suite stayed green
+# with the locale-independence regression silently unexercised. Track
+# whether at least one case actually ran and fail loudly if not.
+locale_exercised=0
 for loc in C.UTF-8 en_US.UTF-8; do
-  pfs_locale_check "non-ASCII commit type matches JS (invalid_title)" "$loc" "féat: x" invalid_title
-  pfs_locale_check "plain ASCII commit type still required" "$loc" "feat: x" required
+  # `|| rc=$?` (not a bare call + `$?` on the next line) so that this
+  # script's own `set -e` doesn't abort the whole suite when a locale is
+  # missing and the function returns 2 -- a command on the left of `||` is
+  # exempt from errexit, but a bare non-zero return is not.
+  rc=0
+  pfs_locale_check "non-ASCII commit type matches JS (invalid_title)" "$loc" "féat: x" invalid_title || rc=$?
+  [ "$rc" -ne 2 ] && locale_exercised=1
+  rc=0
+  pfs_locale_check "plain ASCII commit type still required" "$loc" "feat: x" required || rc=$?
+  [ "$rc" -ne 2 ] && locale_exercised=1
 done
+if [ "$locale_exercised" -eq 0 ]; then
+  echo "FAIL - pr-fragment-status(locale): neither C.UTF-8 nor en_US.UTF-8 is installed on this machine -- the locale-independence regression test (fixed in 0a0d4afd3) ran zero times this run"
+  fail=1
+fi
 
 # --- skippable-paths: table-driven golden tests ---
 # Drives check-docs-only-changes.sh via the CHANGED_FILES override (no git

--- a/scripts/changelog/tests/run.sh
+++ b/scripts/changelog/tests/run.sh
@@ -286,4 +286,40 @@ for loc in C.UTF-8 en_US.UTF-8; do
   pfs_locale_check "plain ASCII commit type still required" "$loc" "feat: x" required
 done
 
+# --- skippable-paths: table-driven golden tests ---
+# Drives check-docs-only-changes.sh via the CHANGED_FILES override (no git
+# needed). The NOT-skippable direction is the important half: it's what
+# stops a future well-meaning broadening of the regex from silently
+# disabling CI for real code.
+skp_check() { # name changed_files(newline-separated) expect_docs_only
+  local name="$1" files="$2" exp="$3"
+  local out docs_only
+  out="$(CHANGED_FILES="$files" GITHUB_OUTPUT=/dev/stdout scripts/check-docs-only-changes.sh)"
+  docs_only="$(echo "$out" | sed -n 's/^docs_only=//p')"
+  if [ "$docs_only" != "$exp" ]; then
+    echo "FAIL - skippable-paths: $name (docs_only got '$docs_only' want '$exp')"; echo "$out"; fail=1
+    return
+  fi
+  echo "ok   - skippable-paths: $name"
+}
+
+skp_check "per-PR fragment alone is skippable" \
+  "changelog/unreleased/kong-operator/4999.yml" true
+skp_check "a markdown file alone is skippable" \
+  "docs/some-page.md" true
+skp_check "fragment + markdown mix is skippable" \
+  "$(printf 'changelog/unreleased/kong-operator/4999.yml\ndocs/some-page.md')" true
+skp_check "a real script is not skippable" \
+  "scripts/changelog/verify.sh" false
+skp_check "the fragment-scaffolding workflow itself is not skippable" \
+  ".github/workflows/changelog-fragment.yaml" false
+skp_check "the schema template doc is not skippable" \
+  "changelog/unreleased/kong-operator/CHANGELOG_TEMPLATE.yaml" false
+skp_check "wrong extension (.yaml instead of .yml) is not skippable" \
+  "changelog/unreleased/kong-operator/4999.yaml" false
+skp_check "a Go file is not skippable" \
+  "controller/dataplane/controller.go" false
+skp_check "one non-skippable file poisons a fragment mix" \
+  "$(printf 'changelog/unreleased/kong-operator/4999.yml\ncontroller/dataplane/controller.go')" false
+
 exit "$fail"

--- a/scripts/changelog/tests/run.sh
+++ b/scripts/changelog/tests/run.sh
@@ -172,4 +172,47 @@ else
   echo "ok   - verify: rejects bad fragments"
 fi
 
+# --- pr-fragment-status: table-driven golden tests ---
+# Columns: name | PR_TITLE | PR_BODY | PR_LABELS | expected status | expected type | expected scope
+pfs_check() { # name title body labels expect_status expect_type expect_scope
+  local name="$1" title="$2" body="$3" labels="$4" exp_status="$5" exp_type="${6:-}" exp_scope="${7:-}"
+  local out status type scope
+  out="$(PR_TITLE="$title" PR_BODY="$body" PR_LABELS="$labels" PR_NUMBER=1 scripts/changelog/pr-fragment-status.sh)"
+  status="$(echo "$out" | sed -n 's/^status=//p')"
+  type="$(echo "$out" | sed -n 's/^type=//p')"
+  scope="$(echo "$out" | sed -n 's/^scope=//p')"
+  if [ "$status" != "$exp_status" ]; then
+    echo "FAIL - pr-fragment-status: $name (status got '$status' want '$exp_status')"; echo "$out"; fail=1
+    return
+  fi
+  if [ "$exp_status" = "required" ]; then
+    if [ "$type" != "$exp_type" ] || [ "$scope" != "$exp_scope" ]; then
+      echo "FAIL - pr-fragment-status: $name (type/scope got '$type'/'$scope' want '$exp_type'/'$exp_scope')"; echo "$out"; fail=1
+      return
+    fi
+  fi
+  echo "ok   - pr-fragment-status: $name"
+}
+
+pfs_check "deps scope on a chore title (historical drift bug)" \
+  "chore(deps): bump x" "" "" required dependency deps
+pfs_check "chore is exempt" \
+  "chore: x" "" "" exempt
+pfs_check "bang forces breaking_change" \
+  "feat!: x" "" "" required breaking_change ""
+pfs_check "BREAKING CHANGE in body forces breaking_change" \
+  "fix: x" "BREAKING CHANGE: yes" "" required breaking_change ""
+pfs_check "scoped perf maps to performance, scope kept" \
+  "perf(dataplane): x" "" "" required performance dataplane
+pfs_check "scope not in allowlist is blanked" \
+  "feat(weirdscope): x" "" "" required feature ""
+pfs_check "non-conventional title is invalid" \
+  "no colon here" "" "" invalid_title
+pfs_check "skip-changelog label exempts regardless of title" \
+  "no colon here" "" "skip-changelog" exempt
+pfs_check "multi-scope with deps still maps to dependency, scope blanked" \
+  "fix(deps,ci): x" "" "" required dependency ""
+pfs_check "bang on a non-releasable type still forces breaking_change" \
+  "docs!: x" "" "" required breaking_change ""
+
 exit "$fail"

--- a/scripts/changelog/tests/run.sh
+++ b/scripts/changelog/tests/run.sh
@@ -215,4 +215,75 @@ pfs_check "multi-scope with deps still maps to dependency, scope blanked" \
 pfs_check "bang on a non-releasable type still forces breaking_change" \
   "docs!: x" "" "" required breaking_change ""
 
+# --- pr-fragment-status: PR_JSON_FILE mode ---
+# The PR_TITLE-mode cases above never touch the jq/PR_JSON_FILE code path,
+# which is what the changelog-gate CI job actually uses (via `gh api ... >
+# pr.json`). Exercise that path directly, including the failure shapes a
+# transient/malformed `gh api` response can produce -- the script must
+# always exit 0 (policy belongs to callers) even then.
+pfs_json_check() { # name json_content_or_empty_for_missing expect_status
+  local name="$1" json="$2" exp_status="$3"
+  local jf out rc status
+  jf="$(mktemp)"
+  if [ "$json" = "__MISSING__" ]; then
+    rm -f "$jf"
+    jf="/nonexistent-path/does-not-exist-$$.json"
+  else
+    printf '%s' "$json" > "$jf"
+  fi
+  set +e
+  out="$(PR_JSON_FILE="$jf" scripts/changelog/pr-fragment-status.sh)"
+  rc=$?
+  set -e
+  [ "$json" != "__MISSING__" ] && rm -f "$jf"
+  if [ "$rc" -ne 0 ]; then
+    echo "FAIL - pr-fragment-status(json): $name (expected exit 0, got $rc)"; echo "$out"; fail=1
+    return
+  fi
+  status="$(echo "$out" | sed -n 's/^status=//p')"
+  if [ "$status" != "$exp_status" ]; then
+    echo "FAIL - pr-fragment-status(json): $name (status got '$status' want '$exp_status')"; echo "$out"; fail=1
+    return
+  fi
+  echo "ok   - pr-fragment-status(json): $name"
+}
+
+pfs_json_check "valid PR JSON produces expected decision" \
+  '{"title":"fix(dataplane): x","body":"","labels":[],"number":42}' required
+pfs_json_check "missing PR_JSON_FILE degrades to error, not a crash" \
+  "__MISSING__" error
+pfs_json_check "malformed PR_JSON_FILE degrades to error, not a crash" \
+  'not json at all {{{' error
+
+# --- pr-fragment-status: locale-independence of the title regex ---
+# [[:alnum:]]/[[:space:]] are locale-sensitive under bash's [[ =~ ]]; under a
+# UTF-8 locale (a common GitHub Actions runner default) they'd match
+# non-ASCII letters, diverging from the JS this script replaces (\w is
+# always ASCII-only). Assert the ASCII-only title_re now agrees with the JS
+# regardless of locale.
+pfs_locale_check() { # name locale title expect_status
+  local name="$1" loc="$2" title="$3" exp_status="$4"
+  local out status
+  # Scoped `set +o pipefail`: under this script's pipefail, `grep -q`
+  # closing the pipe on its first match sends SIGPIPE to `locale -a`, which
+  # then exits non-zero (141) even though the locale *was* found -- a false
+  # "not available". The subshell keeps that relaxation local to this check.
+  if ! ( set +o pipefail; locale -a 2>/dev/null | grep -qx "$loc" ); then
+    echo "skip - pr-fragment-status(locale): $name (locale '$loc' not available on this machine)"
+    return
+  fi
+  out="$(LC_ALL="$loc" PR_TITLE="$title" PR_BODY="" PR_LABELS="" PR_NUMBER=1 scripts/changelog/pr-fragment-status.sh)"
+  status="$(echo "$out" | sed -n 's/^status=//p')"
+  if [ "$status" != "$exp_status" ]; then
+    echo "FAIL - pr-fragment-status(locale): $name [$loc] (status got '$status' want '$exp_status')"; echo "$out"; fail=1
+    return
+  fi
+  echo "ok   - pr-fragment-status(locale): $name [$loc]"
+}
+
+for loc in C.UTF-8 en_US.UTF-8; do
+  pfs_locale_check "non-ASCII commit type matches JS (invalid_title)" "$loc" "féat: x" invalid_title
+  pfs_locale_check "plain ASCII commit type still required" "$loc" "feat: x" required
+done
+
 exit "$fail"

--- a/scripts/changelog/tests/stub-changelog
+++ b/scripts/changelog/tests/stub-changelog
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Test stub mimicking `gateway-changelog generate`. Ignores all flags.
+set -euo pipefail
+cat <<'EOF'
+
+# stub-title
+
+### Features
+
+- Stub feature entry.
+  [#99](https://github.com/Kong/kong-operator/pull/99)
+EOF

--- a/scripts/changelog/tests/stub-changelog-empty
+++ b/scripts/changelog/tests/stub-changelog-empty
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Test stub mimicking `gateway-changelog generate` when every fragment was
+# skipped (e.g. wrong file extension): emits a title but no entries, the same
+# shape the real tool produces in that failure mode. Ignores all flags.
+set -euo pipefail
+cat <<'EOF'
+
+# stub-title
+
+
+
+EOF

--- a/scripts/changelog/tests/testdata/merge/expected-changelog.md
+++ b/scripts/changelog/tests/testdata/merge/expected-changelog.md
@@ -1,0 +1,24 @@
+# Changelog
+
+## Table of Contents
+
+- [v2.4.0](#v240)
+- [v2.3.0](#v230)
+
+## [v2.4.0]
+
+> Release date: 2026-08-01
+
+### Features
+
+- Something new.
+  [#2](https://github.com/Kong/kong-operator/pull/2)
+
+## [v2.3.0]
+
+> Release date: 2026-07-01
+
+### Fixes
+
+- Something old.
+  [#1](https://github.com/Kong/kong-operator/pull/1)

--- a/scripts/changelog/tests/testdata/merge/input-changelog.md
+++ b/scripts/changelog/tests/testdata/merge/input-changelog.md
@@ -1,0 +1,14 @@
+# Changelog
+
+## Table of Contents
+
+- [v2.3.0](#v230)
+
+## [v2.3.0]
+
+> Release date: 2026-07-01
+
+### Fixes
+
+- Something old.
+  [#1](https://github.com/Kong/kong-operator/pull/1)

--- a/scripts/changelog/tests/testdata/merge/section.md
+++ b/scripts/changelog/tests/testdata/merge/section.md
@@ -1,0 +1,8 @@
+## [v2.4.0]
+
+> Release date: 2026-08-01
+
+### Features
+
+- Something new.
+  [#2](https://github.com/Kong/kong-operator/pull/2)

--- a/scripts/changelog/tests/testdata/normalize/expected.md
+++ b/scripts/changelog/tests/testdata/normalize/expected.md
@@ -1,0 +1,8 @@
+## [v2.4.0]
+
+> Release date: 2026-08-01
+
+### Features
+
+- Something new.
+  [#2](https://github.com/Kong/kong-operator/pull/2)

--- a/scripts/changelog/tests/testdata/normalize/raw.md
+++ b/scripts/changelog/tests/testdata/normalize/raw.md
@@ -1,0 +1,7 @@
+
+# v2.4.0
+
+### Features
+
+- Something new.
+  [#2](https://github.com/Kong/kong-operator/pull/2)

--- a/scripts/changelog/tests/testdata/verify/bad/2.yaml
+++ b/scripts/changelog/tests/testdata/verify/bad/2.yaml
@@ -1,0 +1,1 @@
+message: Missing type below.

--- a/scripts/changelog/tests/testdata/verify/good/1.yaml
+++ b/scripts/changelog/tests/testdata/verify/good/1.yaml
@@ -1,0 +1,3 @@
+message: A valid entry.
+type: bugfix
+scope: dataplane

--- a/scripts/changelog/verify.sh
+++ b/scripts/changelog/verify.sh
@@ -1,0 +1,27 @@
+#!/usr/bin/env bash
+# Schema-lint changelog fragments in a directory.
+# Usage: verify.sh [dir]   (default: changelog/unreleased/kong-operator)
+set -euo pipefail
+
+dir="${1:-changelog/unreleased/kong-operator}"
+allowed="feature bugfix dependency deprecation breaking_change performance"
+rc=0
+
+shopt -s nullglob
+for f in "$dir"/*.yaml "$dir"/*.yml; do
+  case "$(basename "$f")" in CHANGELOG_TEMPLATE.yaml) continue ;; esac
+
+  msg="$(yq -r '.message // ""' "$f")"
+  if [ -z "$msg" ] || [ "$msg" = "null" ]; then
+    echo "ERROR: $f: missing required 'message'"; rc=1
+  fi
+
+  typ="$(yq -r '.type // ""' "$f")"
+  if [ -z "$typ" ] || [ "$typ" = "null" ]; then
+    echo "ERROR: $f: missing required 'type'"; rc=1
+  elif ! printf '%s\n' $allowed | grep -qx "$typ"; then
+    echo "ERROR: $f: invalid type '$typ' (allowed: $allowed)"; rc=1
+  fi
+done
+
+exit "$rc"

--- a/scripts/changelog/verify.sh
+++ b/scripts/changelog/verify.sh
@@ -19,8 +19,18 @@ for f in "$dir"/*.yaml "$dir"/*.yml; do
   typ="$(yq -r '.type // ""' "$f")"
   if [ -z "$typ" ] || [ "$typ" = "null" ]; then
     echo "ERROR: $f: missing required 'type'"; rc=1
-  elif ! printf '%s\n' $allowed | grep -qx "$typ"; then
-    echo "ERROR: $f: invalid type '$typ' (allowed: $allowed)"; rc=1
+  else
+    # Intentional word-splitting over $allowed (a space-separated list),
+    # same idiom as pr-fragment-status.sh's allowed_scopes/skip_types loops:
+    # iterate the words to find an exact match rather than piping through
+    # printf/grep, which sidesteps the SC2086 quoting question entirely.
+    type_ok=""
+    for a in $allowed; do
+      [ "$a" = "$typ" ] && type_ok=1
+    done
+    if [ -z "$type_ok" ]; then
+      echo "ERROR: $f: invalid type '$typ' (allowed: $allowed)"; rc=1
+    fi
   fi
 done
 

--- a/scripts/check-docs-only-changes.sh
+++ b/scripts/check-docs-only-changes.sh
@@ -1,13 +1,18 @@
 #!/usr/bin/env bash
 set -e
 
-# Get changed files compared to the base
-CHANGED_FILES=$(git diff --name-only ${1:-$GITHUB_EVENT_PULL_REQUEST_BASE_SHA} ${2:-$GITHUB_SHA})
+# Get changed files compared to the base. CHANGED_FILES can be pre-set in the
+# environment (used by the test suite to drive this classifier without git);
+# otherwise it's computed from git diff as before.
+CHANGED_FILES="${CHANGED_FILES:-$(git diff --name-only ${1:-$GITHUB_EVENT_PULL_REQUEST_BASE_SHA} ${2:-$GITHUB_SHA})}"
 
-# Check if all changed files are documentation or license files
+# Check if all changed files are ones that cannot change a test outcome:
+# docs/license/template files, or a per-PR changelog fragment (schema-linted
+# separately, never executed). "docs_only" below means exactly that -- not
+# literally "only documentation" -- so a fragment-only PR is also docs_only.
 DOCS_ONLY=true
 for file in $CHANGED_FILES; do
-  if [[ ! "$file" =~ ^(LICENSE|LICENSES|CODEOWNERS|\.github/ISSUE_TEMPLATE/.*|.*\.md)$ ]]; then
+  if [[ ! "$file" =~ ^(LICENSE|LICENSES|CODEOWNERS|\.github/ISSUE_TEMPLATE/.*|changelog/unreleased/[^/]+/[0-9]+\.yml|.*\.md)$ ]]; then
     DOCS_ONLY=false
     break
   fi
@@ -15,4 +20,4 @@ done
 
 echo "docs_only=$DOCS_ONLY" >> $GITHUB_OUTPUT
 echo "Changed files: $CHANGED_FILES"
-echo "Docs only: $DOCS_ONLY"
+echo "No-test-impact only (docs/license/fragment): $DOCS_ONLY"

--- a/scripts/check-docs-only-changes.sh
+++ b/scripts/check-docs-only-changes.sh
@@ -4,7 +4,7 @@ set -e
 # Get changed files compared to the base. CHANGED_FILES can be pre-set in the
 # environment (used by the test suite to drive this classifier without git);
 # otherwise it's computed from git diff as before.
-CHANGED_FILES="${CHANGED_FILES:-$(git diff --name-only ${1:-$GITHUB_EVENT_PULL_REQUEST_BASE_SHA} ${2:-$GITHUB_SHA})}"
+CHANGED_FILES="${CHANGED_FILES:-$(git diff --name-only "${1:-$GITHUB_EVENT_PULL_REQUEST_BASE_SHA}" "${2:-$GITHUB_SHA}")}"
 
 # Check if all changed files are ones that cannot change a test outcome:
 # docs/license/template files, or a per-PR changelog fragment (schema-linted
@@ -18,6 +18,6 @@ for file in $CHANGED_FILES; do
   fi
 done
 
-echo "docs_only=$DOCS_ONLY" >> $GITHUB_OUTPUT
+echo "docs_only=$DOCS_ONLY" >> "$GITHUB_OUTPUT"
 echo "Changed files: $CHANGED_FILES"
 echo "No-test-impact only (docs/license/fragment): $DOCS_ONLY"


### PR DESCRIPTION
**What this PR does / why we need it**:

Replaces hand-edited `CHANGELOG.md` entries with per-PR YAML fragments (`changelog/unreleased/kong-operator/<PR>.yml`) to fix two related problems:
- Backport cherry-picks conflicted on `CHANGELOG.md` in ~99% of PRs, since every PR edited the same file. Fragments are uniquely named per PR, so cherry-picks add a new file and never conflict.
- Patch releases are cut from `release/x.y.z` branches whose tags never reach `main`, making tag-range-based changelog generation impossible on `main`. Fragments are read from whatever's present on the branch being released, not from tag history, so this is no longer an issue.

A bot scaffolds the fragment automatically from the PR's Conventional Commit title (author can edit for richer prose); CI gates on a fragment being present. At release time, `make changelog` assembles `CHANGELOG.md` from the branch's fragments via Kong's `gateway-changelog` tool and archives them under `changelog/<version>/`.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

- Fragment files use `.yml` (not `.yaml`) — the pinned `gateway-changelog` binary silently skips `.yaml` with no error; `CHANGELOG_TEMPLATE.yaml` keeps its `.yaml` name on purpose so the tool ignores it.
- `generate.sh` fails loudly if a release's assembled section has no entries, instead of silently shipping an empty section and archiving fragments anyway.
- Manual repo-config steps needed after merge (not automatable from this PR):
  - Create a `skip-changelog` label.

## Changelog

- [x] This PR has a changelog fragment, or is exempt (non-releasable type, or `skip-changelog` label).

The changelog bot adds `changelog/unreleased/kong-operator/<PR>.yml` automatically
from your Conventional Commit title. Edit it if the one-line title is not enough.
Do **not** edit `CHANGELOG.md` directly. See `changelog/README.md`.
