### PR TITLE
chore(ci): disable renovate for go deps and group sigs.k8s.io/* updates with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -13,6 +13,7 @@ updates:
     exclude:
     - "github.com/Kong/*"
     - "github.com/kong/*"
+    - "sigs.k8s.io/*"
   labels:
   - dependencies
   # Create a group of dependencies to be updated together in one pull request

--- a/renovate.json
+++ b/renovate.json
@@ -192,7 +192,6 @@
     {
       "description": "Disable Go dependencies updates (still handled by dependabot)",
       "matchManagers": ["gomod"],
-      "matchDepNames": ["go"],
       "matchBaseBranches": [
         "$default",
         "release/2.1.x",


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
