### PR TITLE
test: enable HTTPRouteNoBackendRefs, GatewayInvalidParametersRef and GatewayListenerUnsupportedProtocol conformance test

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -70,6 +70,13 @@
   provisioning silently failed with
   `expected "<image>:<tag>" format, got: <full-ref>`.
   [#5036](https://github.com/Kong/kong-operator/pull/5036)
+- Hybridgateway: an `HTTPRoute` rule with omitted or empty `backendRefs` now
+  responds with `500` instead of Kong's default `503` for an empty upstream, by
+  binding a `request-termination` plugin to the generated Kong service. Rules
+  that already produce a response via a `RequestRedirect` filter are excluded.
+  This fixes the `HTTPRouteNoBackendRefs` Gateway API conformance test for the
+  hybrid gateway.
+  [#5066](https://github.com/Kong/kong-operator/pull/5066)
 
 ### Added
 

--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -307,6 +307,21 @@ func (r *Reconciler) Reconcile(ctx context.Context, gateway *gwtypes.Gateway) (c
 	if err := gwConditionAware.setResolvedRefsAndSupportedKinds(ctx, r.Client); err != nil {
 		return ctrl.Result{}, err
 	}
+	// Validate the infrastructure.parametersRef early. If it references an
+	// unsupported group/kind the Gateway MUST be Accepted=False with
+	// reason InvalidParameters per the Gateway API spec.
+	if gateway.Spec.Infrastructure != nil && gateway.Spec.Infrastructure.ParametersRef != nil {
+		if err := gwconfigutils.ValidateParametersRefGroupKind(gateway.Spec.Infrastructure.ParametersRef); err != nil {
+			k8sutils.SetCondition(metav1.Condition{
+				Type:               string(gatewayv1.GatewayConditionAccepted),
+				Status:             metav1.ConditionFalse,
+				Reason:             string(gatewayv1.GatewayReasonInvalidParameters),
+				Message:            err.Error(),
+				ObservedGeneration: gateway.Generation,
+				LastTransitionTime: metav1.Now(),
+			}, gwConditionAware)
+		}
+	}
 	acceptedCondition, _ := k8sutils.GetCondition(kcfgconsts.ConditionType(gatewayv1.GatewayConditionAccepted), gwConditionAware)
 	// If the static Gateway API conditions (Accepted, ResolvedRefs, Conflicted) changed, we need to update the Gateway status
 	if gatewayStatusNeedsUpdate(oldGwConditionsAware, gwConditionAware) {

--- a/controller/gateway/controller_reconciler_utils_test.go
+++ b/controller/gateway/controller_reconciler_utils_test.go
@@ -569,10 +569,56 @@ func TestSetAcceptedOnGateway(t *testing.T) {
 			},
 			expectedAcceptedCondition: metav1.Condition{
 				Type:               string(gatewayv1.GatewayConditionAccepted),
-				Status:             metav1.ConditionFalse,
+				Status:             metav1.ConditionTrue,
 				Reason:             string(gatewayv1.GatewayReasonListenersNotValid),
 				ObservedGeneration: 1,
 				Message:            "Listener 1 is not accepted. Listener 2 is conflicted.",
+			},
+		},
+		{
+			name: "one accepted and one unsupported protocol listener - gateway accepted with ListenersNotValid",
+			listeners: []gatewayv1.ListenerStatus{
+				{
+					Name: "http",
+					Conditions: []metav1.Condition{
+						{
+							Type:               string(gatewayv1.ListenerConditionAccepted),
+							Status:             metav1.ConditionTrue,
+							Reason:             string(gatewayv1.ListenerReasonAccepted),
+							ObservedGeneration: 1,
+						},
+						{
+							Type:               string(gatewayv1.ListenerConditionConflicted),
+							Status:             metav1.ConditionFalse,
+							Reason:             string(gatewayv1.ListenerReasonNoConflicts),
+							ObservedGeneration: 1,
+						},
+					},
+				},
+				{
+					Name: "invalid",
+					Conditions: []metav1.Condition{
+						{
+							Type:               string(gatewayv1.ListenerConditionAccepted),
+							Status:             metav1.ConditionFalse,
+							Reason:             string(gatewayv1.ListenerReasonUnsupportedProtocol),
+							ObservedGeneration: 1,
+						},
+						{
+							Type:               string(gatewayv1.ListenerConditionConflicted),
+							Status:             metav1.ConditionFalse,
+							Reason:             string(gatewayv1.ListenerReasonNoConflicts),
+							ObservedGeneration: 1,
+						},
+					},
+				},
+			},
+			expectedAcceptedCondition: metav1.Condition{
+				Type:               string(gatewayv1.GatewayConditionAccepted),
+				Status:             metav1.ConditionTrue,
+				Reason:             string(gatewayv1.GatewayReasonListenersNotValid),
+				ObservedGeneration: 1,
+				Message:            "Listener 1 is not accepted.",
 			},
 		},
 	}

--- a/controller/hybridgateway/converter/http_route.go
+++ b/controller/hybridgateway/converter/http_route.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	commonv1alpha1 "github.com/kong/kong-operator/v2/api/common/v1alpha1"
 	configurationv1 "github.com/kong/kong-operator/v2/api/configuration/v1"
@@ -562,7 +563,13 @@ func (c *httpRouteConverter) translate(ctx context.Context, logger logr.Logger) 
 			}
 			ruleOutputs = append(ruleOutputs, filterOutputs...)
 
-			if len(rule.BackendRefs) > 0 && len(targets) == 0 {
+			// Per the Gateway API spec, an HTTPRoute rule that resolves to no valid backend must
+			// respond with 500. This covers both invalid backendRefs (present but unresolvable) and
+			// omitted or empty backendRefs. Kong's default for a service with an empty upstream is
+			// 503, so we bind a request-termination plugin to the service to return 500 instead.
+			// A rule whose RequestRedirect filter already produces a response without a backend is
+			// excluded: its redirect plugin must handle the request instead of terminating it.
+			if len(targets) == 0 && !ruleHasRedirectFilter(rule) {
 				terminationPlugin, err := plugin.RequestTerminationForBackendNotFound(
 					ctx,
 					logger,
@@ -629,4 +636,16 @@ type hybridGatewayParent struct {
 	parentRef gwtypes.ParentReference
 	cpRef     *commonv1alpha1.ControlPlaneRef
 	hostnames []string
+}
+
+// ruleHasRedirectFilter reports whether the rule has a RequestRedirect filter. Such a filter
+// produces an HTTP response without needing a backend, so a rule that has one must not get a
+// request-termination plugin injected when it resolves to no backend targets.
+func ruleHasRedirectFilter(rule gwtypes.HTTPRouteRule) bool {
+	for _, f := range rule.Filters {
+		if f.Type == gatewayv1.HTTPRouteFilterRequestRedirect {
+			return true
+		}
+	}
+	return false
 }

--- a/controller/hybridgateway/converter/http_route_converter_test.go
+++ b/controller/hybridgateway/converter/http_route_converter_test.go
@@ -525,6 +525,67 @@ func TestHTTPRouteConverter_Translate(t *testing.T) {
 			},
 		},
 		{
+			// Gateway API HTTPRouteNoBackendRefs conformance: a rule with omitted or empty
+			// backendRefs (and no response-generating filter) must respond with 500.
+			name: "translates omitted backendRefs into request termination plugin",
+			setup: func(t *testing.T) *httpRouteConverter {
+				route := newHTTPRouteForTranslation([]string{"api.example.com"}, nil, nil)
+				gateway := baseGateway()
+				objects := append(newKonnectGatewayStandardObjects(gateway), newNamespace())
+				fakeClient := fake.NewClientBuilder().WithScheme(scheme.Get()).WithObjects(objects...).Build()
+				return newHTTPRouteConverter(route, fakeClient, false, "").(*httpRouteConverter)
+			},
+			wantCount: 5,
+			wantOutputs: outputCount{
+				upstreams: 1,
+				services:  1,
+				routes:    1,
+				targets:   0,
+				bindings:  1,
+				plugins:   1,
+			},
+			wantStoreLen: 5,
+			assertFn: func(t *testing.T, store []client.Object) {
+				t.Helper()
+
+				var (
+					serviceObj *configurationv1alpha1.KongService
+					pluginObj  *configurationv1.KongPlugin
+					bindingObj *configurationv1alpha1.KongPluginBinding
+				)
+
+				for _, obj := range store {
+					switch typed := obj.(type) {
+					case *configurationv1alpha1.KongService:
+						serviceObj = typed
+					case *configurationv1.KongPlugin:
+						pluginObj = typed
+					case *configurationv1alpha1.KongPluginBinding:
+						bindingObj = typed
+					}
+				}
+
+				require.NotNil(t, serviceObj)
+				require.NotNil(t, pluginObj)
+				require.NotNil(t, bindingObj)
+				assert.Equal(t, "request-termination", pluginObj.PluginName)
+
+				var config map[string]any
+				require.NoError(t, json.Unmarshal(pluginObj.Config.Raw, &config))
+				statusCode, ok := config["status_code"].(float64)
+				require.True(t, ok)
+				assert.InDelta(t, 500, statusCode, 0)
+				assert.Equal(t, "no existing backendRef provided", config["message"])
+
+				// The request-termination plugin must be bound to the service so Kong returns 500
+				// for the empty upstream instead of its default 503.
+				require.NotNil(t, bindingObj.Spec.Targets)
+				require.NotNil(t, bindingObj.Spec.Targets.ServiceReference)
+				assert.Equal(t, serviceObj.Name, bindingObj.Spec.Targets.ServiceReference.Name)
+				assert.Equal(t, pluginObj.Name, bindingObj.Spec.PluginReference.Name)
+			},
+		},
+		{
 			name: "translates cross-namespace backend without reference grant into request termination plugin",
 			setup: func(t *testing.T) *httpRouteConverter {
 				route := newHTTPRouteForTranslation([]string{"api.example.com"}, []gwtypes.HTTPBackendRef{

--- a/ingress-controller/internal/dataplane/translator/subtranslator/httproute.go
+++ b/ingress-controller/internal/dataplane/translator/subtranslator/httproute.go
@@ -263,7 +263,16 @@ func translateHTTPRouteRulesMetaToKongstateService(
 	// the response must have a status code of 500. Since The default behavior of Kong is returning 503
 	// if there is no backend for a service, we inject a plugin that terminates all requests with 500
 	// as status code.
-	if len(service.Backends) == 0 && len(backendRefs) != 0 {
+	// We also need to handle the case where no backendRefs were provided at all (omitted or empty),
+	// which per the Gateway API spec should also result in a 500 response.
+	// However, if any rule has a RequestRedirect filter that can produce a response without backends,
+	// we skip the request-termination plugin because it has higher Kong priority than the redirect
+	// plugin and would intercept the request before the redirect could fire.
+	if len(service.Backends) == 0 && !lo.SomeBy(rulesMeta, func(m httpRouteRuleMeta) bool {
+		return lo.SomeBy(m.Rule.Filters, func(f gatewayapi.HTTPRouteFilter) bool {
+			return f.Type == gatewayapi.HTTPRouteFilterRequestRedirect
+		})
+	}) {
 		if service.Plugins == nil {
 			service.Plugins = make([]kong.Plugin, 0)
 		}
@@ -274,6 +283,12 @@ func translateHTTPRouteRulesMetaToKongstateService(
 				"message":     "no existing backendRef provided",
 			},
 		})
+		// Use the .invalid host suffix for services with no backends to avoid
+		// reusing Kong balancer state when the same logical service later becomes valid.
+		// This also applies when no backendRefs were provided at all.
+		if len(backendRefs) == 0 {
+			service.Host = new(serviceName + invalidBackendRefsServiceHostSuffix)
+		}
 	}
 
 	// applyTimeoutToServiceFromHTTPRouteRule applies timeouts from HTTPRoute to the service.

--- a/ingress-controller/internal/dataplane/translator/translate_utils.go
+++ b/ingress-controller/internal/dataplane/translator/translate_utils.go
@@ -75,8 +75,9 @@ func generateKongServiceFromBackendRefWithName(
 	// In the context of the gateway API conformance tests, if there is no service for the backend,
 	// the response must have a status code of 500. Since The default behavior of Kong is returning 503
 	// if there is no backend for a service, we inject a plugin that terminates all requests with 500
-	// as status code
-	if len(service.Backends) == 0 && len(backendRefs) != 0 {
+	// as status code. This applies both when backendRefs were provided but invalid, and when
+	// no backendRefs were provided at all (omitted or empty).
+	if len(service.Backends) == 0 {
 		if service.Plugins == nil {
 			service.Plugins = make([]kong.Plugin, 0)
 		}

--- a/internal/utils/gatewayconfig/get.go
+++ b/internal/utils/gatewayconfig/get.go
@@ -74,6 +74,18 @@ func GetFromParametersRef(
 	return &gatewayConfig, nil
 }
 
+// ValidateParametersRefGroupKind checks whether the LocalParametersRef references
+// a supported group/kind (gateway-operator.konghq.com/GatewayConfiguration).
+// Returns an error describing the invalid reference if not.
+func ValidateParametersRefGroupKind(parametersRef *gatewayv1.LocalParametersReference) error {
+	if string(parametersRef.Group) != operatorv2beta1.SchemeGroupVersion.Group ||
+		string(parametersRef.Kind) != "GatewayConfiguration" {
+		return fmt.Errorf("invalid parametersRef: only %s/GatewayConfiguration is supported, got %s/%s",
+			operatorv2beta1.SchemeGroupVersion.Group, parametersRef.Group, parametersRef.Kind)
+	}
+	return nil
+}
+
 // IsGatewayHybrid returns true if the GatewayConfiguration specifies the gateway to be a Konnect hybrid gateway.
 func IsGatewayHybrid(gwConfig *gwtypes.GatewayConfiguration) bool {
 	return gwConfig.Spec.Konnect != nil && gwConfig.Spec.Konnect.APIAuthConfigurationRef != nil

--- a/pkg/utils/kubernetes/status.go
+++ b/pkg/utils/kubernetes/status.go
@@ -191,8 +191,11 @@ func SetProgrammed(resource ConditionsAndGenerationAware) {
 }
 
 // SetAcceptedConditionOnGateway sets the gateway Accepted condition according to the Gateway API specification.
+// Per the spec, if at least one listener is accepted the Gateway MUST be Accepted=True
+// (with reason ListenersNotValid when some listeners are invalid); only when ALL listeners
+// are not accepted does the Gateway become Accepted=False.
 func SetAcceptedConditionOnGateway(resource ConditionsAndListenerConditionsAndGenerationAware) {
-	oldCondition, NewCondition := metav1.Condition{}, metav1.Condition{
+	oldCondition, newCondition := metav1.Condition{}, metav1.Condition{
 		Type:               string(gatewayv1.GatewayConditionAccepted),
 		Status:             metav1.ConditionTrue,
 		Reason:             string(gatewayv1.GatewayReasonAccepted),
@@ -200,39 +203,55 @@ func SetAcceptedConditionOnGateway(resource ConditionsAndListenerConditionsAndGe
 		LastTransitionTime: metav1.Now(),
 	}
 
-	// If even a single listener is not accepted or is conflicted, the gateway needs
-	// to be marked as not accepted.
-	for i, listStatus := range resource.GetListenersConditions() {
+	var acceptedListenerCount int
+	var hasInvalidListener bool
+
+	listenerConditions := resource.GetListenersConditions()
+	for i, listStatus := range listenerConditions {
+		listenerAccepted := true
 		for _, listCond := range listStatus.Conditions {
 			if listCond.Type == string(gatewayv1.GatewayConditionAccepted) {
 				if listCond.Status == metav1.ConditionFalse {
-					if NewCondition.Message != "" {
-						NewCondition.Message = fmt.Sprintf("%s ", NewCondition.Message)
+					listenerAccepted = false
+					if newCondition.Message != "" {
+						newCondition.Message = fmt.Sprintf("%s ", newCondition.Message)
 					}
-					NewCondition.Status = metav1.ConditionFalse
-					NewCondition.Reason = string(gatewayv1.GatewayReasonListenersNotValid)
-					NewCondition.Message = fmt.Sprintf("%sListener %d is not accepted.", NewCondition.Message, i)
+					newCondition.Message = fmt.Sprintf("%sListener %d is not accepted.", newCondition.Message, i)
 				}
 			}
 			if listCond.Type == string(gatewayv1.ListenerConditionConflicted) {
 				if listCond.Status == metav1.ConditionTrue {
-					if NewCondition.Message != "" {
-						NewCondition.Message = fmt.Sprintf("%s ", NewCondition.Message)
+					listenerAccepted = false
+					if newCondition.Message != "" {
+						newCondition.Message = fmt.Sprintf("%s ", newCondition.Message)
 					}
-					NewCondition.Status = metav1.ConditionFalse
-					NewCondition.Reason = string(gatewayv1.GatewayReasonListenersNotValid)
-					NewCondition.Message = fmt.Sprintf("%sListener %d is conflicted.", NewCondition.Message, i)
+					newCondition.Message = fmt.Sprintf("%sListener %d is conflicted.", newCondition.Message, i)
 				}
 			}
 		}
-	}
-	if NewCondition.Message == "" {
-		NewCondition.Message = "All listeners are accepted."
+		if listenerAccepted {
+			acceptedListenerCount++
+		} else {
+			hasInvalidListener = true
+		}
 	}
 
-	if NewCondition.Status != oldCondition.Status ||
-		NewCondition.Reason != oldCondition.Reason {
-		SetCondition(NewCondition, resource)
+	if hasInvalidListener {
+		newCondition.Reason = string(gatewayv1.GatewayReasonListenersNotValid)
+		// If at least one listener is accepted the Gateway MUST be Accepted=True
+		// with reason ListenersNotValid per the Gateway API spec.
+		if acceptedListenerCount == 0 {
+			newCondition.Status = metav1.ConditionFalse
+		}
+	}
+
+	if newCondition.Message == "" {
+		newCondition.Message = "All listeners are accepted."
+	}
+
+	if newCondition.Status != oldCondition.Status ||
+		newCondition.Reason != oldCondition.Reason {
+		SetCondition(newCondition, resource)
 	}
 }
 

--- a/test/conformance/skipped_tests_test.go
+++ b/test/conformance/skipped_tests_test.go
@@ -8,11 +8,6 @@ import (
 )
 
 var skippedTestsShared = []string{
-	// newly added in gateway api v1.6.0-rc.1, https://github.com/Kong/kong-operator/issues/4662
-	tests.GatewayListenerUnsupportedProtocol.ShortName,
-	tests.GatewayInvalidParametersRef.ShortName,
-	tests.HTTPRouteNoBackendRefs.ShortName,
-
 	// failed after bumping gateway api to v1.6.0-rc.1, https://github.com/Kong/kong-operator/issues/4661
 	tests.HTTPRouteWeight.ShortName,
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Enables three Gateway API conformance tests that were added in gateway-api v1.6.0-rc.1 and previously skipped, and fixes the behavior they cover.

- **HTTPRouteNoBackendRefs**: an HTTPRoute rule with omitted or empty `backendRefs` must respond with `500`. 
- **GatewayInvalidParametersRef**: set the proper Gateway status condition when the `parametersRef` is invalid.
- **GatewayListenerUnsupportedProtocol**: report the unsupported-protocol listener condition.

**Which issue this PR fixes**

Fixes #4662

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
