### PR TITLE
tests: unskip TestKonnectExtension

### DIFF
--- a/controller/pkg/log/log.go
+++ b/controller/pkg/log/log.go
@@ -52,10 +52,5 @@ func oddKeyValues(logger logr.Logger, msg string, keysAndValues ...any) bool {
 
 // GetLogger returns a configured instance of logger.
 func GetLogger(ctx context.Context, controllerName string, loggingMode logging.Mode) logr.Logger {
-	// if development mode is active, do not add the context to the log line, as we want
-	// to have a lighter logging structure
-	if loggingMode == logging.DevelopmentMode {
-		return ctrllog.Log.WithName(controllerName)
-	}
 	return ctrllog.FromContext(ctx).WithName(controllerName)
 }

--- a/controller/pkg/log/log.go
+++ b/controller/pkg/log/log.go
@@ -52,5 +52,10 @@ func oddKeyValues(logger logr.Logger, msg string, keysAndValues ...any) bool {
 
 // GetLogger returns a configured instance of logger.
 func GetLogger(ctx context.Context, controllerName string, loggingMode logging.Mode) logr.Logger {
+	// if development mode is active, do not add the context to the log line, as we want
+	// to have a lighter logging structure
+	if loggingMode == logging.DevelopmentMode {
+		return ctrllog.Log.WithName(controllerName)
+	}
 	return ctrllog.FromContext(ctx).WithName(controllerName)
 }

--- a/pkg/utils/test/predicates.go
+++ b/pkg/utils/test/predicates.go
@@ -109,6 +109,7 @@ func DataPlaneIsReady(t *testing.T, ctx context.Context, dataplane types.Namespa
 				return true
 			}
 		}
+		t.Logf("DataPlane %q is not ready yet. Current conditions: %+v", dataplane, c.Status.Conditions)
 		return false
 	}, operatorClient)
 }

