### PR TITLE
fix(gateway): validate namespace in ListTCPRoutesForGateway

### DIFF
--- a/pkg/utils/gateway/ownerrefs.go
+++ b/pkg/utils/gateway/ownerrefs.go
@@ -329,32 +329,7 @@ func ListTCPRoutesForGateway(
 	var tcpRoutes []gwtypes.TCPRoute
 	for _, tcpRoute := range tcpRoutesList.Items {
 		if !lo.ContainsBy(tcpRoute.Spec.ParentRefs, func(parentRef gwtypes.ParentReference) bool {
-			gwGVK := gateway.GroupVersionKind()
-			if parentRef.Group != nil && string(*parentRef.Group) != gwGVK.Group {
-				return false
-			}
-			if parentRef.Kind != nil && string(*parentRef.Kind) != gwGVK.Kind {
-				return false
-			}
-			if string(parentRef.Name) != gateway.Name {
-				return false
-			}
-
-			if parentRef.SectionName != nil {
-				if !lo.ContainsBy(gateway.Spec.Listeners, func(listener gwtypes.Listener) bool {
-					if listener.Name != *parentRef.SectionName {
-						return false
-					}
-					if parentRef.Port != nil && listener.Port != *parentRef.Port {
-						return false
-					}
-					return true
-				}) {
-					return false
-				}
-			}
-
-			return true
+			return parentRefMatchGateway(tcpRoute.Namespace, parentRef, gateway)
 		}) {
 			continue
 		}

--- a/pkg/utils/gateway/ownerrefs_test.go
+++ b/pkg/utils/gateway/ownerrefs_test.go
@@ -521,3 +521,265 @@ func TestListGRPCRoutesForGateway(t *testing.T) {
 		})
 	}
 }
+
+func TestListTCPRoutesForGateway(t *testing.T) {
+	testCases := []struct {
+		name        string
+		tcpRoutes   []client.Object
+		gateway     *gwtypes.Gateway
+		expected    []gwtypes.TCPRoute
+		expectedErr bool
+	}{
+		{
+			name: "returns TCPRoute for a Gateway",
+			tcpRoutes: []client.Object{
+				&gwtypes.TCPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "tcp-route-1",
+						Namespace:       "default",
+						ResourceVersion: "1",
+					},
+					Spec: gwtypes.TCPRouteSpec{
+						CommonRouteSpec: gwtypes.CommonRouteSpec{
+							ParentRefs: []gwtypes.ParentReference{
+								{
+									Group: new(gwtypes.Group(gwtypes.GroupVersion.Group)),
+									Kind:  new(gwtypes.Kind("Gateway")),
+									Name:  gwtypes.ObjectName("gw-1"),
+								},
+							},
+						},
+					},
+				},
+			},
+			gateway: &gwtypes.Gateway{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Gateway",
+					APIVersion: gwtypes.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gw-1",
+					Namespace: "default",
+				},
+			},
+			expected: []gwtypes.TCPRoute{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "tcp-route-1",
+						Namespace:       "default",
+						ResourceVersion: "1",
+					},
+					Spec: gwtypes.TCPRouteSpec{
+						CommonRouteSpec: gwtypes.CommonRouteSpec{
+							ParentRefs: []gwtypes.ParentReference{
+								{
+									Group: new(gwtypes.Group(gwtypes.GroupVersion.Group)),
+									Kind:  new(gwtypes.Kind("Gateway")),
+									Name:  gwtypes.ObjectName("gw-1"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "does not return TCPRoute for a Gateway when it is not a parent",
+			tcpRoutes: []client.Object{
+				&gwtypes.TCPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "tcp-route-1",
+						Namespace:       "default",
+						ResourceVersion: "1",
+					},
+					Spec: gwtypes.TCPRouteSpec{},
+				},
+			},
+			gateway: &gwtypes.Gateway{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Gateway",
+					APIVersion: gwtypes.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gw-1",
+					Namespace: "default",
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "does not return TCPRoute referencing a same-named Gateway in another namespace",
+			tcpRoutes: []client.Object{
+				&gwtypes.TCPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "tcp-route-1",
+						Namespace:       "other-namespace",
+						ResourceVersion: "1",
+					},
+					Spec: gwtypes.TCPRouteSpec{
+						CommonRouteSpec: gwtypes.CommonRouteSpec{
+							ParentRefs: []gwtypes.ParentReference{
+								{
+									Group: new(gwtypes.Group(gwtypes.GroupVersion.Group)),
+									Kind:  new(gwtypes.Kind("Gateway")),
+									// Namespace omitted: defaults to the route's namespace
+									// (other-namespace), which must not match a Gateway in
+									// "default" even when the name is identical.
+									Name: gwtypes.ObjectName("gw-1"),
+								},
+							},
+						},
+					},
+				},
+			},
+			gateway: &gwtypes.Gateway{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Gateway",
+					APIVersion: gwtypes.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gw-1",
+					Namespace: "default",
+				},
+			},
+			expected: nil,
+		},
+		{
+			name: "returns TCPRoute referencing the Gateway by explicit namespace",
+			tcpRoutes: []client.Object{
+				&gwtypes.TCPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "tcp-route-1",
+						Namespace:       "other-namespace",
+						ResourceVersion: "1",
+					},
+					Spec: gwtypes.TCPRouteSpec{
+						CommonRouteSpec: gwtypes.CommonRouteSpec{
+							ParentRefs: []gwtypes.ParentReference{
+								{
+									Group:     new(gwtypes.Group(gwtypes.GroupVersion.Group)),
+									Kind:      new(gwtypes.Kind("Gateway")),
+									Namespace: new(gwtypes.Namespace("default")),
+									Name:      gwtypes.ObjectName("gw-1"),
+								},
+							},
+						},
+					},
+				},
+			},
+			gateway: &gwtypes.Gateway{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Gateway",
+					APIVersion: gwtypes.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gw-1",
+					Namespace: "default",
+				},
+			},
+			expected: []gwtypes.TCPRoute{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "tcp-route-1",
+						Namespace:       "other-namespace",
+						ResourceVersion: "1",
+					},
+					Spec: gwtypes.TCPRouteSpec{
+						CommonRouteSpec: gwtypes.CommonRouteSpec{
+							ParentRefs: []gwtypes.ParentReference{
+								{
+									Group:     new(gwtypes.Group(gwtypes.GroupVersion.Group)),
+									Kind:      new(gwtypes.Kind("Gateway")),
+									Namespace: new(gwtypes.Namespace("default")),
+									Name:      gwtypes.ObjectName("gw-1"),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "returns TCPRoute when section name and port match",
+			tcpRoutes: []client.Object{
+				&gwtypes.TCPRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "tcp-route-1",
+						Namespace:       "default",
+						ResourceVersion: "1",
+					},
+					Spec: gwtypes.TCPRouteSpec{
+						CommonRouteSpec: gwtypes.CommonRouteSpec{
+							ParentRefs: []gwtypes.ParentReference{
+								{
+									Group:       new(gwtypes.Group(gwtypes.GroupVersion.Group)),
+									Kind:        new(gwtypes.Kind("Gateway")),
+									Name:        gwtypes.ObjectName("gw-1"),
+									SectionName: new(gwtypes.SectionName("tcp")),
+									Port:        new(gwtypes.PortNumber(8888)),
+								},
+							},
+						},
+					},
+				},
+			},
+			gateway: &gwtypes.Gateway{
+				TypeMeta: metav1.TypeMeta{
+					Kind:       "Gateway",
+					APIVersion: gwtypes.GroupVersion.String(),
+				},
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "gw-1",
+					Namespace: "default",
+				},
+				Spec: gwtypes.GatewaySpec{
+					Listeners: []gwtypes.Listener{
+						{
+							Name: "tcp",
+							Port: 8888,
+						},
+					},
+				},
+			},
+			expected: []gwtypes.TCPRoute{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:            "tcp-route-1",
+						Namespace:       "default",
+						ResourceVersion: "1",
+					},
+					Spec: gwtypes.TCPRouteSpec{
+						CommonRouteSpec: gwtypes.CommonRouteSpec{
+							ParentRefs: []gwtypes.ParentReference{
+								{
+									Group:       new(gwtypes.Group(gwtypes.GroupVersion.Group)),
+									Kind:        new(gwtypes.Kind("Gateway")),
+									Name:        gwtypes.ObjectName("gw-1"),
+									SectionName: new(gwtypes.SectionName("tcp")),
+									Port:        new(gwtypes.PortNumber(8888)),
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			cl := fake.NewClientBuilder().
+				WithScheme(scheme.Get()).
+				WithObjects(tc.gateway).
+				WithObjects(tc.tcpRoutes...).
+				Build()
+			routes, err := ListTCPRoutesForGateway(t.Context(), cl, tc.gateway)
+			if tc.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.ElementsMatch(t, tc.expected, routes)
+			}
+		})
+	}
+}

