### PR TITLE
fix(on-prem): align TCPRoute translation with conformance requirements

### DIFF
--- a/ingress-controller/internal/controllers/gateway/tcproute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/tcproute_controller.go
@@ -413,15 +413,6 @@ func (r *TCPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			debug(log, tcproute, "Failed to update object in data-plane, requeueing")
 			return ctrl.Result{}, err
 		}
-		if r.DataplaneClient.AreKubernetesObjectReportsEnabled() {
-			// if the dataplane client has reporting enabled (this is the default and is
-			// tied in with status updates being enabled in the controller manager) then
-			// we will wait until the object is reported as successfully configured before
-			// moving on to status updates.
-			if !r.DataplaneClient.KubernetesObjectIsConfigured(tcproute) {
-				return ctrl.Result{Requeue: true}, nil
-			}
-		}
 	} else {
 		// route is not accepted, remove it from kong store
 		if err := r.DataplaneClient.DeleteObject(tcproute); err != nil {
@@ -445,6 +436,16 @@ func (r *TCPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	if updated {
 		// if the status was updated it will trigger a follow-up reconciliation
 		return ctrl.Result{}, nil
+	}
+
+	if r.DataplaneClient.AreKubernetesObjectReportsEnabled() {
+		// if the dataplane client has reporting enabled (this is the default and is
+		// tied in with status updates being enabled in the controller manager) then
+		// we will wait until the object is reported as successfully configured before
+		// moving on to the remaining status updates.
+		if !r.DataplaneClient.KubernetesObjectIsConfigured(tcproute) {
+			return ctrl.Result{Requeue: true}, nil
+		}
 	}
 
 	// update "Programmed" condition if the TCPRoute is translated to Kong configuration.

--- a/ingress-controller/internal/dataplane/testdata/golden/tcproute-example/in.yaml
+++ b/ingress-controller/internal/dataplane/testdata/golden/tcproute-example/in.yaml
@@ -1,9 +1,17 @@
 apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: example-gateway-class
+spec:
+  controllerName: konghq.com/kic-gateway-controller
+---
+apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
   name: example-tcp-gateway
   namespace: tcp-example
 spec:
+  gatewayClassName: example-gateway-class
   listeners:
   - name: tcp
     protocol: TCP

--- a/ingress-controller/internal/dataplane/testdata/golden/tcproute-example/in.yaml
+++ b/ingress-controller/internal/dataplane/testdata/golden/tcproute-example/in.yaml
@@ -8,6 +8,18 @@ spec:
   - name: tcp
     protocol: TCP
     port: 1025
+status:
+  listeners:
+  - name: tcp
+    supportedKinds:
+    - group: gateway.networking.k8s.io
+      kind: TCPRoute
+    conditions:
+    - type: Programmed
+      status: "True"
+      reason: Programmed
+      message: ""
+      lastTransitionTime: "2024-01-01T00:00:00Z"
 ---
 apiVersion: gateway.networking.k8s.io/v1
 kind: TCPRoute

--- a/ingress-controller/internal/dataplane/translator/translate_tcproute.go
+++ b/ingress-controller/internal/dataplane/translator/translate_tcproute.go
@@ -45,7 +45,7 @@ func (t *Translator) ingressRulesFromTCPRoutes() ingressRules {
 	attachments := make(map[l4ListenerKey][]*gatewayapi.TCPRoute)
 	attachedRoutes := make(map[*gatewayapi.TCPRoute]struct{})
 	for _, r := range valid {
-		listenerKeys := l4RouteListenerAttachments(r, t.logger, listenersByGateway)
+		listenerKeys := l4RouteListenerAttachments(r, t.logger, t.storer, listenersByGateway)
 		for _, k := range listenerKeys {
 			attachments[k] = append(attachments[k], r)
 			attachedRoutes[r] = struct{}{}

--- a/ingress-controller/internal/dataplane/translator/translate_tcproute.go
+++ b/ingress-controller/internal/dataplane/translator/translate_tcproute.go
@@ -12,7 +12,10 @@ import (
 // -----------------------------------------------------------------------------
 
 // ingressRulesFromTCPRoutes processes a list of TCPRoute objects and translates
-// then into Kong configuration objects.
+// them into Kong configuration objects.
+// Per GEP-2645, when multiple TCPRoutes attached to the same listener, only the
+// winner is rendered into the dataplane.
+// Winner selection: oldest CreationTimestamp; namespace/name (alphabetical).
 func (t *Translator) ingressRulesFromTCPRoutes() ingressRules {
 	result := newIngressRules()
 
@@ -23,14 +26,62 @@ func (t *Translator) ingressRulesFromTCPRoutes() ingressRules {
 	}
 
 	var errs []error
-	for _, tcproute := range tcpRouteList {
-		if err := t.ingressRulesFromTCPRoute(&result, tcproute); err != nil {
-			err = fmt.Errorf("TCPRoute %s/%s can't be routed: %w", tcproute.Namespace, tcproute.Name, err)
+
+	// Validate first; keep only structurally-valid routes for arbitration.
+	valid := make([]*gatewayapi.TCPRoute, 0, len(tcpRouteList))
+	for _, r := range tcpRouteList {
+		if err := validateTCPRoute(r); err != nil {
 			errs = append(errs, err)
-		} else {
-			// at this point the object has been configured and can be
-			// reported as successfully translated.
-			t.registerSuccessfullyTranslatedObject(tcproute)
+			t.registerTranslationFailure(err.Error(), r)
+			continue
+		}
+		valid = append(valid, r)
+	}
+
+	// Build gateway -> TCP listeners index for the gateways referenced anywhere.
+	listenersByGateway := collectL4ListenersByGateway(t.storer, valid, gatewayapi.TCPProtocolType)
+
+	// Group routes by l4ListenerKey.
+	attachments := make(map[l4ListenerKey][]*gatewayapi.TCPRoute)
+	attachedRoutes := make(map[*gatewayapi.TCPRoute]struct{})
+	for _, r := range valid {
+		listenerKeys := l4RouteListenerAttachments(r, t.logger, listenersByGateway)
+		for _, k := range listenerKeys {
+			attachments[k] = append(attachments[k], r)
+			attachedRoutes[r] = struct{}{}
+		}
+	}
+
+	// Pick a winner per listener, then aggregate the listener ports each
+	// winning route owns.
+	winningPorts := make(map[*gatewayapi.TCPRoute][]gatewayapi.PortNumber)
+	for key, candidates := range attachments {
+		winner := pickWinningL4Route(candidates)
+		if winner == nil {
+			continue
+		}
+		winningPorts[winner] = append(winningPorts[winner], key.port)
+	}
+
+	for _, r := range valid {
+		ports, ok := winningPorts[r]
+		if !ok {
+			continue
+		}
+		ports = dedupPorts(ports)
+		if err := t.translateTCPRouteWithPorts(&result, r, ports); err != nil {
+			errs = append(errs, fmt.Errorf("TCPRoute %s/%s can't be routed: %w",
+				r.Namespace, r.Name, err))
+		}
+	}
+
+	// Every TCPRoute that successfully attached to at least one listener (even
+	// if it lost arbitration on all of them) is reported as successfully
+	// translated — the route is "attached" per spec; arbitration is a
+	// translation-layer detail.
+	for _, r := range valid {
+		if _, ok := attachedRoutes[r]; ok {
+			t.registerSuccessfullyTranslatedObject(r)
 		}
 	}
 
@@ -39,41 +90,56 @@ func (t *Translator) ingressRulesFromTCPRoutes() ingressRules {
 	}
 
 	for _, err := range errs {
-		t.logger.Error(err, "could not generate route from TCPRoute")
+		t.logger.Error(err, "Could not generate route from TCPRoute")
 	}
 
 	return result
 }
 
-func (t *Translator) ingressRulesFromTCPRoute(result *ingressRules, tcproute *gatewayapi.TCPRoute) error {
-	spec := tcproute.Spec
+// translateTCPRouteWithPorts emits kong.Route(s) + kong.Service(s) for every
+// rule on `route`, with Destinations covering the supplied listener ports.
+// Callers must pass only ports for listeners where `route` won arbitration.
+func (t *Translator) translateTCPRouteWithPorts(
+	result *ingressRules,
+	route *gatewayapi.TCPRoute,
+	gwPorts []gatewayapi.PortNumber,
+) error {
+	spec := route.Spec
 	if len(spec.Rules) == 0 {
 		return subtranslator.ErrRouteValidationNoRules
 	}
 
-	gwPorts := t.getGatewayListeningPorts(tcproute.Namespace, gatewayapi.TCPProtocolType, spec.ParentRefs)
-
-	// Each rule may represent a different set of backend services that will be accepting
-	// traffic, so we make separate routes and Kong services for every present rule.
 	for ruleNumber, rule := range spec.Rules {
-
-		// Determine the routes needed to route traffic to services for this rule.
-		routes, err := generateKongRoutesFromRouteRule(tcproute, gwPorts, ruleNumber, rule)
+		routes, err := generateKongRoutesFromRouteRule(route, gwPorts, ruleNumber, rule)
 		if err != nil {
 			return err
 		}
-
-		// create a service and attach the routes to it
-		service, err := generateKongServiceFromBackendRefWithRuleNumber(t.logger, t.storer, result, tcproute, ruleNumber, "tcp", rule.BackendRefs...)
+		service, err := generateKongServiceFromBackendRefWithRuleNumber(
+			t.logger, t.storer, result, route, ruleNumber, "tcp", rule.BackendRefs...)
 		if err != nil {
 			return err
 		}
 		service.Routes = append(service.Routes, routes...)
 
-		// cache the service to avoid duplicates in further loop iterations
 		result.ServiceNameToServices[*service.Name] = service
-		result.ServiceNameToParent[*service.Name] = tcproute
+		result.ServiceNameToParent[*service.Name] = route
 	}
+	return nil
+}
 
+// validateTCPRoute validates TCPRoute, and return a translation error if the spec is invalid.
+// Validation for TCPRoutes will happen at a higher layer, but in spite of that we run
+// validation at this level as well as a fallback so that if routes are posted which
+// are invalid somehow make it past validation (e.g. the webhook is not enabled) we can
+// at least try to provide a helpful message about the situation in the manager logs.
+func validateTCPRoute(tcproute *gatewayapi.TCPRoute) error {
+	if len(tcproute.Spec.Rules) == 0 {
+		return subtranslator.ErrRouteValidationNoRules
+	}
+	for _, rule := range tcproute.Spec.Rules {
+		if len(rule.BackendRefs) == 0 {
+			return subtranslator.ErrRotueValidationRuleNoBackendRef
+		}
+	}
 	return nil
 }

--- a/ingress-controller/internal/dataplane/translator/translate_tcproute_test.go
+++ b/ingress-controller/internal/dataplane/translator/translate_tcproute_test.go
@@ -401,9 +401,10 @@ func TestIngressRulesFromTCPRoutesUsingExpressionRoutes(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			fakeStore, err := store.NewFakeStore(store.FakeObjects{
-				Gateways:  tc.gateways,
-				TCPRoutes: tc.tcpRoutes,
-				Services:  tc.services,
+				GatewayClasses: []*gatewayapi.GatewayClass{defaultOwnedGatewayClass},
+				Gateways:       tc.gateways,
+				TCPRoutes:      tc.tcpRoutes,
+				Services:       tc.services,
 			})
 			require.NoError(t, err)
 			translator := mustNewTranslator(t, fakeStore)
@@ -775,9 +776,10 @@ func TestIngressRulesFromTCPRoutes(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			fakeStore, err := store.NewFakeStore(store.FakeObjects{
-				Gateways:  tc.gateways,
-				TCPRoutes: tc.tcpRoutes,
-				Services:  tc.services,
+				GatewayClasses: []*gatewayapi.GatewayClass{defaultOwnedGatewayClass},
+				Gateways:       tc.gateways,
+				TCPRoutes:      tc.tcpRoutes,
+				Services:       tc.services,
 			})
 			require.NoError(t, err)
 			translator := mustNewTranslator(t, fakeStore)

--- a/ingress-controller/internal/dataplane/translator/translate_tcproute_test.go
+++ b/ingress-controller/internal/dataplane/translator/translate_tcproute_test.go
@@ -3,6 +3,7 @@ package translator
 import (
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/go-logr/zapr"
 	"github.com/kong/go-kong/kong"
@@ -15,10 +16,32 @@ import (
 
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/dataplane/failures"
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/dataplane/kongstate"
+	"github.com/kong/kong-operator/v2/ingress-controller/internal/dataplane/translator/subtranslator"
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/gatewayapi"
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/store"
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/util/builder"
 )
+
+// tcpProgrammedStatus builds Gateway.Status.Listeners entries that mark each
+// named listener as Programmed and accepting TCPRoute - the status a real
+// GatewayReconciler would have written by the time the Gateway is pushed
+// into the translator's cache, and what listener-attachment arbitration now
+// requires.
+func tcpProgrammedStatus(listenerNames ...string) gatewayapi.GatewayStatus {
+	kinds := builder.NewRouteGroupKind().TCPRoute().IntoSlice()
+	statuses := make([]gatewayapi.ListenerStatus, 0, len(listenerNames))
+	for _, name := range listenerNames {
+		statuses = append(statuses, gatewayapi.ListenerStatus{
+			Name:           gatewayapi.SectionName(name),
+			SupportedKinds: kinds,
+			Conditions: []metav1.Condition{{
+				Type:   string(gatewayapi.ListenerConditionProgrammed),
+				Status: metav1.ConditionTrue,
+			}},
+		})
+	}
+	return gatewayapi.GatewayStatus{Listeners: statuses}
+}
 
 func TestIngressRulesFromTCPRoutesUsingExpressionRoutes(t *testing.T) {
 	tcpRouteTypeMeta := metav1.TypeMeta{Kind: "TCPRoute", APIVersion: gatewayv1.GroupVersion.String()}
@@ -46,6 +69,7 @@ func TestIngressRulesFromTCPRoutesUsingExpressionRoutes(t *testing.T) {
 							builder.NewListener("udp80").WithPort(80).UDP().Build(),
 						},
 					},
+					Status: tcpProgrammedStatus("tcp80"),
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -125,6 +149,7 @@ func TestIngressRulesFromTCPRoutesUsingExpressionRoutes(t *testing.T) {
 							builder.NewListener("tcp443").WithPort(443).TCP().Build(),
 						},
 					},
+					Status: tcpProgrammedStatus("tcp80", "tcp443"),
 				},
 				{
 					ObjectMeta: metav1.ObjectMeta{
@@ -233,6 +258,7 @@ func TestIngressRulesFromTCPRoutesUsingExpressionRoutes(t *testing.T) {
 							},
 						},
 					},
+					Status: tcpProgrammedStatus("tcp80", "tcp443", "tcp8080", "tcp8443"),
 				},
 			},
 			tcpRoutes: []*gatewayapi.TCPRoute{
@@ -407,6 +433,382 @@ func TestIngressRulesFromTCPRoutesUsingExpressionRoutes(t *testing.T) {
 					require.Truef(t, ok, "should find route %s", *routeName)
 					require.Equalf(t, expectedRoute.Expression, r.Expression, "route %s should have expected expression", *routeName)
 					require.Equal(t, expectedRoute.Protocols, r.Protocols)
+				}
+			}
+			// check translation failures
+			translationFailures := failureCollector.PopResourceFailures()
+			require.Len(t, translationFailures, len(tc.expectedFailures))
+			for _, expectedTranslationFailure := range tc.expectedFailures {
+				expectedFailureMessage := expectedTranslationFailure.Message()
+				require.True(t, lo.ContainsBy(translationFailures, func(failure failures.ResourceFailure) bool {
+					return strings.Contains(failure.Message(), expectedFailureMessage)
+				}))
+			}
+		})
+	}
+}
+
+func TestIngressRulesFromTCPRoutes(t *testing.T) {
+	tcpRouteTypeMeta := metav1.TypeMeta{Kind: "TCPRoute", APIVersion: gatewayv1.GroupVersion.String()}
+
+	testCases := []struct {
+		name                 string
+		gateways             []*gatewayapi.Gateway
+		tcpRoutes            []*gatewayapi.TCPRoute
+		services             []*corev1.Service
+		expectedKongServices []kongstate.Service
+		expectedKongRoutes   map[string][]kongstate.Route
+		expectedFailures     []failures.ResourceFailure
+	}{
+		{
+			name: "single TCPRoute with single rule, single backendref and Gateway in the same namespace",
+			gateways: []*gatewayapi.Gateway{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gateway-1",
+						Namespace: "default",
+					},
+					Spec: gatewayapi.GatewaySpec{
+						Listeners: []gatewayapi.Listener{
+							builder.NewListener("tcp80").WithPort(80).TCP().Build(),
+							builder.NewListener("udp80").WithPort(80).UDP().Build(),
+						},
+					},
+					Status: tcpProgrammedStatus("tcp80"),
+				},
+			},
+			tcpRoutes: []*gatewayapi.TCPRoute{
+				{
+					TypeMeta: tcpRouteTypeMeta,
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "single-rule",
+						Namespace: "default",
+					},
+					Spec: gatewayapi.TCPRouteSpec{
+						CommonRouteSpec: gatewayapi.CommonRouteSpec{
+							ParentRefs: []gatewayapi.ParentReference{
+								{
+									Name: "gateway-1",
+								},
+							},
+						},
+						Rules: []gatewayapi.TCPRouteRule{
+							{
+								BackendRefs: []gatewayapi.BackendRef{
+									builder.NewBackendRef("service1").WithPort(8080).Build(),
+								},
+							},
+						},
+					},
+				},
+			},
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "service1",
+					},
+				},
+			},
+			expectedKongServices: []kongstate.Service{
+				{
+					Service: kong.Service{
+						Name:     new("tcproute.default.single-rule.0"),
+						Protocol: new("tcp"),
+					},
+					Backends: []kongstate.ServiceBackend{
+						builder.NewKongstateServiceBackend("service1").
+							WithNamespace("default").
+							WithPortNumber(8080).
+							MustBuild(),
+					},
+				},
+			},
+			expectedKongRoutes: map[string][]kongstate.Route{
+				"tcproute.default.single-rule.0": {
+					{
+						Route: kong.Route{
+							Name: new("tcproute.default.single-rule.0.0"),
+							Destinations: []*kong.CIDRPort{
+								{Port: new(80)},
+							},
+							Protocols: kong.StringSlice("tcp"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "two TCPRoutes on the same listener — only the older one wins",
+			gateways: []*gatewayapi.Gateway{
+				{
+					ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "tcp-gw"},
+					Spec: gatewayapi.GatewaySpec{
+						Listeners: []gatewayapi.Listener{{
+							Name:     "tcp",
+							Protocol: gatewayapi.TCPProtocolType,
+							Port:     9999,
+						}},
+					},
+					Status: tcpProgrammedStatus("tcp"),
+				},
+			},
+			tcpRoutes: []*gatewayapi.TCPRoute{
+				{
+					TypeMeta: tcpRouteTypeMeta,
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:         "default",
+						Name:              "older",
+						CreationTimestamp: metav1.NewTime(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)),
+					},
+					Spec: gatewayapi.TCPRouteSpec{
+						CommonRouteSpec: gatewayapi.CommonRouteSpec{
+							ParentRefs: []gatewayv1.ParentReference{{
+								Name: gatewayv1.ObjectName("tcp-gw"),
+							}},
+						},
+						Rules: []gatewayapi.TCPRouteRule{{
+							BackendRefs: []gatewayv1.BackendRef{{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Name: "svc-older",
+									Kind: new(gatewayv1.Kind("Service")),
+									Port: new(gatewayv1.PortNumber(8080)),
+								},
+							}},
+						}},
+					},
+				},
+				{
+					TypeMeta: tcpRouteTypeMeta,
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace:         "default",
+						Name:              "newer",
+						CreationTimestamp: metav1.NewTime(time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)),
+					},
+					Spec: gatewayapi.TCPRouteSpec{
+						CommonRouteSpec: gatewayapi.CommonRouteSpec{
+							ParentRefs: []gatewayv1.ParentReference{{
+								Name: gatewayv1.ObjectName("tcp-gw"),
+							}},
+						},
+						Rules: []gatewayapi.TCPRouteRule{{
+							BackendRefs: []gatewayv1.BackendRef{{
+								BackendObjectReference: gatewayv1.BackendObjectReference{
+									Name: "svc-newer",
+									Kind: new(gatewayv1.Kind("Service")),
+									Port: new(gatewayv1.PortNumber(9090)),
+								},
+							}},
+						}},
+					},
+				},
+			},
+			services: []*corev1.Service{
+				{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "svc-older"}},
+				{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "svc-newer"}},
+			},
+			expectedKongServices: []kongstate.Service{
+				{
+					Service: kong.Service{
+						Name:     new("tcproute.default.older.0"),
+						Protocol: new("tcp"),
+					},
+					Backends: []kongstate.ServiceBackend{
+						builder.NewKongstateServiceBackend("svc-older").
+							WithNamespace("default").
+							WithPortNumber(8080).
+							MustBuild(),
+					},
+				},
+			},
+			expectedKongRoutes: map[string][]kongstate.Route{
+				"tcproute.default.older.0": {
+					{
+						Route: kong.Route{
+							Name:         new("tcproute.default.older.0.0"),
+							Destinations: []*kong.CIDRPort{{Port: new(9999)}},
+							Protocols:    kong.StringSlice("tcp"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "multiple TCPRoutes with translation errors",
+			gateways: []*gatewayapi.Gateway{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "gateway-1",
+						Namespace: "default",
+					},
+					Spec: gatewayapi.GatewaySpec{
+						Listeners: []gatewayapi.Listener{
+							builder.NewListener("tcp80").WithPort(80).TCP().Build(),
+							builder.NewListener("tcp8080").WithPort(8080).TCP().Build(),
+						},
+					},
+					Status: tcpProgrammedStatus("tcp80", "tcp8080"),
+				},
+			},
+			tcpRoutes: []*gatewayapi.TCPRoute{
+				{
+					TypeMeta:   tcpRouteTypeMeta,
+					ObjectMeta: metav1.ObjectMeta{Name: "single-rule", Namespace: "default"},
+					Spec: gatewayapi.TCPRouteSpec{
+						CommonRouteSpec: gatewayapi.CommonRouteSpec{
+							ParentRefs: []gatewayapi.ParentReference{
+								{
+									Name:        "gateway-1",
+									SectionName: new(gatewayapi.SectionName("tcp80")),
+								},
+							},
+						},
+						Rules: []gatewayapi.TCPRouteRule{
+							{
+								BackendRefs: []gatewayapi.BackendRef{
+									builder.NewBackendRef("service1").WithPort(80).Build(),
+								},
+							},
+						},
+					},
+				},
+				{
+					TypeMeta:   tcpRouteTypeMeta,
+					ObjectMeta: metav1.ObjectMeta{Name: "single-rule-2", Namespace: "default"},
+					Spec: gatewayapi.TCPRouteSpec{
+						CommonRouteSpec: gatewayapi.CommonRouteSpec{
+							ParentRefs: []gatewayapi.ParentReference{
+								{
+									Name:        "gateway-1",
+									SectionName: new(gatewayapi.SectionName("tcp8080")),
+								},
+							},
+						},
+						Rules: []gatewayapi.TCPRouteRule{
+							{
+								BackendRefs: []gatewayapi.BackendRef{
+									builder.NewBackendRef("service2").WithPort(8080).Build(),
+								},
+							},
+						},
+					},
+				},
+				{
+					TypeMeta:   tcpRouteTypeMeta,
+					ObjectMeta: metav1.ObjectMeta{Name: "no-rule", Namespace: "default"},
+					Spec:       gatewayapi.TCPRouteSpec{},
+				},
+			},
+			services: []*corev1.Service{
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "service1",
+					},
+				},
+				{
+					ObjectMeta: metav1.ObjectMeta{
+						Namespace: "default",
+						Name:      "service2",
+					},
+				},
+			},
+			expectedKongServices: []kongstate.Service{
+				{
+					Service: kong.Service{
+						Name:     new("tcproute.default.single-rule.0"),
+						Protocol: new("tcp"),
+					},
+					Backends: []kongstate.ServiceBackend{
+						builder.NewKongstateServiceBackend("service1").
+							WithNamespace("default").
+							WithPortNumber(80).
+							MustBuild(),
+					},
+				},
+				{
+					Service: kong.Service{
+						Name:     new("tcproute.default.single-rule-2.0"),
+						Protocol: new("tcp"),
+					},
+					Backends: []kongstate.ServiceBackend{
+						builder.NewKongstateServiceBackend("service2").WithPortNumber(8080).MustBuild(),
+					},
+				},
+			},
+			expectedKongRoutes: map[string][]kongstate.Route{
+				"tcproute.default.single-rule.0": {
+					{
+						Route: kong.Route{
+							Name: new("tcproute.default.single-rule.0.0"),
+							Destinations: []*kong.CIDRPort{
+								{Port: new(80)},
+							},
+							Protocols: kong.StringSlice("tcp"),
+						},
+					},
+				},
+				"tcproute.default.single-rule-2.0": {
+					{
+						Route: kong.Route{
+							Name: new("tcproute.default.single-rule-2.0.0"),
+							Destinations: []*kong.CIDRPort{
+								{Port: new(8080)},
+							},
+							Protocols: kong.StringSlice("tcp"),
+						},
+					},
+				},
+			},
+			expectedFailures: []failures.ResourceFailure{
+				newResourceFailure(
+					t, subtranslator.ErrRouteValidationNoRules.Error(),
+					&gatewayapi.TCPRoute{
+						TypeMeta:   tcpRouteTypeMeta,
+						ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "no-rule"},
+					},
+				),
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeStore, err := store.NewFakeStore(store.FakeObjects{
+				Gateways:  tc.gateways,
+				TCPRoutes: tc.tcpRoutes,
+				Services:  tc.services,
+			})
+			require.NoError(t, err)
+			translator := mustNewTranslator(t, fakeStore)
+
+			failureCollector := failures.NewResourceFailuresCollector(zapr.NewLogger(zap.NewNop()))
+			translator.failuresCollector = failureCollector
+
+			result := translator.ingressRulesFromTCPRoutes()
+			// check services
+			require.Len(t, result.ServiceNameToServices, len(tc.expectedKongServices),
+				"should have expected number of services")
+			for _, expectedKongService := range tc.expectedKongServices {
+				kongService, ok := result.ServiceNameToServices[*expectedKongService.Name]
+				require.Truef(t, ok, "should find service %s", *expectedKongService.Name)
+				require.Equalf(t, expectedKongService.Backends, kongService.Backends,
+					"service %s should have expected backends", *expectedKongService.Name)
+				require.Equalf(t, "tcp", *kongService.Protocol, "service %s should use TCP protocol", *expectedKongService.Name)
+				// check routes
+				expectedKongRoutes := tc.expectedKongRoutes[*kongService.Name]
+				require.Lenf(t, kongService.Routes, len(expectedKongRoutes),
+					"service %s should have expected number of routes", *expectedKongService.Name)
+
+				kongRouteNameToRoute := lo.SliceToMap(kongService.Routes, func(r kongstate.Route) (string, kongstate.Route) {
+					return *r.Name, r
+				})
+				for _, expectedRoute := range expectedKongRoutes {
+					routeName := expectedRoute.Name
+					r, ok := kongRouteNameToRoute[*routeName]
+					require.Truef(t, ok, "should find route %s", *routeName)
+					require.Equalf(t, expectedRoute.Destinations, r.Destinations, "route %s should have expected destinations", *routeName)
+					require.Equalf(t, expectedRoute.Protocols, r.Protocols, "route %s should have expected protocols", *routeName)
 				}
 			}
 			// check translation failures

--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -3,7 +3,6 @@ package conformance
 import (
 	"context"
 	"fmt"
-	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -147,7 +146,7 @@ func runConformance(
 	}
 	opts.Mode = mode
 	opts.ConformanceProfiles = conformanceProfiles(gwType)
-	opts.SupportedFeatures = conformanceSupportedFeatures(gwType, supportedFeatures)
+	opts.SupportedFeatures = supportedFeatures
 	opts.SkipTests = skipped
 	opts.CleanupBaseResources = cleanupResources
 	opts.GatewayClassName = gwc.Name
@@ -173,27 +172,14 @@ func runConformance(
 	conformance.RunConformanceWithOptions(t, opts)
 }
 
-func conformanceProfiles(gwType gatewayType) []suite.ConformanceProfileName {
-	profiles := []suite.ConformanceProfileName{
+func conformanceProfiles(_ gatewayType) []suite.ConformanceProfileName {
+	return []suite.ConformanceProfileName{
 		suite.GatewayHTTPConformanceProfileName,
 		suite.GatewayGRPCConformanceProfileName,
 		suite.GatewayTLSConformanceProfileName,
+		suite.GatewayTCPConformanceProfileName,
 		suite.GatewayUDPConformanceProfileName,
 	}
-	if gwType == hybridGateway {
-		profiles = append(profiles, suite.GatewayTCPConformanceProfileName)
-	}
-	return profiles
-}
-
-func conformanceSupportedFeatures(gwType gatewayType, supportedFeatures []features.FeatureName) []features.FeatureName {
-	if gwType == hybridGateway {
-		return supportedFeatures
-	}
-
-	return slices.DeleteFunc(slices.Clone(supportedFeatures), func(feature features.FeatureName) bool {
-		return feature == features.SupportTCPRoute
-	})
 }
 
 // conformanceCleanupTimeout bounds how long the post-test Hook waits for
@@ -201,20 +187,20 @@ func conformanceSupportedFeatures(gwType gatewayType, supportedFeatures []featur
 // proceed anyway (so a stuck finalizer can't hang the whole suite).
 const conformanceCleanupTimeout = 90 * time.Second
 
-// waitForConformanceResourcesCleanup blocks until no HTTPRoute, TLSRoute or
-// ReferenceGrant in any conformance namespace still has a deletion timestamp,
+// waitForConformanceResourcesCleanup blocks until no HTTPRoute, TLSRoute,
+// TCPRoute or ReferenceGrant in any conformance namespace still has a deletion
+// timestamp,
 // i.e. the previous test's resources have been fully finalized and removed.
 // These are per-test resources (the base manifests only contribute
 // Gateways/Services), and several tests reuse the same names (for example the
 // "reference-grant" HTTPRoute, the "gateway-conformance-infra-test" TLSRoute,
-// and the "reference-grant-wrong-*" ReferenceGrants shared by the
-// *InvalidReferenceGrant tests), so letting them fully drain prevents the next
-// test from racing a still-finalizing object. HTTPRoutes and TLSRoutes carry
-// the operator's (hybrid/Konnect) finalizers and are the slow case;
-// ReferenceGrants are not finalized and usually clear instantly, but are
-// checked too for robustness. HTTPRoute and TLSRoute are the only route kinds
-// the operator supports. In the common case nothing is terminating and this
-// returns right away. On timeout it logs and returns without failing.
+// the TCPRoute conformance resources, and the "reference-grant-wrong-*"
+// ReferenceGrants shared by the *InvalidReferenceGrant tests), so letting them
+// fully drain prevents the next test from racing a still-finalizing object.
+// Routes can carry the operator's finalizers and are the slow case;
+// ReferenceGrants are not finalized and usually clear instantly, but are checked
+// too for robustness. In the common case nothing is terminating and this returns
+// right away. On timeout it logs and returns without failing.
 func waitForConformanceResourcesCleanup(ctx context.Context, cl client.Client, logf func(string, ...any)) {
 	waitCtx, cancel := context.WithTimeout(ctx, conformanceCleanupTimeout)
 	defer cancel()
@@ -246,6 +232,17 @@ func waitForConformanceResourcesCleanup(ctx context.Context, cl client.Client, l
 			}
 		}
 
+		var tcpRoutes gatewayv1.TCPRouteList
+		if err := cl.List(ctx, &tcpRoutes); err != nil {
+			return false, nil //nolint:nilerr
+		}
+		for i := range tcpRoutes.Items {
+			if r := &tcpRoutes.Items[i]; isConformanceNS(r.Namespace) && r.DeletionTimestamp != nil {
+				logf("waiting for TCPRoute %s/%s to finish terminating before next test", r.Namespace, r.Name)
+				return false, nil
+			}
+		}
+
 		var grants gatewayv1beta1.ReferenceGrantList
 		if err := cl.List(ctx, &grants); err != nil {
 			return false, nil //nolint:nilerr
@@ -259,7 +256,7 @@ func waitForConformanceResourcesCleanup(ctx context.Context, cl client.Client, l
 		return true, nil
 	})
 	if err != nil {
-		logf("timed out after %s waiting for conformance HTTPRoutes/ReferenceGrants to be cleaned up; proceeding anyway", conformanceCleanupTimeout)
+		logf("timed out after %s waiting for conformance routes/ReferenceGrants to be cleaned up; proceeding anyway", conformanceCleanupTimeout)
 	}
 }
 

--- a/test/conformance/skipped_tests_test.go
+++ b/test/conformance/skipped_tests_test.go
@@ -17,6 +17,13 @@ var skippedTestsShared = []string{
 	tests.GRPCRouteListenerHostnameMatching.ShortName,
 }
 
+var skippedTestsForStandard = []string{
+	// TODO: https://github.com/kubernetes-sigs/gateway-api/issues/5121
+	// The readiness probe can establish a TCP connection before the TCPRoute
+	// configuration reaches the data plane, causing the test to fail with EOF.
+	tests.TCPRouteWeightedRouting.ShortName,
+}
+
 var skippedTestsForExpressionsRouter = []string{}
 
 var skippedTestsForStandardTraditionalCompatibleRouter = []string{
@@ -50,6 +57,9 @@ var skippedTestsForHybrid = []string{
 // skippedTestsForConfig returns the list of skipped tests for the given router flavor and gateway type.
 func skippedTestsForConfig(routerFlavor consts.RouterFlavor, gwType gatewayType) []string {
 	skipped := append([]string{}, skippedTestsShared...)
+	if gwType == standardGateway {
+		skipped = append(skipped, skippedTestsForStandard...)
+	}
 
 	switch routerFlavor {
 	case consts.RouterFlavorTraditionalCompatible:

--- a/test/conformance/skipped_tests_test.go
+++ b/test/conformance/skipped_tests_test.go
@@ -17,6 +17,13 @@ var skippedTestsShared = []string{
 	tests.GRPCRouteListenerHostnameMatching.ShortName,
 }
 
+var skippedTestsForStandard = []string{
+	// TODO: https://github.com/Kong/kong-operator/issues/5079
+	// TCPRouteMultipleRoutesAttachment fails because TCPRouteMustHaveCondition
+	// times out after 60s, unlike the loosened 180s HTTPRoute timeout.
+	tests.TCPRouteMultipleRoutesAttachment.ShortName,
+}
+
 var skippedTestsForExpressionsRouter = []string{}
 
 var skippedTestsForStandardTraditionalCompatibleRouter = []string{
@@ -50,6 +57,9 @@ var skippedTestsForHybrid = []string{
 // skippedTestsForConfig returns the list of skipped tests for the given router flavor and gateway type.
 func skippedTestsForConfig(routerFlavor consts.RouterFlavor, gwType gatewayType) []string {
 	skipped := append([]string{}, skippedTestsShared...)
+	if gwType == standardGateway {
+		skipped = append(skipped, skippedTestsForStandard...)
+	}
 
 	switch routerFlavor {
 	case consts.RouterFlavorTraditionalCompatible:

--- a/test/conformance/skipped_tests_test.go
+++ b/test/conformance/skipped_tests_test.go
@@ -17,13 +17,6 @@ var skippedTestsShared = []string{
 	tests.GRPCRouteListenerHostnameMatching.ShortName,
 }
 
-var skippedTestsForStandard = []string{
-	// TODO: https://github.com/Kong/kong-operator/issues/5079
-	// TCPRouteMultipleRoutesAttachment fails because TCPRouteMustHaveCondition
-	// times out after 60s, unlike the loosened 180s HTTPRoute timeout.
-	tests.TCPRouteMultipleRoutesAttachment.ShortName,
-}
-
 var skippedTestsForExpressionsRouter = []string{}
 
 var skippedTestsForStandardTraditionalCompatibleRouter = []string{
@@ -57,9 +50,6 @@ var skippedTestsForHybrid = []string{
 // skippedTestsForConfig returns the list of skipped tests for the given router flavor and gateway type.
 func skippedTestsForConfig(routerFlavor consts.RouterFlavor, gwType gatewayType) []string {
 	skipped := append([]string{}, skippedTestsShared...)
-	if gwType == standardGateway {
-		skipped = append(skipped, skippedTestsForStandard...)
-	}
 
 	switch routerFlavor {
 	case consts.RouterFlavorTraditionalCompatible:


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**

Fixes https://github.com/Kong/kong-operator/issues/5074

**Special notes for your reviewer**:

~I have skipped the `TCPRouteMultipleRoutesAttachment` conformance test and use https://github.com/Kong/kong-operator/issues/5079 for tracking.~

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
