### PR TITLE
tests: add uninstall support for chainsaw prereqs scripts

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -844,7 +844,12 @@ CHAINSAW_FIXTURES_DIR ?= ./test/e2e/chainsaw/fixtures
 .PHONY: test.e2e.chainsaw.prereq
 test.e2e.chainsaw.prereq: export DIRNAME := $(DIRNAME)
 test.e2e.chainsaw.prereq: ## Apply prerequisite fixtures for a chainsaw suite (usage: DIRNAME=<suite>).
-	bash $(CHAINSAW_FIXTURES_DIR)/run-prereq.sh
+	bash $(CHAINSAW_FIXTURES_DIR)/run-prereq.sh install
+
+.PHONY: test.e2e.chainsaw.prereq.uninstall
+test.e2e.chainsaw.prereq.uninstall: export DIRNAME := $(DIRNAME)
+test.e2e.chainsaw.prereq.uninstall:
+	bash $(CHAINSAW_FIXTURES_DIR)/run-prereq.sh uninstall
 
 .PHONY: test.e2e.chainsaw
 test.e2e.chainsaw: chainsaw grpcurl ## Run chainsaw e2e tests.

--- a/test/e2e/chainsaw/fixtures/aigateway/prereq.sh
+++ b/test/e2e/chainsaw/fixtures/aigateway/prereq.sh
@@ -15,9 +15,21 @@ KONG_MOCK_TIMEOUT="${KONG_MOCK_TIMEOUT:-180s}"
 
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 
-# Namespace first, then the rest of the manifests in this directory.
-kubectl apply -f "${SCRIPT_DIR}/00-namespace.yaml"
-kubectl apply -f "${SCRIPT_DIR}"
+case $1 in
+  install)
+    # Namespace first, then the rest of the manifests in this directory.
+    kubectl apply -f "${SCRIPT_DIR}/00-namespace.yaml"
+    kubectl apply -f "${SCRIPT_DIR}"
 
-kubectl -n kong-aigateway-mock rollout status deploy/ollama --timeout="${OLLAMA_TIMEOUT}"
-kubectl -n kong-aigateway-mock rollout status deploy/kong-mock --timeout="${KONG_MOCK_TIMEOUT}"
+    kubectl -n kong-aigateway-mock rollout status deploy/ollama --timeout="${OLLAMA_TIMEOUT}"
+    kubectl -n kong-aigateway-mock rollout status deploy/kong-mock --timeout="${KONG_MOCK_TIMEOUT}"
+    ;;
+  uninstall)
+    kubectl delete --ignore-not-found=true -f "${SCRIPT_DIR}"
+    kubectl delete --ignore-not-found=true -f "${SCRIPT_DIR}/00-namespace.yaml"
+    ;;
+  *)
+    echo "unknown action '$1', must be 'install' or 'uninstall'" >&2
+    exit 1
+    ;;
+esac

--- a/test/e2e/chainsaw/fixtures/run-prereq.sh
+++ b/test/e2e/chainsaw/fixtures/run-prereq.sh
@@ -25,8 +25,19 @@ SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SUITE_SCRIPT="${SCRIPT_DIR}/${DIRNAME}/prereq.sh"
 
 if [ -f "${SUITE_SCRIPT}" ]; then
-  echo "[run-prereq] applying prerequisites for suite '${DIRNAME}'"
-  bash "${SUITE_SCRIPT}"
+  case $1 in
+    install)
+      echo "[run-prereq] installing prerequisites for suite '${DIRNAME}'"
+      ;;
+    uninstall)
+      echo "[run-prereq] uninstalling prerequisites for suite '${DIRNAME}'"
+      ;;
+    *)
+      echo "[run-prereq] unknown action '$1', must be 'install' or 'uninstall'" >&2
+      exit 1
+      ;;
+  esac
+  bash "${SUITE_SCRIPT}" "$1"
 else
   echo "[run-prereq] no prerequisites for suite '${DIRNAME}', skipping"
 fi


### PR DESCRIPTION
**What this PR does / why we need it**:

Add `test.e2e.chainsaw.prereq.uninstall` makefile target.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
