### PR TITLE
fix(versions): tag parser accepts registry references with a port

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,13 +63,13 @@
   `Deployment` to skip reconciliation of deployments if only `deployment.scaling`
   is changed in dataplane options.
   [#5003](https://github.com/Kong/kong-operator/pull/5003)
-- Version parser: accept DataPlane image references whose registry host contains
+- Accept `DataPlane` image references whose registry host contains
   a port (e.g. `registry.example.com:5000/kong/kong-gateway:3.10`). The tag is
   now split at the last `:` instead of every `:`, so a host-port colon is no
   longer misread as the tag separator. Without this fix, DataPlane Deployment
   provisioning silently failed with
   `expected "<image>:<tag>" format, got: <full-ref>`.
-  [#XXXX](https://github.com/Kong/kong-operator/pull/XXXX)
+  [#5036](https://github.com/Kong/kong-operator/pull/5036)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -63,6 +63,13 @@
   `Deployment` to skip reconciliation of deployments if only `deployment.scaling`
   is changed in dataplane options.
   [#5003](https://github.com/Kong/kong-operator/pull/5003)
+- Version parser: accept DataPlane image references whose registry host contains
+  a port (e.g. `registry.example.com:5000/kong/kong-gateway:3.10`). The tag is
+  now split at the last `:` instead of every `:`, so a host-port colon is no
+  longer misread as the tag separator. Without this fix, DataPlane Deployment
+  provisioning silently failed with
+  `expected "<image>:<tag>" format, got: <full-ref>`.
+  [#XXXX](https://github.com/Kong/kong-operator/pull/XXXX)
 
 ### Added
 

--- a/internal/versions/validation.go
+++ b/internal/versions/validation.go
@@ -43,17 +43,15 @@ func FromImage(image string) (semver.Version, error) {
 	}
 
 	// Use the last ':' as the tag separator. Splitting on every ':' breaks
-	// references whose registry host carries a port, e.g.
-	//   registry.example.com:5000/foo/bar:3.10
+	// when registry host carries a port, e.g. registry.example.com:5000/foo/bar:3.10
 	// where the first ':' is part of the host ("<host>:<port>") rather than
-	// a tag separator. The tag, if present, always follows the LAST ':'
-	// (any digest was already stripped above).
+	// a tag separator. The tag, if present, always follows the LAST ':'.
 	idx := strings.LastIndex(image, ":")
 	if idx == -1 {
 		return semver.Version{}, fmt.Errorf(`%w, got: %s`, ErrExpectedSemverVersion, image)
 	}
 	tag := image[idx+1:]
-	// If what looks like a tag actually contains '/', we split on a port
+	// If what looks like a tag actually contains '/', split it on a port
 	// separator in the registry host and the reference has no tag at all
 	// (e.g. "registry:5000/foo/bar" — LastIndex found ':' inside the host).
 	if tag == "" || strings.Contains(tag, "/") {

--- a/internal/versions/validation.go
+++ b/internal/versions/validation.go
@@ -42,12 +42,25 @@ func FromImage(image string) (semver.Version, error) {
 		image = image[:idx]
 	}
 
-	splitImage := strings.Split(image, ":")
-	if len(splitImage) != 2 {
+	// Use the last ':' as the tag separator. Splitting on every ':' breaks
+	// references whose registry host carries a port, e.g.
+	//   registry.example.com:5000/foo/bar:3.10
+	// where the first ':' is part of the host ("<host>:<port>") rather than
+	// a tag separator. The tag, if present, always follows the LAST ':'
+	// (any digest was already stripped above).
+	idx := strings.LastIndex(image, ":")
+	if idx == -1 {
+		return semver.Version{}, fmt.Errorf(`%w, got: %s`, ErrExpectedSemverVersion, image)
+	}
+	tag := image[idx+1:]
+	// If what looks like a tag actually contains '/', we split on a port
+	// separator in the registry host and the reference has no tag at all
+	// (e.g. "registry:5000/foo/bar" — LastIndex found ':' inside the host).
+	if tag == "" || strings.Contains(tag, "/") {
 		return semver.Version{}, fmt.Errorf(`%w, got: %s`, ErrExpectedSemverVersion, image)
 	}
 
-	rawVersion := strings.TrimPrefix(splitImage[1], "v")
+	rawVersion := strings.TrimPrefix(tag, "v")
 
 	// If we matched a semver without patch version with suffix e.g. 3.3-ubuntu
 	// then append ".0" before the flavour suffix for successful semver parsing.

--- a/internal/versions/validation_test.go
+++ b/internal/versions/validation_test.go
@@ -111,6 +111,49 @@ func Test_versionFromImage(t *testing.T) {
 				return v
 			},
 		},
+		// Regression: image references whose registry host carries a port
+		// number contain more than one ':', but the tag is always after the
+		// last one. See https://github.com/Kong/kong-operator/issues/... .
+		{
+			Tag: "registry.example.com:5000/kong/kong-gateway:3.3.0",
+			Expected: func(t *testing.T) semver.Version {
+				v, err := semver.Parse("3.3.0")
+				require.NoError(t, err)
+				return v
+			},
+		},
+		{
+			Tag: "registry.example.com:5000/kong/kong-gateway:3.10",
+			Expected: func(t *testing.T) semver.Version {
+				v, err := semver.Parse("3.10.0")
+				require.NoError(t, err)
+				return v
+			},
+		},
+		{
+			Tag: "registry.example.com:5000/kong/kong-gateway:3.3-alpine@sha256:abc123def456",
+			Expected: func(t *testing.T) semver.Version {
+				v, err := semver.Parse("3.3.0")
+				require.NoError(t, err)
+				return v
+			},
+		},
+		{
+			// Registry with port but no tag: the last ':' is inside the host,
+			// what follows it contains '/'. Must be rejected as "no tag".
+			Tag:           "registry.example.com:5000/kong/kong-gateway",
+			ExpectedError: ErrExpectedSemverVersion,
+		},
+		{
+			// No colon at all — no tag can exist.
+			Tag:           "kong/kong-gateway",
+			ExpectedError: ErrExpectedSemverVersion,
+		},
+		{
+			// Trailing colon with empty tag — invalid.
+			Tag:           "kong/kong-gateway:",
+			ExpectedError: ErrExpectedSemverVersion,
+		},
 	}
 
 	for _, tc := range testcases {

--- a/internal/versions/validation_test.go
+++ b/internal/versions/validation_test.go
@@ -111,9 +111,6 @@ func Test_versionFromImage(t *testing.T) {
 				return v
 			},
 		},
-		// Regression: image references whose registry host carries a port
-		// number contain more than one ':', but the tag is always after the
-		// last one. See https://github.com/Kong/kong-operator/issues/... .
 		{
 			Tag: "registry.example.com:5000/kong/kong-gateway:3.3.0",
 			Expected: func(t *testing.T) semver.Version {


### PR DESCRIPTION
**What this PR does / why we need it**:

Cherry-pick of outside contribution

- https://github.com/Kong/kong-operator/pull/4723

Fixes https://github.com/Kong/kong-operator/issues/4724

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
