### PR TITLE
chore(api): Move ReferenceGrant from gateway v1beta1 to v1

### DIFF
--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -27,7 +27,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	kcfgconsts "github.com/kong/kong-operator/v2/api/common/consts"
 	commonv1alpha1 "github.com/kong/kong-operator/v2/api/common/v1alpha1"
@@ -118,7 +117,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) err
 		Watches(
 			&gwtypes.ReferenceGrant{},
 			handler.EnqueueRequestsFromMapFunc(r.listReferenceGrantsForGateway),
-			builder.WithPredicates(ref.ReferenceGrantForSecretFrom(gatewayv1.GroupName, gatewayv1beta1.Kind("Gateway")))).
+			builder.WithPredicates(ref.ReferenceGrantForSecretFrom(gatewayv1.GroupName, gatewayv1.Kind("Gateway")))).
 		// watch for KongReferenceGrants to keep managed Konnect API auth grants in sync.
 		Watches(
 			&configurationv1alpha1.KongReferenceGrant{},

--- a/controller/hybridgateway/watch/mapfuncs_gateway_test.go
+++ b/controller/hybridgateway/watch/mapfuncs_gateway_test.go
@@ -10,7 +10,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	gwtypes "github.com/kong/kong-operator/v2/internal/types"
 	"github.com/kong/kong-operator/v2/internal/utils/index"
@@ -401,7 +400,7 @@ func Test_MapGatewayForTLSSecret(t *testing.T) {
 
 func Test_MapGatewayForReferenceGrant(t *testing.T) {
 	secretKind := gatewayv1.Kind("Secret")
-	gatewayKind := gatewayv1beta1.Kind("Gateway")
+	gatewayKind := gatewayv1.Kind("Gateway")
 	ns1 := gatewayv1.Namespace("ns1")
 	ns2 := gatewayv1.Namespace("ns2")
 	gwGroup := gatewayv1.Group(gwtypes.GroupName)
@@ -1020,7 +1019,7 @@ func Test_MapGatewayForReferenceGrant(t *testing.T) {
 
 func Test_hasMatchingCrossNamespaceSecretRef(t *testing.T) {
 	secretKind := gatewayv1.Kind("Secret")
-	gatewayKind := gatewayv1beta1.Kind("Gateway")
+	gatewayKind := gatewayv1.Kind("Gateway")
 	ns1 := gatewayv1.Namespace("ns1")
 	ns2 := gatewayv1.Namespace("ns2")
 	gwGroup := gatewayv1.Group(gwtypes.GroupName)

--- a/controller/specialized/aigateway_controller_watch.go
+++ b/controller/specialized/aigateway_controller_watch.go
@@ -11,7 +11,6 @@ import (
 	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	operatorv1alpha1 "github.com/kong/kong-operator/v2/api/gateway-operator/v1alpha1"
 	operatorerrors "github.com/kong/kong-operator/v2/internal/errors"
@@ -98,7 +97,7 @@ func (r *AIGatewayReconciler) listAIGatewaysForReferenceGrants(ctx context.Conte
 
 	namespaces := []string{}
 	for _, from := range referenceGrant.Spec.From {
-		if from.Group != gatewayv1beta1.Group(operatorv1alpha1.SchemeGroupVersion.Group) || from.Kind != gatewayv1beta1.Kind("AIGateway") {
+		if from.Group != gatewayv1.Group(operatorv1alpha1.SchemeGroupVersion.Group) || from.Kind != gatewayv1.Kind("AIGateway") {
 			continue
 		}
 		ns := string(from.Namespace)
@@ -134,6 +133,6 @@ func referenceGrantReferencesAIGateway(obj client.Object) bool {
 		return false
 	}
 	return lo.ContainsBy(referenceGrant.Spec.From, func(from gwtypes.ReferenceGrantFrom) bool {
-		return from.Group == gatewayv1beta1.Group(operatorv1alpha1.SchemeGroupVersion.Group) && from.Kind == gatewayv1beta1.Kind("AIGateway")
+		return from.Group == gatewayv1.Group(operatorv1alpha1.SchemeGroupVersion.Group) && from.Kind == gatewayv1.Kind("AIGateway")
 	})
 }

--- a/ingress-controller/internal/controllers/gateway/gateway_controller.go
+++ b/ingress-controller/internal/controllers/gateway/gateway_controller.go
@@ -27,7 +27,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/annotations"
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/controllers"
@@ -85,8 +85,8 @@ func (r *GatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// Once the GatewayReconciler is set up without ReferenceGrant, there's no possibility to enable
 	// ReferenceGrant handling again in this reconciler at runtime.
 	r.enableReferenceGrant = ctrlutils.CRDExists(mgr.GetRESTMapper(), schema.GroupVersionResource{
-		Group:    gatewayv1beta1.GroupVersion.Group,
-		Version:  gatewayv1beta1.GroupVersion.Version,
+		Group:    gatewayv1.GroupVersion.Group,
+		Version:  gatewayv1.GroupVersion.Version,
 		Resource: "referencegrants",
 	})
 
@@ -691,7 +691,7 @@ var (
 
 func init() {
 	// gather the supported RouteGroupKinds for the Gateway listeners
-	group := gatewayapi.Group(gatewayv1beta1.GroupName)
+	group := gatewayapi.Group(gatewayv1.GroupName)
 	for _, supportedKind := range supportedKinds {
 		supportedRouteGroupKinds = append(supportedRouteGroupKinds, gatewayapi.RouteGroupKind{
 			Group: &group,

--- a/ingress-controller/internal/controllers/gateway/httproute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/httproute_controller.go
@@ -26,7 +26,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	configurationv1 "github.com/kong/kong-operator/v2/api/configuration/v1"
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/controllers"
@@ -73,8 +72,8 @@ func (r *HTTPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// Once the HTTPRouteReconciler is set up without ReferenceGrant, there's no possibility to enable
 	// ReferenceGrant handling again in this reconciler at runtime.
 	r.enableReferenceGrant = ctrlutils.CRDExists(mgr.GetRESTMapper(), schema.GroupVersionResource{
-		Group:    gatewayv1beta1.GroupVersion.Group,
-		Version:  gatewayv1beta1.GroupVersion.Version,
+		Group:    gatewayv1.GroupVersion.Group,
+		Version:  gatewayv1.GroupVersion.Version,
 		Resource: "referencegrants",
 	})
 

--- a/ingress-controller/internal/controllers/gateway/tcproute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/tcproute_controller.go
@@ -24,7 +24,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/controllers"
 	ctrlutils "github.com/kong/kong-operator/v2/ingress-controller/internal/controllers/utils"
@@ -67,8 +66,8 @@ func (r *TCPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// Once the TCPRouteReconciler is set up without ReferenceGrant, there's no possibility to enable
 	// ReferenceGrant handling again in this reconciler at runtime.
 	r.enableReferenceGrant = ctrlutils.CRDExists(mgr.GetRESTMapper(), schema.GroupVersionResource{
-		Group:    gatewayv1beta1.GroupVersion.Group,
-		Version:  gatewayv1beta1.GroupVersion.Version,
+		Group:    gatewayv1.GroupVersion.Group,
+		Version:  gatewayv1.GroupVersion.Version,
 		Resource: "referencegrants",
 	})
 

--- a/ingress-controller/internal/controllers/gateway/tlsroute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/tlsroute_controller.go
@@ -24,7 +24,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/controllers"
 	ctrlutils "github.com/kong/kong-operator/v2/ingress-controller/internal/controllers/utils"
@@ -67,8 +66,8 @@ func (r *TLSRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// Once the TLSRouteReconciler is set up without ReferenceGrant, there's no possibility to enable
 	// ReferenceGrant handling again in this reconciler at runtime.
 	r.enableReferenceGrant = ctrlutils.CRDExists(mgr.GetRESTMapper(), schema.GroupVersionResource{
-		Group:    gatewayv1beta1.GroupVersion.Group,
-		Version:  gatewayv1beta1.GroupVersion.Version,
+		Group:    gatewayv1.GroupVersion.Group,
+		Version:  gatewayv1.GroupVersion.Version,
 		Resource: "referencegrants",
 	})
 

--- a/ingress-controller/internal/controllers/gateway/udproute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/udproute_controller.go
@@ -24,7 +24,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/controllers"
 	ctrlutils "github.com/kong/kong-operator/v2/ingress-controller/internal/controllers/utils"
@@ -67,8 +66,8 @@ func (r *UDPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// Once the UDPRouteReconciler is set up without ReferenceGrant, there's no possibility to enable
 	// ReferenceGrant handling again in this reconciler at runtime.
 	r.enableReferenceGrant = ctrlutils.CRDExists(mgr.GetRESTMapper(), schema.GroupVersionResource{
-		Group:    gatewayv1beta1.GroupVersion.Group,
-		Version:  gatewayv1beta1.GroupVersion.Version,
+		Group:    gatewayv1.GroupVersion.Group,
+		Version:  gatewayv1.GroupVersion.Version,
 		Resource: "referencegrants",
 	})
 

--- a/ingress-controller/internal/gatewayapi/typemeta.go
+++ b/ingress-controller/internal/gatewayapi/typemeta.go
@@ -3,7 +3,6 @@ package gatewayapi
 import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 )
 
 var V1GatewayTypeMeta = metav1.TypeMeta{
@@ -22,7 +21,7 @@ var V1HTTPRouteTypeMeta = metav1.TypeMeta{
 }
 
 var ReferenceGrantTypeMeta = metav1.TypeMeta{
-	APIVersion: gatewayv1beta1.GroupVersion.String(),
+	APIVersion: gatewayv1.GroupVersion.String(),
 	Kind:       "ReferenceGrant",
 }
 
@@ -58,13 +57,13 @@ var (
 		Resource: "httproutes",
 	}
 	V1beta1GatewayGVResource = metav1.GroupVersionResource{
-		Group:    gatewayv1beta1.GroupVersion.Group,
-		Version:  gatewayv1beta1.GroupVersion.Version,
+		Group:    gatewayv1.GroupVersion.Group,
+		Version:  gatewayv1.GroupVersion.Version,
 		Resource: "gateways",
 	}
 	V1beta1HTTPRouteGVResource = metav1.GroupVersionResource{
-		Group:    gatewayv1beta1.GroupVersion.Group,
-		Version:  gatewayv1beta1.GroupVersion.Version,
+		Group:    gatewayv1.GroupVersion.Group,
+		Version:  gatewayv1.GroupVersion.Version,
 		Resource: "httproutes",
 	}
 )

--- a/ingress-controller/internal/manager/controllerdef.go
+++ b/ingress-controller/internal/manager/controllerdef.go
@@ -9,7 +9,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1alpha3 "sigs.k8s.io/gateway-api/apis/v1alpha3"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/controllers"
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/controllers/configuration"
@@ -338,8 +337,8 @@ func setupControllers(
 				Log:              ctrl.LoggerFrom(ctx).WithName("controllers").WithName("Dynamic/ReferenceGrant"),
 				CacheSyncTimeout: c.CacheSyncTimeout,
 				RequiredCRDs: append(baseGatewayCRDs(), schema.GroupVersionResource{
-					Group:    gatewayv1beta1.GroupVersion.Group,
-					Version:  gatewayv1beta1.GroupVersion.Version,
+					Group:    gatewayv1.GroupVersion.Group,
+					Version:  gatewayv1.GroupVersion.Version,
 					Resource: "referencegrants",
 				}),
 				Controller: &gateway.ReferenceGrantReconciler{

--- a/ingress-controller/internal/store/fake_store.go
+++ b/ingress-controller/internal/store/fake_store.go
@@ -17,7 +17,6 @@ import (
 	"k8s.io/client-go/tools/cache"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1alpha3 "sigs.k8s.io/gateway-api/apis/v1alpha3"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	"sigs.k8s.io/yaml"
 
 	configurationv1 "github.com/kong/kong-operator/v2/api/configuration/v1"
@@ -276,7 +275,7 @@ func (objects FakeObjects) MarshalToYAML() ([]byte, error) {
 		reflect.TypeFor[*gatewayapi.TCPRoute]():                          schema.GroupVersion(gatewayv1.GroupVersion).WithKind("TCPRoute"),
 		reflect.TypeFor[*gatewayapi.TLSRoute]():                          schema.GroupVersion(gatewayv1.GroupVersion).WithKind("TLSRoute"),
 		reflect.TypeFor[*gatewayapi.GRPCRoute]():                         schema.GroupVersion(gatewayv1.GroupVersion).WithKind("GRPCRoute"),
-		reflect.TypeFor[*gatewayapi.ReferenceGrant]():                    schema.GroupVersion(gatewayv1beta1.GroupVersion).WithKind("ReferenceGrant"),
+		reflect.TypeFor[*gatewayapi.ReferenceGrant]():                    schema.GroupVersion(gatewayv1.GroupVersion).WithKind("ReferenceGrant"),
 		reflect.TypeFor[*gatewayapi.Gateway]():                           schema.GroupVersion(gatewayv1.GroupVersion).WithKind("Gateway"),
 		reflect.TypeFor[*gatewayapi.BackendTLSPolicy]():                  schema.GroupVersion(gatewayv1alpha3.GroupVersion).WithKind("BackendTLSPolicy"),
 		reflect.TypeFor[*configurationv1alpha1.IngressClassParameters](): configurationv1alpha1.SchemeGroupVersion.WithKind("IngressClassParameters"),

--- a/ingress-controller/internal/store/store.go
+++ b/ingress-controller/internal/store/store.go
@@ -36,7 +36,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1alpha3 "sigs.k8s.io/gateway-api/apis/v1alpha3"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	"sigs.k8s.io/yaml"
 
 	configurationv1 "github.com/kong/kong-operator/v2/api/configuration/v1"
@@ -774,7 +773,7 @@ func mkObjFromGVK(gvk schema.GroupVersionKind) (runtime.Object, error) {
 		return &gatewayapi.UDPRoute{}, nil
 	case schema.GroupVersion(gatewayv1.GroupVersion).WithKind("TLSRoute"):
 		return &gatewayapi.TLSRoute{}, nil
-	case schema.GroupVersion(gatewayv1beta1.GroupVersion).WithKind("ReferenceGrant"):
+	case schema.GroupVersion(gatewayv1.GroupVersion).WithKind("ReferenceGrant"):
 		return &gatewayapi.ReferenceGrant{}, nil
 	case schema.GroupVersion(gatewayv1alpha3.GroupVersion).WithKind("BackendTLSPolicy"):
 		return &gatewayapi.BackendTLSPolicy{}, nil

--- a/modules/manager/controller_setup.go
+++ b/modules/manager/controller_setup.go
@@ -263,13 +263,13 @@ func requiredCRDChecks(c *Config) []requiredCRDCheck {
 					Resource: "gateways",
 				},
 				{
-					Group:    gatewayv1beta1.GroupVersion.Group,
-					Version:  gatewayv1beta1.GroupVersion.Version,
+					Group:    gatewayv1.GroupVersion.Group,
+					Version:  gatewayv1.GroupVersion.Version,
 					Resource: "referencegrants",
 				},
 				{
-					Group:    gatewayv1beta1.GroupVersion.Group,
-					Version:  gatewayv1beta1.GroupVersion.Version,
+					Group:    gatewayv1.GroupVersion.Group,
+					Version:  gatewayv1.GroupVersion.Version,
 					Resource: "httproutes",
 				},
 				gwtypes.GatewayConfigurationGVR(),
@@ -285,7 +285,7 @@ func requiredCRDChecks(c *Config) []requiredCRDCheck {
 			gvrs: []schema.GroupVersionResource{
 				operatorv1alpha1.AIGatewayGVR(),
 				{
-					Group:    gatewayv1beta1.GroupVersion.Group,
+					Group:    gatewayv1.GroupVersion.Group,
 					Version:  gatewayv1beta1.GroupVersion.Version,
 					Resource: "referencegrants",
 				},

--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -16,7 +16,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 	"sigs.k8s.io/gateway-api/conformance"
 	conformancev1 "sigs.k8s.io/gateway-api/conformance/apis/v1"
 	conformanceconfig "sigs.k8s.io/gateway-api/conformance/utils/config"
@@ -226,7 +225,7 @@ func waitForConformanceResourcesCleanup(ctx context.Context, cl client.Client, l
 			}
 		}
 
-		var grants gatewayv1beta1.ReferenceGrantList
+		var grants gatewayv1.ReferenceGrantList
 		if err := cl.List(ctx, &grants); err != nil {
 			return false, nil //nolint:nilerr
 		}


### PR DESCRIPTION
**What this PR does / why we need it**:

Since `ReferenceGrant` has graduated to `v1` in gateway API 1.5, we bump all the appearance of `ReferenceGrant` from `v1beta1` to `v1`.

**Which issue this PR fixes**

Fixes #5045

**Special notes for your reviewer**:

There are no actual usage of `gatewayv1beta1` and `gatewayv1alpha2` resources. Should we remove the installation of them in `modules/manager/scheme`?

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
No need to update changelog