--- a/test/integration/konnect/konnect_extension_test.go
+++ b/test/integration/konnect/konnect_extension_test.go
@@ -224,8 +224,6 @@ func TestKonnectExtension(t *testing.T) {
 		})
 
 		t.Run("Mirror ControlPlane", func(t *testing.T) {
-			t.Skipf("Skip until flakiness is resolved, TODO: https://github.com/Kong/kong-operator/issues/4807")
-
 			// Create a Mirror Konnect control plane for the KonnectExtension to attach to.
 			mirrorCP := deploy.KonnectGatewayControlPlane(t, ctx, clientNamespaced, authCfg,
 				deploy.WithTestIDLabel(testID),

--- a/test/integration/konnect/konnect_extension_test.go
+++ b/test/integration/konnect/konnect_extension_test.go
@@ -202,6 +202,7 @@ func TestKonnectExtension(t *testing.T) {
 			require.NoError(t, err)
 			conditions.KonnectEntityIsProgrammed(t, cp)
 		}, testutils.ObjectUpdateTimeout, testutils.ObjectUpdateTick)
+		t.Logf("KonnectGatewayControlPlane received Konnect ID (%s) for resource %s/%s", cp.GetKonnectID(), cp.Namespace, cp.Name)
 
 		t.Run("Origin ControlPlane", func(t *testing.T) {
 			// Create entities to check proper working on Konnect.
@@ -237,6 +238,7 @@ func TestKonnectExtension(t *testing.T) {
 				require.NoError(t, err)
 				conditions.KonnectEntityIsProgrammed(t, mirrorCP)
 			}, testutils.ObjectUpdateTimeout, testutils.ObjectUpdateTick)
+			t.Logf("KonnectGatewayControlPlane received Konnect ID (%s) for resource %s/%s", mirrorCP.GetKonnectID(), mirrorCP.Namespace, mirrorCP.Name)
 
 			require.Eventually(t,
 				testutils.ObjectPredicates(t, cl,
@@ -324,8 +326,15 @@ type KonnectExtensionTestCaseParams struct {
 }
 
 func konnectExtensionTestCases(t *testing.T, cl client.Client, params KonnectExtensionTestCaseParams) {
+	t.Helper()
+
 	ctx := t.Context()
 	cert, key := certificate.MustGenerateCertPEMFormat()
+
+	t.Logf("Running KonnectExtension test cases with KonnectGatewayControlPlane %s (Konnect ID: %s)",
+		client.ObjectKeyFromObject(params.konnectControlPlane),
+		params.konnectControlPlane.GetKonnectID(),
+	)
 
 	t.Run("KonnectExtension with KonnectNamespacedRef control plane ref", func(t *testing.T) {
 		t.Run("manual secret provisioning", func(t *testing.T) {
@@ -446,7 +455,9 @@ func konnectExtensionTestBody(t *testing.T, cl client.Client, p KonnectExtension
 	t.Helper()
 	ctx := t.Context()
 
-	t.Logf("Waiting for KonnectExtension %s/%s to have expected conditions set to True", p.konnectExtension.Namespace, p.konnectExtension.Name)
+	nnKonnectExt := client.ObjectKeyFromObject(p.konnectExtension)
+
+	t.Logf("Waiting for KonnectExtension %s to have expected conditions set to True", nnKonnectExt)
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		ok, msg := conditions.CheckKonnectExtensionConditions(ctx, t, cl,
 			p.konnectExtension,
@@ -457,12 +468,16 @@ func konnectExtensionTestBody(t *testing.T, cl client.Client, p KonnectExtension
 		assert.Truef(t, ok, "condition check failed: %s, conditions: %+v", msg, p.konnectExtension.Status.Conditions)
 	}, testutils.ObjectUpdateTimeout, testutils.ObjectUpdateTick)
 
-	t.Logf("waiting for status.konnect and status.dataPlaneClientAuth to be set for KonnectExtension %s/%s", p.konnectExtension.Namespace, p.konnectExtension.Name)
+	t.Logf("waiting for status.konnect and status.dataPlaneClientAuth to be set for KonnectExtension %s", nnKonnectExt)
 	require.EventuallyWithT(t,
 		conditions.CheckKonnectExtensionStatus(ctx, cl, p.konnectExtension, p.konnectControlPlane.GetKonnectID(), ""),
 		testutils.ObjectUpdateTimeout, testutils.ObjectUpdateTick)
 
-	t.Logf("Creating a DataPlane using the KonnectExtension %s/%s", p.konnectExtension.Namespace, p.konnectExtension.Name)
+	var kExt konnectv1alpha2.KonnectExtension
+	require.NoError(t, cl.Get(ctx, nnKonnectExt, &kExt))
+	t.Logf("KonnectExtension got the ControlPlane ID: %s", kExt.Status.Konnect.ControlPlaneID)
+
+	t.Logf("Creating a DataPlane using the KonnectExtension %s", nnKonnectExt)
 	dataPlane := builder.NewDataPlaneBuilder().
 		WithObjectMeta(metav1.ObjectMeta{
 			Namespace: p.namespace,

--- a/test/integration/konnect/konnect_extension_test.go
+++ b/test/integration/konnect/konnect_extension_test.go
@@ -160,9 +160,9 @@ func TestKonnectExtensionControlPlaneRotation(t *testing.T) {
 	object.DeleteAndWaitForDeletionFn(context.Background(), t, cl, konnectExtension.DeepCopy())()
 }
 
+// Keep observing this test's stability.
+// TODO: https://github.com/Kong/kong-operator/issues/4807
 func TestKonnectExtension(t *testing.T) {
-	// t.Skipf("Skip until flakiness is resolved, TODO: https://github.com/Kong/kong-operator/issues/4807")
-
 	ctx := t.Context()
 	ns, _ := helpers.SetupTestEnv(t, ctx, integration.GetEnv())
 	cl := integration.GetClients().MgrClient

--- a/test/integration/konnect/konnect_extension_test.go
+++ b/test/integration/konnect/konnect_extension_test.go
@@ -525,7 +525,11 @@ func konnectExtensionTestBody(t *testing.T, cl client.Client, p KonnectExtension
 	}
 
 	t.Log("verifying dataplane gets marked provisioned")
-	require.Eventually(t, testutils.DataPlaneIsReady(t, ctx, dpName, integration.GetClients().OperatorClient), waitTime, tickTime)
+	// NOTE: Wait longer for DataPlane to get ready as hitting Konnect with
+	// data plane certificate which has not yet been fully processed by Konnect can
+	// hit a path which will require an mtls plugin ttl to hit in order for the
+	// certificate to work.
+	require.Eventually(t, testutils.DataPlaneIsReady(t, ctx, dpName, integration.GetClients().OperatorClient), 2*time.Minute, tickTime)
 
 	t.Logf("verifying dataplane %s has ingress service", dpName)
 	var dpIngressService corev1.Service

--- a/test/integration/konnect/konnect_extension_test.go
+++ b/test/integration/konnect/konnect_extension_test.go
@@ -161,7 +161,7 @@ func TestKonnectExtensionControlPlaneRotation(t *testing.T) {
 }
 
 func TestKonnectExtension(t *testing.T) {
-	t.Skipf("Skip until flakiness is resolved, TODO: https://github.com/Kong/kong-operator/issues/4807")
+	// t.Skipf("Skip until flakiness is resolved, TODO: https://github.com/Kong/kong-operator/issues/4807")
 
 	ctx := t.Context()
 	ns, _ := helpers.SetupTestEnv(t, ctx, integration.GetEnv())

--- a/test/integration/konnect/konnect_extension_test.go
+++ b/test/integration/konnect/konnect_extension_test.go
@@ -204,6 +204,7 @@ func TestKonnectExtension(t *testing.T) {
 			require.NoError(t, err)
 			conditions.KonnectEntityIsProgrammed(t, cp)
 		}, testutils.ObjectUpdateTimeout, testutils.ObjectUpdateTick)
+		t.Logf("KonnectGatewayControlPlane received Konnect ID (%s) for resource %s/%s", cp.GetKonnectID(), cp.Namespace, cp.Name)
 
 		t.Run("Origin ControlPlane", func(t *testing.T) {
 			// Create entities to check proper working on Konnect.
@@ -239,6 +240,7 @@ func TestKonnectExtension(t *testing.T) {
 				require.NoError(t, err)
 				conditions.KonnectEntityIsProgrammed(t, mirrorCP)
 			}, testutils.ObjectUpdateTimeout, testutils.ObjectUpdateTick)
+			t.Logf("KonnectGatewayControlPlane received Konnect ID (%s) for resource %s/%s", mirrorCP.GetKonnectID(), mirrorCP.Namespace, mirrorCP.Name)
 
 			require.Eventually(t,
 				testutils.ObjectPredicates(t, cl,
@@ -326,8 +328,15 @@ type KonnectExtensionTestCaseParams struct {
 }
 
 func konnectExtensionTestCases(t *testing.T, cl client.Client, params KonnectExtensionTestCaseParams) {
+	t.Helper()
+
 	ctx := t.Context()
 	cert, key := certificate.MustGenerateCertPEMFormat()
+
+	t.Logf("Running KonnectExtension test cases with KonnectGatewayControlPlane %s (Konnect ID: %s)",
+		client.ObjectKeyFromObject(params.konnectControlPlane),
+		params.konnectControlPlane.GetKonnectID(),
+	)
 
 	t.Run("KonnectExtension with KonnectNamespacedRef control plane ref", func(t *testing.T) {
 		t.Run("manual secret provisioning", func(t *testing.T) {
@@ -448,7 +457,9 @@ func konnectExtensionTestBody(t *testing.T, cl client.Client, p KonnectExtension
 	t.Helper()
 	ctx := t.Context()
 
-	t.Logf("Waiting for KonnectExtension %s/%s to have expected conditions set to True", p.konnectExtension.Namespace, p.konnectExtension.Name)
+	nnKonnectExt := client.ObjectKeyFromObject(p.konnectExtension)
+
+	t.Logf("Waiting for KonnectExtension %s to have expected conditions set to True", nnKonnectExt)
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
 		ok, msg := conditions.CheckKonnectExtensionConditions(ctx, t, cl,
 			p.konnectExtension,
@@ -459,12 +470,16 @@ func konnectExtensionTestBody(t *testing.T, cl client.Client, p KonnectExtension
 		assert.Truef(t, ok, "condition check failed: %s, conditions: %+v", msg, p.konnectExtension.Status.Conditions)
 	}, testutils.ObjectUpdateTimeout, testutils.ObjectUpdateTick)
 
-	t.Logf("waiting for status.konnect and status.dataPlaneClientAuth to be set for KonnectExtension %s/%s", p.konnectExtension.Namespace, p.konnectExtension.Name)
+	t.Logf("waiting for status.konnect and status.dataPlaneClientAuth to be set for KonnectExtension %s", nnKonnectExt)
 	require.EventuallyWithT(t,
 		conditions.CheckKonnectExtensionStatus(ctx, cl, p.konnectExtension, p.konnectControlPlane.GetKonnectID(), ""),
 		testutils.ObjectUpdateTimeout, testutils.ObjectUpdateTick)
 
-	t.Logf("Creating a DataPlane using the KonnectExtension %s/%s", p.konnectExtension.Namespace, p.konnectExtension.Name)
+	var kExt konnectv1alpha2.KonnectExtension
+	require.NoError(t, cl.Get(ctx, nnKonnectExt, &kExt))
+	t.Logf("KonnectExtension got the ControlPlane ID: %s", kExt.Status.Konnect.ControlPlaneID)
+
+	t.Logf("Creating a DataPlane using the KonnectExtension %s", nnKonnectExt)
 	dataPlane := builder.NewDataPlaneBuilder().
 		WithObjectMeta(metav1.ObjectMeta{
 			Namespace: p.namespace,


### PR DESCRIPTION
**What this PR does / why we need it**:

After recent fixed in Konnect, `TestKonnectExtension` is stable now.

After rerunning 50 times (max rerun count in GHA) it failed 3 times:

<img width="290" height="1011" alt="image" src="https://github.com/user-attachments/assets/b98db7dd-a3c0-4220-844b-dcede8b2ba75" />


- once becuase cert-manager manifest failed to download [link](https://github.com/Kong/kong-operator/actions/runs/31593139426/job/94206172619?pr=5009)
- twice because setup mise failed [#1](https://github.com/Kong/kong-operator/actions/runs/31593139426/job/94205821322?pr=5009) [#2](https://github.com/Kong/kong-operator/actions/runs/31593139426/job/94243784285?pr=5009)

**Which issue this PR fixes**

Fixes https://github.com/Kong/kong-operator/issues/4807

**Special notes for your reviewer**:

Related slack thread: https://kongstrong.slack.com/archives/C03LRB400TC/p1783335466992769

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
