### PR TITLE
tests: skip AI GW 2.0 e2e chainsaw tests until model routing is fixed

### DIFF
--- a/test/e2e/chainsaw/aigateway/ai-proxy-mirror/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/aigateway/ai-proxy-mirror/chainsaw-test.yaml
@@ -3,6 +3,9 @@ kind: Test
 metadata:
   name: aigateway-ai-proxy-mirror
 spec:
+  # Skipping this test until related AI model routing issue is resolved.
+  # TODO: https://github.com/Kong/kong-operator/issues/5046
+  skip: true
   description: |
     AI GW 1.1 — AI Proxy Advanced against a MIRROR KonnectAIGateway. Creates an Origin
     KonnectAIGateway (which provisions the Konnect AI Gateway control plane), grabs its

--- a/test/e2e/chainsaw/aigateway/ai-proxy/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/aigateway/ai-proxy/chainsaw-test.yaml
@@ -3,6 +3,9 @@ kind: Test
 metadata:
   name: aigateway-ai-proxy
 spec:
+  # Skipping this test until related AI model routing issue is resolved.
+  # TODO: https://github.com/Kong/kong-operator/issues/5046
+  skip: true
   description: |
     AI GW 1.1 — AI Proxy Advanced. Stands up the Konnect AIGateway control plane, an
     OpenAI-compatible provider + model exposing /aigw11/chat pointed at the shared mock

--- a/test/e2e/chainsaw/aigateway/aigateway-policy/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/aigateway/aigateway-policy/chainsaw-test.yaml
@@ -3,6 +3,9 @@ kind: Test
 metadata:
   name: aigateway-policy
 spec:
+  # Skipping this test until related AI model routing issue is resolved.
+  # TODO: https://github.com/Kong/kong-operator/issues/5046
+  skip: true
   description: |
     Konnect AIGateway - Policy. Stands up the Konnect AIGateway control plane
     and creates policies to test the AIGatewayPolicy CRD. Then check for the policies


### PR DESCRIPTION
**What this PR does / why we need it**:

Related issue which will track re-enabling these tests: https://github.com/Kong/kong-operator/issues/5046.

Related slack thread: https://kongstrong.slack.com/archives/C08GKTWJHDX/p1784123590371689

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
