### PR TITLE
tests: skip TestKonnectExtension origin control plane test case

### DIFF
--- a/test/integration/konnect/konnect_extension_test.go
+++ b/test/integration/konnect/konnect_extension_test.go
@@ -161,6 +161,8 @@ func TestKonnectExtensionControlPlaneRotation(t *testing.T) {
 }
 
 func TestKonnectExtension(t *testing.T) {
+	t.Skipf("Skip until flakiness is resolved, TODO: https://github.com/Kong/kong-operator/issues/4807")
+
 	ctx := t.Context()
 	ns, _ := helpers.SetupTestEnv(t, ctx, integration.GetEnv())
 	cl := integration.GetClients().MgrClient
@@ -224,8 +226,6 @@ func TestKonnectExtension(t *testing.T) {
 		})
 
 		t.Run("Mirror ControlPlane", func(t *testing.T) {
-			t.Skipf("Skip until flakiness is resolved, TODO: https://github.com/Kong/kong-operator/issues/4807")
-
 			// Create a Mirror Konnect control plane for the KonnectExtension to attach to.
 			mirrorCP := deploy.KonnectGatewayControlPlane(t, ctx, clientNamespaced, authCfg,
 				deploy.WithTestIDLabel(testID),


### PR DESCRIPTION
**What this PR does / why we need it**:

Origin Control Plane test case has also been failing recently so skip it.

https://github.com/Kong/kong-operator/actions/runs/30087004982/job/89461523095?pr=4970#step:16:3149

```
    konnect_extension_test.go:382: 
        	Error Trace:	/home/runner/work/kong-operator/kong-operator/test/integration/konnect/konnect_extension_test.go:513
        	            				/home/runner/work/kong-operator/kong-operator/test/integration/konnect/konnect_extension_test.go:382
        	Error:      	Condition never satisfied
        	Test:       	TestKonnectExtension/Konnect_hybrid_ControlPlane/Origin_ControlPlane/KonnectExtension_with_KonnectNamespacedRef_control_plane_ref/automatic_secret_provisioning
```

Related slack thread with investigation: https://kongstrong.slack.com/archives/C03LRB400TC/p1783335466992769

Related issue for re-enabling these tests: https://github.com/Kong/kong-operator/issues/4807

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
