### PR TITLE
 feat: add deployment labels and annotations to `KegDataPlane`'s `DeploymentOptions` and simplify code

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -84,7 +84,8 @@
 - Support `spec.deployment.labels` and `spec.deployment.annotations` for metadata
   of underlying dataplane `Deployment` for:
   - `DataPlane` [#5037](https://github.com/Kong/kong-operator/pull/5037)
-  - `AIGatewayDataPlane` [5081](https://github.com/Kong/kong-operator/pull/5081)
+  - `AIGatewayDataPlane` [#5081](https://github.com/Kong/kong-operator/pull/5081)
+  - `KegDataPlane` [#5088](https://github.com/Kong/kong-operator/pull/5088)
   with safe managed-key removal so operator-managed keys are removed without
   clobbering external labels or annotations. This change causes a rolling
   restart of the underlying `Pod`s when updating operator to this version,

--- a/api/eventgateway/v1alpha1/kegdataplane_types.go
+++ b/api/eventgateway/v1alpha1/kegdataplane_types.go
@@ -108,6 +108,20 @@ type DeploymentOptions struct {
 	// +optional
 	Scaling *Scaling `json:"scaling,omitempty"`
 
+	// Annotations are custom annotations that are propagated to the keg
+	// Deployment metadata by the operator.
+	//
+	// +optional
+	// +kubebuilder:validation:MaxProperties=64
+	Annotations map[string]string `json:"annotations,omitempty"`
+
+	// Labels are custom labels that are propagated to the keg Deployment
+	// metadata by the operator.
+	//
+	// +optional
+	// +kubebuilder:validation:MaxProperties=64
+	Labels map[string]string `json:"labels,omitempty"`
+
 	// PodTemplateSpec defines PodTemplateSpec for Deployment's pods.
 	// It's being applied on top of the generated Deployments using
 	// [StrategicMergePatch](https://pkg.go.dev/k8s.io/apimachinery/pkg/util/strategicpatch#StrategicMergePatch).

--- a/api/eventgateway/v1alpha1/zz_generated.deepcopy.go
+++ b/api/eventgateway/v1alpha1/zz_generated.deepcopy.go
@@ -61,6 +61,20 @@ func (in *DeploymentOptions) DeepCopyInto(out *DeploymentOptions) {
 		*out = new(Scaling)
 		(*in).DeepCopyInto(*out)
 	}
+	if in.Annotations != nil {
+		in, out := &in.Annotations, &out.Annotations
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
+	if in.Labels != nil {
+		in, out := &in.Labels, &out.Labels
+		*out = make(map[string]string, len(*in))
+		for key, val := range *in {
+			(*out)[key] = val
+		}
+	}
 	if in.PodTemplateSpec != nil {
 		in, out := &in.PodTemplateSpec, &out.PodTemplateSpec
 		*out = new(v1.PodTemplateSpec)

--- a/charts/kong-operator/charts/ko-crds/templates/ko-crds-eventgateway.konghq.com_kegdataplanes.yaml
+++ b/charts/kong-operator/charts/ko-crds/templates/ko-crds-eventgateway.konghq.com_kegdataplanes.yaml
@@ -215,6 +215,22 @@ spec:
                   Deployment configures the keg Deployment: image, replicas, resources,
                   extra env vars, volume mounts, etc.
                 properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Annotations are custom annotations that are propagated to the keg
+                      Deployment metadata by the operator.
+                    maxProperties: 64
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Labels are custom labels that are propagated to the keg Deployment
+                      metadata by the operator.
+                    maxProperties: 64
+                    type: object
                   podTemplateSpec:
                     description: |-
                       PodTemplateSpec defines PodTemplateSpec for Deployment's pods.

--- a/charts/kong-operator/ci/__snapshots__/affinity-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/affinity-values.snap
@@ -22886,6 +22886,22 @@ spec:
                   Deployment configures the keg Deployment: image, replicas, resources,
                   extra env vars, volume mounts, etc.
                 properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Annotations are custom annotations that are propagated to the keg
+                      Deployment metadata by the operator.
+                    maxProperties: 64
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Labels are custom labels that are propagated to the keg Deployment
+                      metadata by the operator.
+                    maxProperties: 64
+                    type: object
                   podTemplateSpec:
                     description: |-
                       PodTemplateSpec defines PodTemplateSpec for Deployment's pods.

--- a/charts/kong-operator/ci/__snapshots__/cert-manager-enabled-everywhere.snap
+++ b/charts/kong-operator/ci/__snapshots__/cert-manager-enabled-everywhere.snap
@@ -22821,6 +22821,22 @@ spec:
                   Deployment configures the keg Deployment: image, replicas, resources,
                   extra env vars, volume mounts, etc.
                 properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Annotations are custom annotations that are propagated to the keg
+                      Deployment metadata by the operator.
+                    maxProperties: 64
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Labels are custom labels that are propagated to the keg Deployment
+                      metadata by the operator.
+                    maxProperties: 64
+                    type: object
                   podTemplateSpec:
                     description: |-
                       PodTemplateSpec defines PodTemplateSpec for Deployment's pods.

--- a/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
+++ b/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
@@ -22886,6 +22886,22 @@ spec:
                   Deployment configures the keg Deployment: image, replicas, resources,
                   extra env vars, volume mounts, etc.
                 properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Annotations are custom annotations that are propagated to the keg
+                      Deployment metadata by the operator.
+                    maxProperties: 64
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Labels are custom labels that are propagated to the keg Deployment
+                      metadata by the operator.
+                    maxProperties: 64
+                    type: object
                   podTemplateSpec:
                     description: |-
                       PodTemplateSpec defines PodTemplateSpec for Deployment's pods.

--- a/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
@@ -22886,6 +22886,22 @@ spec:
                   Deployment configures the keg Deployment: image, replicas, resources,
                   extra env vars, volume mounts, etc.
                 properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Annotations are custom annotations that are propagated to the keg
+                      Deployment metadata by the operator.
+                    maxProperties: 64
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Labels are custom labels that are propagated to the keg Deployment
+                      metadata by the operator.
+                    maxProperties: 64
+                    type: object
                   podTemplateSpec:
                     description: |-
                       PodTemplateSpec defines PodTemplateSpec for Deployment's pods.

--- a/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
@@ -22886,6 +22886,22 @@ spec:
                   Deployment configures the keg Deployment: image, replicas, resources,
                   extra env vars, volume mounts, etc.
                 properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Annotations are custom annotations that are propagated to the keg
+                      Deployment metadata by the operator.
+                    maxProperties: 64
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Labels are custom labels that are propagated to the keg Deployment
+                      metadata by the operator.
+                    maxProperties: 64
+                    type: object
                   podTemplateSpec:
                     description: |-
                       PodTemplateSpec defines PodTemplateSpec for Deployment's pods.

--- a/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
@@ -22886,6 +22886,22 @@ spec:
                   Deployment configures the keg Deployment: image, replicas, resources,
                   extra env vars, volume mounts, etc.
                 properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Annotations are custom annotations that are propagated to the keg
+                      Deployment metadata by the operator.
+                    maxProperties: 64
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Labels are custom labels that are propagated to the keg Deployment
+                      metadata by the operator.
+                    maxProperties: 64
+                    type: object
                   podTemplateSpec:
                     description: |-
                       PodTemplateSpec defines PodTemplateSpec for Deployment's pods.

--- a/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
@@ -22887,6 +22887,22 @@ spec:
                   Deployment configures the keg Deployment: image, replicas, resources,
                   extra env vars, volume mounts, etc.
                 properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Annotations are custom annotations that are propagated to the keg
+                      Deployment metadata by the operator.
+                    maxProperties: 64
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Labels are custom labels that are propagated to the keg Deployment
+                      metadata by the operator.
+                    maxProperties: 64
+                    type: object
                   podTemplateSpec:
                     description: |-
                       PodTemplateSpec defines PodTemplateSpec for Deployment's pods.

--- a/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
@@ -22886,6 +22886,22 @@ spec:
                   Deployment configures the keg Deployment: image, replicas, resources,
                   extra env vars, volume mounts, etc.
                 properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Annotations are custom annotations that are propagated to the keg
+                      Deployment metadata by the operator.
+                    maxProperties: 64
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Labels are custom labels that are propagated to the keg Deployment
+                      metadata by the operator.
+                    maxProperties: 64
+                    type: object
                   podTemplateSpec:
                     description: |-
                       PodTemplateSpec defines PodTemplateSpec for Deployment's pods.

--- a/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
@@ -22886,6 +22886,22 @@ spec:
                   Deployment configures the keg Deployment: image, replicas, resources,
                   extra env vars, volume mounts, etc.
                 properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Annotations are custom annotations that are propagated to the keg
+                      Deployment metadata by the operator.
+                    maxProperties: 64
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Labels are custom labels that are propagated to the keg Deployment
+                      metadata by the operator.
+                    maxProperties: 64
+                    type: object
                   podTemplateSpec:
                     description: |-
                       PodTemplateSpec defines PodTemplateSpec for Deployment's pods.

--- a/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
@@ -22886,6 +22886,22 @@ spec:
                   Deployment configures the keg Deployment: image, replicas, resources,
                   extra env vars, volume mounts, etc.
                 properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Annotations are custom annotations that are propagated to the keg
+                      Deployment metadata by the operator.
+                    maxProperties: 64
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Labels are custom labels that are propagated to the keg Deployment
+                      metadata by the operator.
+                    maxProperties: 64
+                    type: object
                   podTemplateSpec:
                     description: |-
                       PodTemplateSpec defines PodTemplateSpec for Deployment's pods.

--- a/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
@@ -22886,6 +22886,22 @@ spec:
                   Deployment configures the keg Deployment: image, replicas, resources,
                   extra env vars, volume mounts, etc.
                 properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Annotations are custom annotations that are propagated to the keg
+                      Deployment metadata by the operator.
+                    maxProperties: 64
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Labels are custom labels that are propagated to the keg Deployment
+                      metadata by the operator.
+                    maxProperties: 64
+                    type: object
                   podTemplateSpec:
                     description: |-
                       PodTemplateSpec defines PodTemplateSpec for Deployment's pods.

--- a/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
@@ -22886,6 +22886,22 @@ spec:
                   Deployment configures the keg Deployment: image, replicas, resources,
                   extra env vars, volume mounts, etc.
                 properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Annotations are custom annotations that are propagated to the keg
+                      Deployment metadata by the operator.
+                    maxProperties: 64
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Labels are custom labels that are propagated to the keg Deployment
+                      metadata by the operator.
+                    maxProperties: 64
+                    type: object
                   podTemplateSpec:
                     description: |-
                       PodTemplateSpec defines PodTemplateSpec for Deployment's pods.

--- a/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
+++ b/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
@@ -22886,6 +22886,22 @@ spec:
                   Deployment configures the keg Deployment: image, replicas, resources,
                   extra env vars, volume mounts, etc.
                 properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Annotations are custom annotations that are propagated to the keg
+                      Deployment metadata by the operator.
+                    maxProperties: 64
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Labels are custom labels that are propagated to the keg Deployment
+                      metadata by the operator.
+                    maxProperties: 64
+                    type: object
                   podTemplateSpec:
                     description: |-
                       PodTemplateSpec defines PodTemplateSpec for Deployment's pods.

--- a/charts/kong-operator/ci/__snapshots__/webhook-cert-manager-fullname-override.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-cert-manager-fullname-override.snap
@@ -22836,6 +22836,22 @@ spec:
                   Deployment configures the keg Deployment: image, replicas, resources,
                   extra env vars, volume mounts, etc.
                 properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Annotations are custom annotations that are propagated to the keg
+                      Deployment metadata by the operator.
+                    maxProperties: 64
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Labels are custom labels that are propagated to the keg Deployment
+                      metadata by the operator.
+                    maxProperties: 64
+                    type: object
                   podTemplateSpec:
                     description: |-
                       PodTemplateSpec defines PodTemplateSpec for Deployment's pods.

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
@@ -22861,6 +22861,22 @@ spec:
                   Deployment configures the keg Deployment: image, replicas, resources,
                   extra env vars, volume mounts, etc.
                 properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Annotations are custom annotations that are propagated to the keg
+                      Deployment metadata by the operator.
+                    maxProperties: 64
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Labels are custom labels that are propagated to the keg Deployment
+                      metadata by the operator.
+                    maxProperties: 64
+                    type: object
                   podTemplateSpec:
                     description: |-
                       PodTemplateSpec defines PodTemplateSpec for Deployment's pods.

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
@@ -22836,6 +22836,22 @@ spec:
                   Deployment configures the keg Deployment: image, replicas, resources,
                   extra env vars, volume mounts, etc.
                 properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Annotations are custom annotations that are propagated to the keg
+                      Deployment metadata by the operator.
+                    maxProperties: 64
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Labels are custom labels that are propagated to the keg Deployment
+                      metadata by the operator.
+                    maxProperties: 64
+                    type: object
                   podTemplateSpec:
                     description: |-
                       PodTemplateSpec defines PodTemplateSpec for Deployment's pods.

--- a/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
@@ -22836,6 +22836,22 @@ spec:
                   Deployment configures the keg Deployment: image, replicas, resources,
                   extra env vars, volume mounts, etc.
                 properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Annotations are custom annotations that are propagated to the keg
+                      Deployment metadata by the operator.
+                    maxProperties: 64
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Labels are custom labels that are propagated to the keg Deployment
+                      metadata by the operator.
+                    maxProperties: 64
+                    type: object
                   podTemplateSpec:
                     description: |-
                       PodTemplateSpec defines PodTemplateSpec for Deployment's pods.

--- a/config/crd/kong-operator/eventgateway.konghq.com_kegdataplanes.yaml
+++ b/config/crd/kong-operator/eventgateway.konghq.com_kegdataplanes.yaml
@@ -211,6 +211,22 @@ spec:
                   Deployment configures the keg Deployment: image, replicas, resources,
                   extra env vars, volume mounts, etc.
                 properties:
+                  annotations:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Annotations are custom annotations that are propagated to the keg
+                      Deployment metadata by the operator.
+                    maxProperties: 64
+                    type: object
+                  labels:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Labels are custom labels that are propagated to the keg Deployment
+                      metadata by the operator.
+                    maxProperties: 64
+                    type: object
                   podTemplateSpec:
                     description: |-
                       PodTemplateSpec defines PodTemplateSpec for Deployment's pods.

--- a/controller/aigateway/dataplane/owned_deployment.go
+++ b/controller/aigateway/dataplane/owned_deployment.go
@@ -259,8 +259,7 @@ func addAnnotationsForAIGatewayDataPlaneDeployment(logger logr.Logger, deploymen
 	if aigwdp.Spec.Deployment == nil || len(aigwdp.Spec.Deployment.Annotations) == 0 {
 		return
 	}
-	obj := &metav1.ObjectMeta{Namespace: aigwdp.Namespace, Name: aigwdp.Name, Annotations: aigwdp.Spec.Deployment.Annotations}
-	specAnnotations := reservedkeys.Filter(logger, reservedkeys.MetadataTypeAnnotation, obj, aiGatewayDataPlaneDeploymentReservedKeys)
+	specAnnotations := reservedkeys.Filter(logger, reservedkeys.MetadataTypeAnnotation, aigwdp.Spec.Deployment.Annotations, aiGatewayDataPlaneDeploymentReservedKeys)
 	deployment.Annotations = reservedkeys.Merge(deployment.Annotations, specAnnotations)
 }
 
@@ -272,8 +271,7 @@ func addLabelsForAIGatewayDataPlaneDeployment(logger logr.Logger, deployment *ap
 	if aigwdp.Spec.Deployment == nil || len(aigwdp.Spec.Deployment.Labels) == 0 {
 		return
 	}
-	obj := &metav1.ObjectMeta{Namespace: aigwdp.Namespace, Name: aigwdp.Name, Labels: aigwdp.Spec.Deployment.Labels}
-	specLabels := reservedkeys.Filter(logger, reservedkeys.MetadataTypeLabel, obj, aiGatewayDataPlaneDeploymentReservedKeys)
+	specLabels := reservedkeys.Filter(logger, reservedkeys.MetadataTypeLabel, aigwdp.Spec.Deployment.Labels, aiGatewayDataPlaneDeploymentReservedKeys)
 	deployment.Labels = reservedkeys.Merge(deployment.Labels, specLabels)
 }
 

--- a/controller/dataplane/controller_utils.go
+++ b/controller/dataplane/controller_utils.go
@@ -152,8 +152,7 @@ func addAnnotationsForDataPlaneDeployment(logger logr.Logger, deployment *appsv1
 		return
 	}
 
-	obj := &metav1.ObjectMeta{Namespace: dataplane.Namespace, Name: dataplane.Name, Annotations: specAnnotations}
-	specAnnotations = reservedkeys.Filter(logger, reservedkeys.MetadataTypeAnnotation, obj, dataPlaneDeploymentReservedKeys)
+	specAnnotations = reservedkeys.Filter(logger, reservedkeys.MetadataTypeAnnotation, specAnnotations, dataPlaneDeploymentReservedKeys)
 	deployment.Annotations = reservedkeys.MergeAnnotationsTracked(deployment.Annotations, specAnnotations)
 }
 
@@ -166,8 +165,7 @@ func addLabelsForDataPlaneDeployment(logger logr.Logger, deployment *appsv1.Depl
 	if specLabels == nil {
 		return
 	}
-	obj := &metav1.ObjectMeta{Namespace: dataplane.Namespace, Name: dataplane.Name, Labels: specLabels}
-	specLabels = reservedkeys.Filter(logger, reservedkeys.MetadataTypeLabel, obj, dataPlaneDeploymentReservedKeys)
+	specLabels = reservedkeys.Filter(logger, reservedkeys.MetadataTypeLabel, specLabels, dataPlaneDeploymentReservedKeys)
 	deployment.Labels = reservedkeys.Merge(deployment.Labels, specLabels)
 }
 

--- a/controller/eventgateway/dataplane/owned_deployment.go
+++ b/controller/eventgateway/dataplane/owned_deployment.go
@@ -36,6 +36,7 @@ import (
 	"github.com/kong/kong-operator/v2/controller/konnect/server"
 	log "github.com/kong/kong-operator/v2/controller/pkg/log"
 	"github.com/kong/kong-operator/v2/controller/pkg/op"
+	"github.com/kong/kong-operator/v2/controller/pkg/reservedkeys"
 	controllerpkgssa "github.com/kong/kong-operator/v2/controller/pkg/ssa"
 	"github.com/kong/kong-operator/v2/pkg/consts"
 	k8sutils "github.com/kong/kong-operator/v2/pkg/utils/kubernetes"
@@ -51,7 +52,7 @@ func (r *Reconciler) ensureDeployment(
 	certSecretName string,
 ) error {
 	image := resolveImage(egdp, consts.DefaultKEGImage)
-	desired, err := buildDeployment(r.TypeConverter, egdp, keg, image, certSecretName)
+	desired, err := buildDeployment(logger, r.TypeConverter, egdp, keg, image, certSecretName)
 	if err != nil {
 		return fmt.Errorf("failed to build Deployment for DataPlane %s/%s: %w",
 			egdp.Namespace, egdp.Name, err)
@@ -100,13 +101,14 @@ func resolveImage(egdp *eventgatewayv1alpha1.KegDataPlane, defaultImage string) 
 // removed so that SSA does not claim ownership of it, leaving the API server
 // (or admission webhooks) free to apply their own default.
 func buildDeployment(
+	logger logr.Logger,
 	tc managedfields.TypeConverter,
 	egdp *eventgatewayv1alpha1.KegDataPlane,
 	keg *konnectv1alpha1.KonnectEventGateway,
 	image string,
 	certSecretName string,
 ) (*unstructured.Unstructured, error) {
-	base, err := generateBaseDeployment(egdp, keg, image, certSecretName)
+	base, err := generateBaseDeployment(logger, egdp, keg, image, certSecretName)
 	if err != nil {
 		return nil, err
 	}
@@ -155,6 +157,7 @@ func buildDeployment(
 
 // generateBaseDeployment creates the operator-managed keg Deployment without user overlays.
 func generateBaseDeployment(
+	logger logr.Logger,
 	egdp *eventgatewayv1alpha1.KegDataPlane,
 	keg *konnectv1alpha1.KonnectEventGateway,
 	image string,
@@ -253,7 +256,41 @@ func generateBaseDeployment(
 	}
 
 	k8sutils.SetOwnerForObject(d, egdp)
+
+	addAnnotationsForKegDataPlaneDeployment(logger, d, egdp)
+	addLabelsForKegDataPlaneDeployment(logger, d, egdp)
+
 	return d, nil
+}
+
+// kegDataPlaneDeploymentReservedKeys reports whether a label/annotation key is
+// reserved for internal operator or Kubernetes use and must be dropped from any
+// spec.deployment.labels/annotations provided by the user.
+var kegDataPlaneDeploymentReservedKeys = reservedkeys.NewChecker("app.kubernetes.io/name", "deployment.kubernetes.io/revision")
+
+// addAnnotationsForKegDataPlaneDeployment merges the user-provided
+// spec.deployment.annotations (with reserved keys filtered out) into the
+// Deployment's own metadata. It does not mutate the base annotations map so it
+// is safe to call even when the Deployment shares maps with other objects
+// (e.g. the Pod template).
+func addAnnotationsForKegDataPlaneDeployment(logger logr.Logger, deployment *appsv1.Deployment, egdp *eventgatewayv1alpha1.KegDataPlane) {
+	if egdp.Spec.Deployment == nil || len(egdp.Spec.Deployment.Annotations) == 0 {
+		return
+	}
+	specAnnotations := reservedkeys.Filter(logger, reservedkeys.MetadataTypeAnnotation, egdp.Spec.Deployment.Annotations, kegDataPlaneDeploymentReservedKeys)
+	deployment.Annotations = reservedkeys.Merge(deployment.Annotations, specAnnotations)
+}
+
+// addLabelsForKegDataPlaneDeployment merges the user-provided
+// spec.deployment.labels (with reserved keys filtered out) into the
+// Deployment's own metadata. It does not mutate the base labels map, which is
+// shared with the Pod template, so the Pod template's labels are unaffected.
+func addLabelsForKegDataPlaneDeployment(logger logr.Logger, deployment *appsv1.Deployment, egdp *eventgatewayv1alpha1.KegDataPlane) {
+	if egdp.Spec.Deployment == nil || len(egdp.Spec.Deployment.Labels) == 0 {
+		return
+	}
+	specLabels := reservedkeys.Filter(logger, reservedkeys.MetadataTypeLabel, egdp.Spec.Deployment.Labels, kegDataPlaneDeploymentReservedKeys)
+	deployment.Labels = reservedkeys.Merge(deployment.Labels, specLabels)
 }
 
 // buildKEGEnvVars builds the full list of keg environment variables from

--- a/controller/eventgateway/dataplane/owned_deployment_test.go
+++ b/controller/eventgateway/dataplane/owned_deployment_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	unstructured "k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
@@ -353,6 +354,119 @@ func Test_buildKEGEnvVars(t *testing.T) {
 	}
 }
 
+// infoCountSink is a minimal logr.LogSink that counts Info() calls.
+type infoCountSink struct{ count *int }
+
+func (s infoCountSink) Init(logr.RuntimeInfo)             {}
+func (s infoCountSink) Enabled(int) bool                  { return true }
+func (s infoCountSink) Info(_ int, _ string, _ ...any)    { *s.count++ }
+func (s infoCountSink) Error(_ error, _ string, _ ...any) {}
+func (s infoCountSink) WithValues(_ ...any) logr.LogSink  { return s }
+func (s infoCountSink) WithName(_ string) logr.LogSink    { return s }
+
+// -----------------------------------------------------------------
+// addAnnotationsForKegDataPlaneDeployment / addLabelsForKegDataPlaneDeployment
+// -----------------------------------------------------------------
+
+func Test_addAnnotationsForKegDataPlaneDeployment(t *testing.T) {
+	testCases := []struct {
+		name                string
+		existingAnnotations map[string]string
+		specAnnotations     map[string]string
+		expectedAnnotations map[string]string
+		expectedInfoCount   int
+	}{
+		{
+			name:                "no-op when KegDataPlane has no deployment annotations",
+			existingAnnotations: map[string]string{"existing": "val"},
+			expectedAnnotations: map[string]string{"existing": "val"},
+		},
+		{
+			name:                "new keys merged, conflicting keys overridden",
+			existingAnnotations: map[string]string{"existing": "val", "conflict": "old"},
+			specAnnotations:     map[string]string{"new": "val", "conflict": "new"},
+			expectedAnnotations: map[string]string{"existing": "val", "new": "val", "conflict": "new"},
+		},
+		{
+			name:                "nil existing annotations initialized correctly",
+			specAnnotations:     map[string]string{"k": "v"},
+			expectedAnnotations: map[string]string{"k": "v"},
+		},
+		{
+			name: "reserved keys are dropped and a warning is logged",
+			specAnnotations: map[string]string{
+				"safe":                           "val",
+				consts.OperatorLabelPrefix + "x": "val",
+			},
+			expectedAnnotations: map[string]string{"safe": "val"},
+			expectedInfoCount:   1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			egdp := &eventgatewayv1alpha1.KegDataPlane{
+				Spec: eventgatewayv1alpha1.KegDataPlaneSpec{
+					Deployment: &eventgatewayv1alpha1.DeploymentOptions{Annotations: tc.specAnnotations},
+				},
+			}
+			deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Annotations: tc.existingAnnotations}}
+			var infoCount int
+			addAnnotationsForKegDataPlaneDeployment(logr.New(infoCountSink{count: &infoCount}), deployment, egdp)
+			require.Equal(t, tc.expectedAnnotations, deployment.Annotations)
+			assert.Equal(t, tc.expectedInfoCount, infoCount)
+		})
+	}
+}
+
+func Test_addLabelsForKegDataPlaneDeployment(t *testing.T) {
+	testCases := []struct {
+		name              string
+		existingLabels    map[string]string
+		specLabels        map[string]string
+		expectedLabels    map[string]string
+		expectedInfoCount int
+	}{
+		{
+			name:           "no-op when KegDataPlane has no deployment labels",
+			existingLabels: map[string]string{"existing": "val"},
+			expectedLabels: map[string]string{"existing": "val"},
+		},
+		{
+			name:           "new keys merged, conflicting keys overridden",
+			existingLabels: map[string]string{"existing": "val", "conflict": "old"},
+			specLabels:     map[string]string{"new": "val", "conflict": "new"},
+			expectedLabels: map[string]string{"existing": "val", "new": "val", "conflict": "new"},
+		},
+		{
+			name:           "nil existing labels initialized correctly",
+			specLabels:     map[string]string{"k": "v"},
+			expectedLabels: map[string]string{"k": "v"},
+		},
+		{
+			name:              "reserved keys are dropped and a warning is logged",
+			specLabels:        map[string]string{"safe": "val", "app.kubernetes.io/name": "should-not-override-base-label"},
+			expectedLabels:    map[string]string{"safe": "val"},
+			expectedInfoCount: 1,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			egdp := &eventgatewayv1alpha1.KegDataPlane{
+				Spec: eventgatewayv1alpha1.KegDataPlaneSpec{
+					Deployment: &eventgatewayv1alpha1.DeploymentOptions{Labels: tc.specLabels},
+				},
+			}
+			deployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Labels: tc.existingLabels}}
+			var infoCount int
+			addLabelsForKegDataPlaneDeployment(logr.New(infoCountSink{count: &infoCount}), deployment, egdp)
+			require.Equal(t, tc.expectedLabels, deployment.Labels)
+			assert.Equal(t, tc.expectedInfoCount, infoCount)
+		})
+	}
+}
+
 // -----------------------------------------------------------------
 // generateBaseDeployment
 // -----------------------------------------------------------------
@@ -367,7 +481,7 @@ func Test_generateBaseDeployment_hardening(t *testing.T) {
 		ID:        "gw-id",
 	}
 
-	d, err := generateBaseDeployment(egdp, keg, "kong/keg:test", "cert-secret")
+	d, err := generateBaseDeployment(logr.Discard(), egdp, keg, "kong/keg:test", "cert-secret")
 	require.NoError(t, err)
 	require.Len(t, d.Spec.Template.Spec.Containers, 1)
 	container := d.Spec.Template.Spec.Containers[0]
@@ -400,6 +514,47 @@ func Test_generateBaseDeployment_hardening(t *testing.T) {
 		volumeNames = append(volumeNames, v.Name)
 	}
 	assert.ElementsMatch(t, []string{"tmp", KonnectCertVolumeName}, volumeNames)
+}
+
+// Test_generateBaseDeployment_LabelsAndAnnotations verifies that
+// spec.deployment.labels/annotations are propagated onto the generated
+// Deployment's own metadata, that reserved keys are dropped, and that the
+// Pod template's labels (which share the base labels map) are unaffected.
+func Test_generateBaseDeployment_LabelsAndAnnotations(t *testing.T) {
+	egdp := &eventgatewayv1alpha1.KegDataPlane{
+		ObjectMeta: metav1.ObjectMeta{Name: "my-keg", Namespace: "test-ns"},
+		Spec: eventgatewayv1alpha1.KegDataPlaneSpec{
+			Deployment: &eventgatewayv1alpha1.DeploymentOptions{
+				Annotations: map[string]string{
+					"deployment-annotation":          "value",
+					consts.OperatorLabelPrefix + "x": "should-be-dropped",
+				},
+				Labels: map[string]string{
+					"deployment-label":       "value",
+					"app.kubernetes.io/name": "should-be-dropped",
+				},
+			},
+		},
+	}
+	keg := &konnectv1alpha1.KonnectEventGateway{}
+	keg.Status.KonnectEntityStatus = konnectv1alpha2.KonnectEntityStatus{
+		ServerURL: "https://us.api.konghq.com",
+		ID:        "gw-id",
+	}
+
+	d, err := generateBaseDeployment(logr.Discard(), egdp, keg, "kong/keg:test", "cert-secret")
+	require.NoError(t, err)
+
+	assert.Equal(t, "value", d.Labels["deployment-label"])
+	assert.Equal(t, "value", d.Annotations["deployment-annotation"])
+	assert.NotContains(t, d.Annotations, consts.OperatorLabelPrefix+"x")
+
+	// The base "app.kubernetes.io/name" label set by the generator must survive the merge.
+	assert.Equal(t, consts.KEGContainerName, d.Labels["app.kubernetes.io/name"])
+
+	// The Pod template shares the base labels map with the Deployment; the
+	// custom Deployment-level label must not leak into it.
+	assert.NotContains(t, d.Spec.Template.Labels, "deployment-label")
 }
 
 // -----------------------------------------------------------------
@@ -512,7 +667,7 @@ func Test_buildDeployment(t *testing.T) {
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			u, err := buildDeployment(tc, tt.egdp, tt.keg, tt.image, tt.certSecretName)
+			u, err := buildDeployment(logr.Discard(), tc, tt.egdp, tt.keg, tt.image, tt.certSecretName)
 			if tt.wantErr {
 				require.Error(t, err)
 				return

--- a/controller/pkg/reservedkeys/reservedkeys.go
+++ b/controller/pkg/reservedkeys/reservedkeys.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"github.com/go-logr/logr"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kong/kong-operator/v2/controller/pkg/log"
 	"github.com/kong/kong-operator/v2/pkg/consts"
@@ -54,9 +53,8 @@ const (
 
 // Filter drops any key from keys for which isReserved returns true, logging
 // an Info message for each one dropped so it's clear why a user-provided
-// label/annotation didn't take effect. extraLogFields are appended verbatim
-// to the log call (e.g. "dataplane", "ns/name") to identify the owning
-// resource.
+// label/annotation didn't take effect. metadataType is only used to label
+// the log line ("label" vs "annotation").
 //
 // This is logged at Info rather than Error level: it's an expected, routine
 // situation (not a bug), and controller-runtime's zap logger attaches a full
@@ -64,17 +62,8 @@ const (
 // otherwise spam the logs on every reconcile of an object whose spec sets
 // a reserved key.
 func Filter(
-	logger logr.Logger, metadataType MetadataType, obj metav1.Object, isReserved IsReservedFunc,
+	logger logr.Logger, metadataType MetadataType, keys map[string]string, isReserved IsReservedFunc,
 ) map[string]string {
-	var keys map[string]string
-	switch metadataType {
-	case MetadataTypeLabel:
-		keys = obj.GetLabels()
-	case MetadataTypeAnnotation:
-		keys = obj.GetAnnotations()
-	default:
-		panic(fmt.Sprintf("unknown metadataType %q", metadataType))
-	}
 	if len(keys) == 0 {
 		return nil
 	}

--- a/controller/pkg/reservedkeys/reservedkeys_test.go
+++ b/controller/pkg/reservedkeys/reservedkeys_test.go
@@ -7,7 +7,6 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kong/kong-operator/v2/pkg/consts"
 )
@@ -69,26 +68,12 @@ func TestFilter(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			var infoCount int
 			logger := logr.New(infoCountSink{count: &infoCount})
-			obj := &metav1.ObjectMeta{Namespace: "ns", Name: "name", Annotations: tc.keys}
 
-			filtered := Filter(logger, MetadataTypeAnnotation, obj, isReserved)
+			filtered := Filter(logger, MetadataTypeAnnotation, tc.keys, isReserved)
 			require.Equal(t, tc.expectedKept, filtered)
 			assert.Equal(t, tc.expectedIgnore, infoCount, "expected a log line per reserved key dropped")
 		})
 	}
-}
-
-func TestFilter_PicksMapByMetadataType(t *testing.T) {
-	isReserved := NewChecker("app")
-	obj := &metav1.ObjectMeta{
-		Namespace:   "ns",
-		Name:        "name",
-		Labels:      map[string]string{"label-key": "val"},
-		Annotations: map[string]string{"annotation-key": "val"},
-	}
-
-	assert.Equal(t, map[string]string{"label-key": "val"}, Filter(logr.Discard(), MetadataTypeLabel, obj, isReserved))
-	assert.Equal(t, map[string]string{"annotation-key": "val"}, Filter(logr.Discard(), MetadataTypeAnnotation, obj, isReserved))
 }
 
 func TestMerge(t *testing.T) {

--- a/docs/all-api-reference.md
+++ b/docs/all-api-reference.md
@@ -6082,6 +6082,8 @@ DeploymentOptions specifies options for the Deployment managed by the KegDataPla
 | --- | --- |
 | `replicas` _*int32_ | Replicas describes the number of desired pods. This is a pointer to distinguish between explicit zero and not specified. This is effectively shorthand for setting a scaling minimum and maximum to the same value. This field and the scaling field are mutually exclusive: You can only configure one or the other. |
 | `scaling` _[Scaling](#eventgateway-konghq-com-v1alpha1-types-scaling)_ | Scaling defines the scaling options for the deployment. |
+| `annotations` _map[string]string_ | Annotations are custom annotations that are propagated to the keg Deployment metadata by the operator. |
+| `labels` _map[string]string_ | Labels are custom labels that are propagated to the keg Deployment metadata by the operator. |
 | `podTemplateSpec` _[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#podtemplatespec-v1-core)_ | PodTemplateSpec defines PodTemplateSpec for Deployment's pods. It's being applied on top of the generated Deployments using [StrategicMergePatch](https://pkg.go.dev/k8s.io/apimachinery/pkg/util/strategicpatch#StrategicMergePatch).<br /><br />Note: environment variables set here take precedence over strongly-typed fields in Spec.Config. Using raw env vars is discouraged and intended for advanced use cases only. |
 
 _Appears in:_

--- a/docs/eventgateway-api-reference.md
+++ b/docs/eventgateway-api-reference.md
@@ -97,6 +97,8 @@ DeploymentOptions specifies options for the Deployment managed by the KegDataPla
 | --- | --- |
 | `replicas` _*int32_ | Replicas describes the number of desired pods. This is a pointer to distinguish between explicit zero and not specified. This is effectively shorthand for setting a scaling minimum and maximum to the same value. This field and the scaling field are mutually exclusive: You can only configure one or the other. |
 | `scaling` _[Scaling](#eventgateway-konghq-com-v1alpha1-types-scaling)_ | Scaling defines the scaling options for the deployment. |
+| `annotations` _map[string]string_ | Annotations are custom annotations that are propagated to the keg Deployment metadata by the operator. |
+| `labels` _map[string]string_ | Labels are custom labels that are propagated to the keg Deployment metadata by the operator. |
 | `podTemplateSpec` _[PodTemplateSpec](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.33/#podtemplatespec-v1-core)_ | PodTemplateSpec defines PodTemplateSpec for Deployment's pods. It's being applied on top of the generated Deployments using [StrategicMergePatch](https://pkg.go.dev/k8s.io/apimachinery/pkg/util/strategicpatch#StrategicMergePatch).<br /><br />Note: environment variables set here take precedence over strongly-typed fields in Spec.Config. Using raw env vars is discouraged and intended for advanced use cases only. |
 
 _Appears in:_


### PR DESCRIPTION
**What this PR does / why we need it**:

The last PR from the series. It adds support for setting labels and annotations to `KegDataPlane`'s `DeploymentOptions` and contains some refactoring.

**Which issue this PR fixes**

Closes #3682

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