--- a/test/e2e/chainsaw/gateway/tcproute-onprem/01-gatewayconfiguration.yaml
+++ b/test/e2e/chainsaw/gateway/tcproute-onprem/01-gatewayconfiguration.yaml
@@ -1,5 +1,5 @@
 # On-prem GatewayConfiguration with no KONG_STREAM_LISTEN set.
-# The operator generates the default value for the TLS listener.
+# The operator generates the default value for the TCP listener.
 apiVersion: gateway-operator.konghq.com/v2beta1
 kind: GatewayConfiguration
 metadata:

--- a/test/e2e/chainsaw/gateway/tcproute-onprem/02-gateway.yaml
+++ b/test/e2e/chainsaw/gateway/tcproute-onprem/02-gateway.yaml
@@ -1,5 +1,5 @@
-# Operator-managed Gateway with a single TLS passthrough (L4) listener.
-# A TLS listener is what drives the operator to generate KONG_STREAM_LISTEN.
+# Operator-managed Gateway with a single TCP (L4) listener.
+# A TCP listener is what drives the operator to generate KONG_STREAM_LISTEN.
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:


### PR DESCRIPTION
**What this PR does / why we need it**:

`ListTCPRoutesForGateway` used a hand-written inline parentRef filter that omitted the namespace check performed by the shared `parentRefMatchGateway` helper used by the HTTP/TLS/GRPC/UDP variants. As a result a TCPRoute that referenced a Gateway by name only (defaulting the parentRef namespace to the route's own namespace) could match a same-named Gateway in a different namespace, potentially inflating `status.listeners[].attachedRoutes` across namespaces.

Reuse parentRefMatchGateway so TCP behaves consistently with the other route kinds, and add regression coverage for the cross-namespace case.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
