### PR TITLE
fix: handle update conflicts when updating certs in KonnectExtension reconciler

### DIFF
--- a/controller/konnect/konnectextension_controller.go
+++ b/controller/konnect/konnectextension_controller.go
@@ -187,7 +187,7 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, ext *konnect
 	if updated {
 		if err := r.Update(ctx, ext); err != nil {
 			if apierrors.IsConflict(err) {
-				return ctrl.Result{Requeue: true}, nil
+				return ctrl.Result{RequeueAfter: ctrlconsts.RequeueWithoutBackoff}, nil
 			}
 			// in case the finalizer removal fails because the resource does not exist, ignore the error.
 			if isFinalizerToBeRemoved && apierrors.IsNotFound(err) {
@@ -232,7 +232,7 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, ext *konnect
 			if updated {
 				if err := r.Update(ctx, ext); err != nil {
 					if apierrors.IsConflict(err) {
-						return ctrl.Result{Requeue: true}, nil
+						return ctrl.Result{RequeueAfter: ctrlconsts.RequeueWithoutBackoff}, nil
 					}
 					// in case the finalizer removal fails because the resource does not exist, ignore the error.
 					if apierrors.IsNotFound(err) {
@@ -465,6 +465,12 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, ext *konnect
 		}
 		certificateSecret.Annotations[consts.DataPlaneCertificateIDAnnotationKey] = newMappedIDsStr
 		if err := r.Update(ctx, certificateSecret); err != nil {
+			if apierrors.IsConflict(err) {
+				return ctrl.Result{RequeueAfter: ctrlconsts.RequeueWithoutBackoff}, nil
+			}
+			if apierrors.IsNotFound(err) {
+				return ctrl.Result{}, nil
+			}
 			return ctrl.Result{}, err
 		}
 		return ctrl.Result{}, nil
@@ -643,7 +649,7 @@ func (r *KonnectExtensionReconciler) Reconcile(ctx context.Context, ext *konnect
 			if updated {
 				if err := r.Update(ctx, certificateSecret); err != nil {
 					if apierrors.IsConflict(err) {
-						return ctrl.Result{Requeue: true}, nil
+						return ctrl.Result{RequeueAfter: ctrlconsts.RequeueWithoutBackoff}, nil
 					}
 					// in case the finalizer removal fails because the resource does not exist, ignore the error.
 					if apierrors.IsNotFound(err) {


### PR DESCRIPTION
**What this PR does / why we need it**:

Avoid errors like:

```
2026-07-21T09:33:10.5527955Z 2026-07-21T09:33:10Z	ERROR	Reconciler error	{"controller": "konnectextension", "controllerGroup": "konnect.konghq.com", "controllerKind": "KonnectExtension", "KonnectExtension": {"name":"konnect-extension-5px4n","namespace":"1889d0e6-c4c0-4d30-986c-cf2c455a878d"}, "namespace": "1889d0e6-c4c0-4d30-986c-cf2c455a878d", "name": "konnect-extension-5px4n", "reconcileID": "9aa581bb-fd4f-4f17-98f3-d099b3b08957", "error": "Operation cannot be fulfilled on secrets \"konnect-extension-konnect-extension-5px4n-djgnr\": the object has been modified; please apply your changes to the latest version and try again"}
2026-07-21T09:33:10.5531067Z sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler
2026-07-21T09:33:10.5533533Z 	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.24.1/pkg/internal/controller/controller.go:494
2026-07-21T09:33:10.5535342Z sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem
2026-07-21T09:33:10.5536415Z 	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.24.1/pkg/internal/controller/controller.go:437
2026-07-21T09:33:10.5537183Z sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1
2026-07-21T09:33:10.5538014Z 	/home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.24.1/pkg/internal/controller/controller.go:312
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
