### PR TITLE
feat: support HybridGateway TCPRoute conformance

### DIFF
--- a/controller/hybridgateway/converter/tcp_route.go
+++ b/controller/hybridgateway/converter/tcp_route.go
@@ -169,10 +169,22 @@ func (c *tcpRouteConverter) translate(ctx context.Context, logger logr.Logger) e
 		return nil
 	}
 
+	winningPortsByParentRef, err := c.winningTCPRoutePortsByParentRef(ctx, logger, supportedParentRefs)
+	if err != nil {
+		return err
+	}
+
 	for _, pRefData := range supportedParentRefs {
 		pRef := pRefData.parentRef
 		cp := pRefData.cpRef
 		hostnames := pRefData.hostnames
+		winningPorts := winningPortsByParentRef[tcpParentRefKeyForRoute(c.route, &pRef)]
+		if len(winningPorts) == 0 {
+			log.Debug(logger, "TCPRoute did not win any matching listener ports, skipping dataplane translation",
+				"parentRef", pRef)
+			continue
+		}
+
 		var namingParentRef *gwtypes.ParentReference
 		if len(supportedParentRefs) > 1 {
 			namingParentRef = &pRef
@@ -224,7 +236,9 @@ func (c *tcpRouteConverter) translate(ctx context.Context, logger logr.Logger) e
 			c.outputStore = append(c.outputStore, servicePtr)
 			log.Debug(logger, "Successfully translated KongService resource", "service", serviceName)
 
-			routes, err := kongroute.RoutesForRule(ctx, logger, c.Client, c.route, rule, ruleIndex, &pRef, cp, namingParentRef, serviceName, hostnames)
+			routes, err := kongroute.RoutesForTCPRouteRuleWithPorts(
+				ctx, logger, c.Client, c.route, rule, &pRef, cp, namingParentRef, serviceName, winningPorts,
+			)
 			if err != nil {
 				log.Error(logger, err, "Failed to translate KongRoute resource, skipping rule",
 					"service", serviceName,

--- a/controller/hybridgateway/converter/tcp_route_conflict.go
+++ b/controller/hybridgateway/converter/tcp_route_conflict.go
@@ -1,0 +1,303 @@
+package converter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"slices"
+
+	"github.com/go-logr/logr"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	"k8s.io/apimachinery/pkg/types"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	hybridgatewayerrors "github.com/kong/kong-operator/v2/controller/hybridgateway/errors"
+	"github.com/kong/kong-operator/v2/controller/hybridgateway/refs"
+	hybridgatewayroute "github.com/kong/kong-operator/v2/controller/hybridgateway/route"
+	gwtypes "github.com/kong/kong-operator/v2/internal/types"
+)
+
+const tcpRouteKind = "TCPRoute"
+
+type tcpListenerKey struct {
+	gatewayNamespace string
+	gatewayName      string
+	listenerName     string
+	port             gatewayv1.PortNumber
+}
+
+type tcpParentRefKey struct {
+	namespace   string
+	name        string
+	sectionName string
+	port        int32
+}
+
+func (c *tcpRouteConverter) winningTCPRoutePortsByParentRef(
+	ctx context.Context,
+	logger logr.Logger,
+	supportedParentRefs []hybridGatewayParent,
+) (map[tcpParentRefKey][]int32, error) {
+	tcpRoutes, err := c.listTCPRouteCandidates(ctx)
+	if err != nil {
+		return nil, err
+	}
+
+	listenerAttachments := make(map[tcpListenerKey][]*gwtypes.TCPRoute)
+	for _, tcpRoute := range tcpRoutes {
+		keys, err := c.tcpRouteListenerAttachments(ctx, logger, tcpRoute)
+		if err != nil {
+			return nil, err
+		}
+		for _, key := range keys {
+			listenerAttachments[key] = append(listenerAttachments[key], tcpRoute)
+		}
+	}
+
+	portsByParentRef := make(map[tcpParentRefKey][]int32, len(supportedParentRefs))
+	for _, parent := range supportedParentRefs {
+		keys, err := c.tcpRouteListenerAttachmentsForParentRef(ctx, logger, c.route, &parent.parentRef)
+		if err != nil {
+			return nil, err
+		}
+
+		parentRefKey := tcpParentRefKeyForRoute(c.route, &parent.parentRef)
+		ports := make([]int32, 0, len(keys))
+		for _, key := range keys {
+			winner := pickWinningTCPRoute(listenerAttachments[key])
+			if winner == nil || !sameTCPRoute(winner, c.route) {
+				continue
+			}
+			ports = append(ports, key.port)
+		}
+		portsByParentRef[parentRefKey] = deduplicateTCPPorts(ports)
+	}
+
+	return portsByParentRef, nil
+}
+
+func (c *tcpRouteConverter) listTCPRouteCandidates(ctx context.Context) ([]*gwtypes.TCPRoute, error) {
+	var tcpRouteList gwtypes.TCPRouteList
+	if err := c.List(ctx, &tcpRouteList); err != nil {
+		return nil, fmt.Errorf("failed to list TCPRoutes for conflict resolution: %w", err)
+	}
+
+	tcpRoutes := make([]*gwtypes.TCPRoute, 0, len(tcpRouteList.Items)+1)
+	currentRouteListed := false
+	for i := range tcpRouteList.Items {
+		tcpRoute := &tcpRouteList.Items[i]
+		if sameTCPRoute(tcpRoute, c.route) {
+			currentRouteListed = true
+		}
+		tcpRoutes = append(tcpRoutes, tcpRoute)
+	}
+
+	if !currentRouteListed {
+		tcpRoutes = append(tcpRoutes, c.route)
+	}
+
+	return tcpRoutes, nil
+}
+
+func (c *tcpRouteConverter) tcpRouteListenerAttachments(
+	ctx context.Context,
+	logger logr.Logger,
+	tcpRoute *gwtypes.TCPRoute,
+) ([]tcpListenerKey, error) {
+	keys := make([]tcpListenerKey, 0)
+	for i := range tcpRoute.Spec.ParentRefs {
+		parentRef := &tcpRoute.Spec.ParentRefs[i]
+		parentRefKeys, err := c.tcpRouteListenerAttachmentsForParentRef(ctx, logger, tcpRoute, parentRef)
+		if err != nil {
+			return nil, err
+		}
+		keys = append(keys, parentRefKeys...)
+	}
+	return keys, nil
+}
+
+func (c *tcpRouteConverter) tcpRouteListenerAttachmentsForParentRef(
+	ctx context.Context,
+	logger logr.Logger,
+	tcpRoute *gwtypes.TCPRoute,
+	parentRef *gwtypes.ParentReference,
+) ([]tcpListenerKey, error) {
+	gateway, found, err := refs.GetSupportedGatewayForParentRef(ctx, logger, c.Client, *parentRef, tcpRoute.Namespace)
+	if err != nil {
+		if isExpectedParentRefError(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	if !found {
+		return nil, nil
+	}
+
+	listeners, condition := hybridgatewayroute.FilterMatchingListeners(
+		logger,
+		gateway,
+		tcpRouteKind,
+		*parentRef,
+		gateway.Spec.Listeners,
+	)
+	if condition != nil {
+		return nil, nil
+	}
+
+	keys := make([]tcpListenerKey, 0, len(listeners))
+	for _, listener := range listeners {
+		if listener.Protocol != gwtypes.TCPProtocolType {
+			continue
+		}
+		allowed, err := c.tcpListenerAllowsRoute(ctx, gateway, listener, tcpRoute)
+		if err != nil {
+			return nil, err
+		}
+		if !allowed {
+			continue
+		}
+
+		keys = append(keys, tcpListenerKey{
+			gatewayNamespace: gateway.Namespace,
+			gatewayName:      gateway.Name,
+			listenerName:     string(listener.Name),
+			port:             listener.Port,
+		})
+	}
+
+	return keys, nil
+}
+
+func (c *tcpRouteConverter) tcpListenerAllowsRoute(
+	ctx context.Context,
+	gateway *gwtypes.Gateway,
+	listener gatewayv1.Listener,
+	tcpRoute *gwtypes.TCPRoute,
+) (bool, error) {
+	if listener.AllowedRoutes == nil {
+		return true, nil
+	}
+
+	allowedRoutes := listener.AllowedRoutes
+	if len(allowedRoutes.Kinds) > 0 {
+		kindAllowed := slices.ContainsFunc(allowedRoutes.Kinds, routeGroupKindMatchesTCPRoute)
+		if !kindAllowed {
+			return false, nil
+		}
+	}
+
+	if allowedRoutes.Namespaces == nil || allowedRoutes.Namespaces.From == nil {
+		return true, nil
+	}
+
+	switch *allowedRoutes.Namespaces.From {
+	case gatewayv1.NamespacesFromAll:
+		return true, nil
+	case gatewayv1.NamespacesFromSame:
+		return gateway.Namespace == tcpRoute.Namespace, nil
+	case gatewayv1.NamespacesFromSelector:
+		if allowedRoutes.Namespaces.Selector == nil {
+			return false, nil
+		}
+		var namespace corev1.Namespace
+		if err := c.Get(ctx, types.NamespacedName{Name: tcpRoute.Namespace}, &namespace); err != nil {
+			if apierrors.IsNotFound(err) {
+				return false, nil
+			}
+			return false, fmt.Errorf("failed to get namespace %s for TCPRoute conflict resolution: %w", tcpRoute.Namespace, err)
+		}
+		selector, err := metav1.LabelSelectorAsSelector(allowedRoutes.Namespaces.Selector)
+		if err != nil {
+			return false, fmt.Errorf("invalid namespace selector for Gateway %s/%s listener %s: %w",
+				gateway.Namespace, gateway.Name, listener.Name, err)
+		}
+		return selector.Matches(labels.Set(namespace.Labels)), nil
+	default:
+		return false, fmt.Errorf("unknown value for AllowedRoutes.Namespaces.From: %s for listener %s for gateway %s/%s",
+			*allowedRoutes.Namespaces.From, listener.Name, gateway.Namespace, gateway.Name)
+	}
+}
+
+func routeGroupKindMatchesTCPRoute(kind gatewayv1.RouteGroupKind) bool {
+	if kind.Kind != gatewayv1.Kind(tcpRouteKind) {
+		return false
+	}
+	return kind.Group == nil || *kind.Group == gatewayv1.GroupName
+}
+
+func pickWinningTCPRoute(tcpRoutes []*gwtypes.TCPRoute) *gwtypes.TCPRoute {
+	if len(tcpRoutes) == 0 {
+		return nil
+	}
+
+	winner := tcpRoutes[0]
+	for _, tcpRoute := range tcpRoutes[1:] {
+		if tcpRouteLess(tcpRoute, winner) {
+			winner = tcpRoute
+		}
+	}
+	return winner
+}
+
+func tcpRouteLess(lhs, rhs *gwtypes.TCPRoute) bool {
+	if lhs.CreationTimestamp.Before(&rhs.CreationTimestamp) {
+		return true
+	}
+	if rhs.CreationTimestamp.Before(&lhs.CreationTimestamp) {
+		return false
+	}
+	if lhs.Namespace != rhs.Namespace {
+		return lhs.Namespace < rhs.Namespace
+	}
+	return lhs.Name < rhs.Name
+}
+
+func sameTCPRoute(lhs, rhs *gwtypes.TCPRoute) bool {
+	return lhs != nil &&
+		rhs != nil &&
+		lhs.Namespace == rhs.Namespace &&
+		lhs.Name == rhs.Name
+}
+
+func tcpParentRefKeyForRoute(tcpRoute *gwtypes.TCPRoute, parentRef *gwtypes.ParentReference) tcpParentRefKey {
+	namespace := tcpRoute.Namespace
+	if parentRef.Namespace != nil && *parentRef.Namespace != "" {
+		namespace = string(*parentRef.Namespace)
+	}
+
+	sectionName := ""
+	if parentRef.SectionName != nil {
+		sectionName = string(*parentRef.SectionName)
+	}
+
+	var port int32
+	if parentRef.Port != nil {
+		port = *parentRef.Port
+	}
+
+	return tcpParentRefKey{
+		namespace:   namespace,
+		name:        string(parentRef.Name),
+		sectionName: sectionName,
+		port:        port,
+	}
+}
+
+func deduplicateTCPPorts(ports []int32) []int32 {
+	if len(ports) == 0 {
+		return nil
+	}
+
+	slices.Sort(ports)
+	ports = slices.Compact(ports)
+	return ports
+}
+
+func isExpectedParentRefError(err error) bool {
+	return errors.Is(err, hybridgatewayerrors.ErrUnsupportedKind) ||
+		errors.Is(err, hybridgatewayerrors.ErrUnsupportedGroup) ||
+		errors.Is(err, hybridgatewayerrors.ErrNoGatewayFound)
+}

--- a/controller/hybridgateway/converter/tcp_route_test.go
+++ b/controller/hybridgateway/converter/tcp_route_test.go
@@ -2,6 +2,7 @@ package converter
 
 import (
 	"testing"
+	"time"
 
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 	"github.com/go-logr/logr"
@@ -69,6 +70,90 @@ func TestTCPRouteConverter_Translate(t *testing.T) {
 	assert.Empty(t, kongRoute.Spec.Hosts)
 	assert.Empty(t, kongRoute.Spec.Paths)
 	assert.Equal(t, "default/test-route", kongRoute.Annotations[consts.GatewayOperatorHybridRoutesTCPRouteAnnotation])
+}
+
+func TestTCPRouteConverter_TranslateKeepsOldestRouteForSameListener(t *testing.T) {
+	olderRoute := newTCPRouteForTranslation()
+	olderRoute.CreationTimestamp = metav1.NewTime(time.Unix(1, 0))
+	newerRoute := newTCPRouteForTranslation()
+	newerRoute.Name = "newer-route"
+	newerRoute.CreationTimestamp = metav1.NewTime(time.Unix(2, 0))
+
+	gateway := newTCPGateway()
+	gateway.UID = types.UID("gateway-uid")
+	objects := append(
+		newKonnectGatewayStandardObjects(gateway),
+		newerRoute,
+		newService("default"),
+		newEndpointSlice("backend-service", "default", []string{"10.0.1.1", "10.0.1.2"}),
+	)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme.Get()).WithObjects(objects...).Build()
+	converter := newTCPRouteConverter(olderRoute, fakeClient, false, "")
+
+	resourceCount, err := converter.Translate(t.Context(), logr.Discard())
+	require.NoError(t, err)
+	require.Equal(t, 5, resourceCount)
+
+	output, err := converter.GetOutputStore(t.Context(), logr.Discard())
+	require.NoError(t, err)
+
+	var kongRoute *configurationv1alpha1.KongRoute
+	for _, obj := range output {
+		if obj.GetKind() != "KongRoute" {
+			continue
+		}
+		converted := &configurationv1alpha1.KongRoute{}
+		require.NoError(t, fakeClient.Scheme().Convert(&obj, converted, nil))
+		kongRoute = converted
+	}
+
+	require.NotNil(t, kongRoute)
+	require.Len(t, kongRoute.Spec.Destinations, 1)
+	require.NotNil(t, kongRoute.Spec.Destinations[0].Port)
+	assert.Equal(t, int64(80), *kongRoute.Spec.Destinations[0].Port)
+}
+
+func TestTCPRouteConverter_TranslateSkipsNewerRouteForSameListener(t *testing.T) {
+	olderRoute := newTCPRouteForTranslation()
+	olderRoute.Name = "older-route"
+	olderRoute.CreationTimestamp = metav1.NewTime(time.Unix(1, 0))
+	newerRoute := newTCPRouteForTranslation()
+	newerRoute.CreationTimestamp = metav1.NewTime(time.Unix(2, 0))
+
+	gateway := newTCPGateway()
+	gateway.UID = types.UID("gateway-uid")
+	objects := append(
+		newKonnectGatewayStandardObjects(gateway),
+		olderRoute,
+	)
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme.Get()).WithObjects(objects...).Build()
+	converter := newTCPRouteConverter(newerRoute, fakeClient, false, "")
+
+	resourceCount, err := converter.Translate(t.Context(), logr.Discard())
+	require.NoError(t, err)
+	assert.Zero(t, resourceCount)
+
+	output, err := converter.GetOutputStore(t.Context(), logr.Discard())
+	require.NoError(t, err)
+	assert.Empty(t, output)
+}
+
+func TestPickWinningTCPRouteTieBreaksByNamespaceAndName(t *testing.T) {
+	route := newTCPRouteForTranslation()
+	route.Namespace = "b"
+	route.Name = "a"
+	route.CreationTimestamp = metav1.NewTime(time.Unix(1, 0))
+	winnerByNamespace := newTCPRouteForTranslation()
+	winnerByNamespace.Namespace = "a"
+	winnerByNamespace.Name = "z"
+	winnerByNamespace.CreationTimestamp = route.CreationTimestamp
+	winnerByName := newTCPRouteForTranslation()
+	winnerByName.Namespace = "b"
+	winnerByName.Name = "0"
+	winnerByName.CreationTimestamp = route.CreationTimestamp
+
+	require.Same(t, winnerByNamespace, pickWinningTCPRoute([]*gwtypes.TCPRoute{route, winnerByNamespace}))
+	require.Same(t, winnerByName, pickWinningTCPRoute([]*gwtypes.TCPRoute{route, winnerByName}))
 }
 
 func TestTCPRouteConverter_TranslateBackendClientCertificate(t *testing.T) {

--- a/controller/hybridgateway/kongroute/route.go
+++ b/controller/hybridgateway/kongroute/route.go
@@ -444,7 +444,30 @@ func routesForTCPRouteRule(
 			pRef.Name, tcpRoute.Namespace, tcpRoute.Name)
 	}
 
+	return RoutesForTCPRouteRuleWithPorts(ctx, logger, cl, tcpRoute, rule, pRef, cp, namingParentRef, serviceName, ports)
+}
+
+// RoutesForTCPRouteRuleWithPorts generates an L4 Kong route for the given TCPRoute rule
+// using the already-arbitrated Gateway listener ports supplied by the caller.
+func RoutesForTCPRouteRuleWithPorts(
+	ctx context.Context,
+	logger logr.Logger,
+	cl client.Client,
+	tcpRoute *gwtypes.TCPRoute,
+	rule gwtypes.TCPRouteRule,
+	pRef *gwtypes.ParentReference,
+	cp *commonv1alpha1.ControlPlaneRef,
+	namingParentRef *gwtypes.ParentReference,
+	serviceName string,
+	ports []int32,
+) ([]*configurationv1alpha1.KongRoute, error) {
+	if len(ports) == 0 {
+		return nil, fmt.Errorf("no TCP listener ports selected for TCPRoute %s/%s", tcpRoute.Namespace, tcpRoute.Name)
+	}
+
 	tags := pkgmetadata.ExtractTags(tcpRoute)
+	routeName := namegen.NewKongRouteNameForTCPRouteRule(tcpRoute, cp, namingParentRef, rule)
+	logger = logger.WithValues("kongroute", routeName)
 
 	routeBuilder := builder.NewKongRoute().WithName(routeName).
 		WithNamespace(metadata.NamespaceFromParentRef(tcpRoute, pRef)).

--- a/pkg/gatewayapi/supportedfeatures.go
+++ b/pkg/gatewayapi/supportedfeatures.go
@@ -24,6 +24,7 @@ var commonSupportedFeatures = []features.FeatureName{
 	features.SupportGateway,
 	features.SupportHTTPRoute,
 	features.SupportTLSRoute,
+	features.SupportTCPRoute,
 	features.SupportGRPCRoute,
 	features.SupportUDPRoute,
 	features.SupportReferenceGrant,

--- a/pkg/gatewayapi/supportedfeatures_test.go
+++ b/pkg/gatewayapi/supportedfeatures_test.go
@@ -1,0 +1,23 @@
+package gatewayapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"sigs.k8s.io/gateway-api/pkg/features"
+
+	"github.com/kong/kong-operator/v2/pkg/consts"
+)
+
+func TestGetSupportedFeaturesIncludesTCPRoute(t *testing.T) {
+	for _, routerFlavor := range []consts.RouterFlavor{
+		consts.RouterFlavorTraditionalCompatible,
+		consts.RouterFlavorExpressions,
+	} {
+		t.Run(string(routerFlavor), func(t *testing.T) {
+			supportedFeatures, err := GetSupportedFeatures(routerFlavor)
+			require.NoError(t, err)
+			require.Contains(t, supportedFeatures, features.SupportTCPRoute)
+		})
+	}
+}

--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -3,6 +3,7 @@ package conformance
 import (
 	"context"
 	"fmt"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -145,13 +146,8 @@ func runConformance(
 		},
 	}
 	opts.Mode = mode
-	opts.ConformanceProfiles = []suite.ConformanceProfileName{
-		suite.GatewayHTTPConformanceProfileName,
-		suite.GatewayGRPCConformanceProfileName,
-		suite.GatewayTLSConformanceProfileName,
-		suite.GatewayUDPConformanceProfileName,
-	}
-	opts.SupportedFeatures = supportedFeatures
+	opts.ConformanceProfiles = conformanceProfiles(gwType)
+	opts.SupportedFeatures = conformanceSupportedFeatures(gwType, supportedFeatures)
 	opts.SkipTests = skipped
 	opts.CleanupBaseResources = cleanupResources
 	opts.GatewayClassName = gwc.Name
@@ -175,6 +171,29 @@ func runConformance(
 
 	t.Log("running the Gateway API conformance test suite")
 	conformance.RunConformanceWithOptions(t, opts)
+}
+
+func conformanceProfiles(gwType gatewayType) []suite.ConformanceProfileName {
+	profiles := []suite.ConformanceProfileName{
+		suite.GatewayHTTPConformanceProfileName,
+		suite.GatewayGRPCConformanceProfileName,
+		suite.GatewayTLSConformanceProfileName,
+		suite.GatewayUDPConformanceProfileName,
+	}
+	if gwType == hybridGateway {
+		profiles = append(profiles, suite.GatewayTCPConformanceProfileName)
+	}
+	return profiles
+}
+
+func conformanceSupportedFeatures(gwType gatewayType, supportedFeatures []features.FeatureName) []features.FeatureName {
+	if gwType == hybridGateway {
+		return supportedFeatures
+	}
+
+	return slices.DeleteFunc(slices.Clone(supportedFeatures), func(feature features.FeatureName) bool {
+		return feature == features.SupportTCPRoute
+	})
 }
 
 // conformanceCleanupTimeout bounds how long the post-test Hook waits for


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR enables TCPRoute conformance for HybridGateway and adds the missing deterministic TCPRoute conflict handling needed for the Gateway API `TCPRouteMultipleRoutesAttachment` behavior.

- Advertises TCPRoute support for Gateway API conformance.
- Keeps TCPRoute conformance scoped to HybridGateway in this PR, so standard gateway TCPRoute conformance can be enabled separately.
- Adds HybridGateway TCPRoute arbitration for routes attached to the same Gateway listener: oldest `CreationTimestamp` wins, with `namespace/name` as the tie-breaker, matching the Gateway API precedence model used by on-prem UDPRoute.
- Ensures only the winning TCPRoute renders dataplane KongRoute resources for the listener while attached routes can still participate in status/attachment accounting.


**Which issue this PR fixes**

Fixes https://github.com/Kong/kong-operator/issues/4335

**Special notes for your reviewer**:



**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
