### PR TITLE
ci: only run crd-breaking-changes verify in pull_request context

### DIFF
--- a/.github/workflows/__verify.yaml
+++ b/.github/workflows/__verify.yaml
@@ -18,7 +18,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: ${{ fromJSON(vars.GHA_EXTENDED_TIMEOUT_MINUTES || 20) }}
     env:
-      CRD_BREAKING_CHANGES_BASE_SHA: ${{ github.event.pull_request.base.sha || github.event.merge_group.base_sha || github.event.before || '' }}
+      CRD_BREAKING_CHANGES_BASE_SHA: ${{ github.event.pull_request.base.sha || '' }}
       ACK_CRD_BREAKING_CHANGE_LABEL: ack_crd_breaking_change
     strategy:
       fail-fast: false
@@ -97,49 +97,27 @@ jobs:
           go-lint-${{ runner.os }}-${{ runner.arch }}-go-
 
     - name: Check CRD breaking-change acknowledgement
-      if: ${{ matrix.name == 'crd-breaking-changes' }}
+      if: ${{ matrix.name == 'crd-breaking-changes' && github.event_name == 'pull_request' }}
       env:
         GH_TOKEN: ${{ github.token }}
         PULL_REQUEST_NUMBER: ${{ github.event.pull_request.number || '' }}
-        MERGE_GROUP_HEAD_REF: ${{ github.event.merge_group.head_ref || '' }}
       run: |
         set -euo pipefail
 
+        # A CRD breaking change is acknowledged by adding the label to the PR. This check
+        # only runs for pull_request events, so there is always a single PR to inspect.
         ack="false"
-        # pull_request has one PR number. merge_group can represent one or more queued PRs,
-        # so keep this as a whitespace-separated list and acknowledge if any PR has the label.
-        pr_numbers="${PULL_REQUEST_NUMBER}"
-
-        if [[ "${GITHUB_EVENT_NAME}" == "merge_group" ]]; then
-          # The merge-group SHA is synthetic, so resolve the queued PRs from that commit.
-          # Fall back to the generated head_ref format because the commit-to-PR API can
-          # return nothing for merge queue commits.
-          pr_numbers="$(gh api \
+        if [[ -n "${PULL_REQUEST_NUMBER}" ]]; then
+          ack="$(gh api \
             -H "Accept: application/vnd.github+json" \
-            "repos/${GITHUB_REPOSITORY}/commits/${GITHUB_SHA}/pulls" \
-            --jq '.[].number' || true)"
-
-          if [[ -z "${pr_numbers}" && "${MERGE_GROUP_HEAD_REF}" =~ (^|/)pr-([0-9]+)- ]]; then
-            pr_numbers="${BASH_REMATCH[2]}"
-          fi
-
-          if [[ -z "${pr_numbers}" ]]; then
-            echo "Could not determine pull requests for merge group; CRD breaking changes will not be acknowledged automatically."
-          fi
-        fi
-
-        for pr_number in ${pr_numbers}; do
-          has_ack_label="$(gh api \
-            -H "Accept: application/vnd.github+json" \
-            "repos/${GITHUB_REPOSITORY}/issues/${pr_number}/labels" \
+            "repos/${GITHUB_REPOSITORY}/issues/${PULL_REQUEST_NUMBER}/labels" \
             --jq 'any(.[].name; . == env.ACK_CRD_BREAKING_CHANGE_LABEL)')"
-
-          if [[ "${has_ack_label}" == "true" ]]; then
-            ack="true"
-            break
-          fi
-        done
+        fi
 
         echo "ACK_CRD_BREAKING_CHANGE=${ack}" >> "${GITHUB_ENV}"
 
-    - run: make ${{ matrix.make-target }}
+    # The CRD breaking-change check compares against a PR base and is acknowledged via a PR
+    # label, so it can only run in a pull_request context. There is no way to acknowledge a
+    # breaking change on a bare commit (push/merge_group), so skip it outside of PRs.
+    - if: ${{ matrix.name != 'crd-breaking-changes' || github.event_name == 'pull_request' }}
+      run: make ${{ matrix.make-target }}


### PR DESCRIPTION
**What this PR does / why we need it**:

The CRD breaking-change check compares against a PR base and is acknowledged via a PR label. Outside of a `pull_request` there is no way to acknowledge a breaking change on a bare commit, and the `merge_group` commit-to-PR resolution was unreliable. 

Restrict the check to `pull_request` events and drop the now-dead merge_group ack logic.


Thanks @pmalek for mentioning this. 
https://github.com/Kong/kong-operator/actions/runs/29814344149/job/88582175555

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
