### PR TITLE
fix: fix label selector when patching `AIGatewayDataPlane`

### DIFF
--- a/controller/aigateway/dataplane/owned_deployment.go
+++ b/controller/aigateway/dataplane/owned_deployment.go
@@ -130,10 +130,7 @@ func buildDeployment(
 			},
 			Spec: appsv1.DeploymentSpec{
 				Selector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{
-						consts.GatewayOperatorManagedByLabel:     consts.AIGatewayDataPlaneManagedByLabelValue,
-						consts.GatewayOperatorManagedByNameLabel: aigwdp.Name,
-					},
+					MatchLabels: selectorLabelsForAIGatewayDataPlane(aigwdp),
 				},
 				Template: *aigwdp.Spec.Deployment.PodTemplateSpec,
 			},
@@ -152,6 +149,14 @@ func buildDeployment(
 	return u, nil
 }
 
+func selectorLabelsForAIGatewayDataPlane(aigwdp *aigatewayv1alpha1.AIGatewayDataPlane) map[string]string {
+	return map[string]string{
+		consts.GatewayOperatorManagedByLabel:          consts.AIGatewayDataPlaneManagedByLabelValue,
+		consts.GatewayOperatorManagedByNameLabel:      aigwdp.Name,
+		consts.GatewayOperatorManagedByNamespaceLabel: aigwdp.Namespace,
+	}
+}
+
 // generateBaseDeployment creates the operator-managed AI Gateway Deployment without user overlays.
 func generateBaseDeployment(
 	logger logr.Logger,
@@ -160,17 +165,10 @@ func generateBaseDeployment(
 	image string,
 	certSecretName string,
 ) (*appsv1.Deployment, error) {
-	labels := map[string]string{
-		"app.kubernetes.io/name":                      consts.AIGatewayDataPlaneContainerName,
-		consts.GatewayOperatorManagedByLabel:          consts.AIGatewayDataPlaneManagedByLabelValue,
-		consts.GatewayOperatorManagedByNameLabel:      aigwdp.Name,
-		consts.GatewayOperatorManagedByNamespaceLabel: aigwdp.Namespace,
-	}
-	selector := map[string]string{
-		consts.GatewayOperatorManagedByLabel:          consts.AIGatewayDataPlaneManagedByLabelValue,
-		consts.GatewayOperatorManagedByNameLabel:      aigwdp.Name,
-		consts.GatewayOperatorManagedByNamespaceLabel: aigwdp.Namespace,
-	}
+	labels := selectorLabelsForAIGatewayDataPlane(aigwdp)
+	labels["app.kubernetes.io/name"] = consts.AIGatewayDataPlaneContainerName
+
+	selector := selectorLabelsForAIGatewayDataPlane(aigwdp)
 
 	envVars, err := buildAIGatewayEnvVars(aigatewaycp)
 	if err != nil {

--- a/test/envtest/aigateway_dataplane_controller_test.go
+++ b/test/envtest/aigateway_dataplane_controller_test.go
@@ -1,0 +1,241 @@
+package envtest
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	aigatewayv1alpha1 "github.com/kong/kong-operator/v2/api/aigateway/v1alpha1"
+	configurationv1alpha1 "github.com/kong/kong-operator/v2/api/configuration/v1alpha1"
+	konnectv1alpha1 "github.com/kong/kong-operator/v2/api/konnect/v1alpha1"
+	konnectv1alpha2 "github.com/kong/kong-operator/v2/api/konnect/v1alpha2"
+	aigwdataplane "github.com/kong/kong-operator/v2/controller/aigateway/dataplane"
+	"github.com/kong/kong-operator/v2/controller/crdschema"
+	controllerpkgssa "github.com/kong/kong-operator/v2/controller/pkg/ssa"
+	"github.com/kong/kong-operator/v2/modules/manager/scheme"
+	"github.com/kong/kong-operator/v2/pkg/consts"
+)
+
+// aigwCRDGroups mirrors the CRD groups the AIGatewayDataPlane controller
+// passes to ApplyIfChanged / MergeObjects, matching the set built in
+// modules/manager/controller_setup.go.
+var aigwCRDGroups = map[string]struct{}{
+	"aigateway.konghq.com":     {},
+	"configuration.konghq.com": {},
+	"konnect.konghq.com":       {},
+}
+
+// TestAIGatewayDataPlaneReconciler_SelectorStability is a regression test for
+// the bug fixed in "fix: fix label selector when patching AIGatewayDataPlane":
+// the Deployment build path taken when spec.deployment.podTemplateSpec is
+// unset produced a different spec.selector.matchLabels than the path taken
+// once it is set, so switching between the two on the same Deployment hit
+// Kubernetes' "spec.selector: field is immutable" rejection.
+//
+// This must be an envtest: the fake client used by unit tests neither
+// enforces Deployment selector immutability (that lives in the real
+// kube-apiserver's Deployment strategy validation) nor merges
+// LabelSelector/matchLabels the way the real OpenAPI schema does (the schema
+// treats LabelSelector as atomic, so a divergent overlay selector replaces
+// the base's rather than unioning with it, as the unit tests' deduced
+// TypeConverter would do).
+func TestAIGatewayDataPlaneReconciler_SelectorStability(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	cfg, ns := Setup(t, ctx, scheme.Get(), WithInstallGatewayCRDs(true))
+	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())
+
+	clusterCA := createClusterCASecret(t, ctx, mgr.GetClient(), ns.Name, "aigw-cluster-ca")
+
+	ssaProvider, err := controllerpkgssa.NewTypeConverterProvider(ctx, mgr.GetLogger(), mgr, aigwCRDGroups)
+	require.NoError(t, err)
+
+	StartReconcilers(ctx, t, mgr, logs,
+		&aigwdataplane.Reconciler{
+			Client:                   mgr.GetClient(),
+			ClusterCASecretName:      clusterCA.Name,
+			ClusterCASecretNamespace: clusterCA.Namespace,
+			CertTTL:                  consts.DefaultCertTTL,
+			TypeConverter:            ssaProvider,
+		},
+		&crdschema.Reconciler{
+			Client:   mgr.GetClient(),
+			Provider: ssaProvider,
+		},
+	)
+
+	cl := mgr.GetClient()
+
+	t.Run("switching to a PodTemplateSpec overlay after a plain create does not trip immutable selector", func(t *testing.T) {
+		t.Parallel()
+
+		aigwdp := setupProgrammedAIGWDP(t, ctx, cl, ns.Name,
+			"aigwcp-selector", "konnect-id-selector", "aigwdp-selector",
+			aigatewayv1alpha1.AIGatewayDataPlaneSpec{},
+		)
+
+		// Step 1: Deployment created via the non-overlay path.
+		deploy := waitForAIGWDeployment(t, ctx, cl, ns.Name, aigwdp.Name)
+		selectorBefore := deploy.Spec.Selector.MatchLabels
+		assert.Equal(t, map[string]string{
+			consts.GatewayOperatorManagedByLabel:          consts.AIGatewayDataPlaneManagedByLabelValue,
+			consts.GatewayOperatorManagedByNameLabel:      aigwdp.Name,
+			consts.GatewayOperatorManagedByNamespaceLabel: ns.Name,
+		}, selectorBefore)
+
+		// Step 2: switch to the PodTemplateSpec overlay path by setting
+		// spec.deployment.podTemplateSpec. This forces buildDeployment onto
+		// the MergeObjects branch against the very same stored Deployment.
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			if !assert.NoError(ct, cl.Get(ctx, client.ObjectKeyFromObject(aigwdp), aigwdp)) {
+				return
+			}
+			aigwdp.Spec.Deployment = &aigatewayv1alpha1.DeploymentOptions{
+				PodTemplateSpec: &corev1.PodTemplateSpec{
+					Spec: corev1.PodSpec{
+						Containers: []corev1.Container{
+							{Name: consts.AIGatewayDataPlaneContainerName, Image: "custom/aigw:overlay"},
+						},
+					},
+				},
+			}
+			assert.NoError(ct, cl.Update(ctx, aigwdp))
+		}, waitTime, tickTime)
+
+		// Step 3: the overlay must actually land. Pre-fix, the SSA apply is
+		// rejected with "spec.selector: field is immutable", the container
+		// image never changes, and a DeploymentFailed event is recorded.
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			var deployAfter appsv1.Deployment
+			if !assert.NoError(ct, cl.Get(ctx, client.ObjectKey{Name: aigwdp.Name, Namespace: ns.Name}, &deployAfter)) {
+				return
+			}
+			var found bool
+			for _, c := range deployAfter.Spec.Template.Spec.Containers {
+				if c.Name == consts.AIGatewayDataPlaneContainerName {
+					found = assert.Equal(ct, "custom/aigw:overlay", c.Image)
+				}
+			}
+			assert.True(ct, found, "aigw container not found in Deployment")
+			// Step 4: selector must be unchanged across the transition.
+			assert.Equal(ct, selectorBefore, deployAfter.Spec.Selector.MatchLabels)
+		}, waitTime, tickTime)
+	})
+}
+
+// setupProgrammedAIGWDP creates a KonnectAIGateway and an AIGatewayDataPlane,
+// programs the control plane and the resulting AIGatewayDataPlaneCertificate,
+// and returns the AIGatewayDataPlane. spec.ControlPlaneRef is populated by the
+// helper, so callers only need to set the fields they care about.
+func setupProgrammedAIGWDP(
+	t *testing.T,
+	ctx context.Context,
+	cl client.Client,
+	ns, aigwcpName, konnectID, aigwdpName string,
+	spec aigatewayv1alpha1.AIGatewayDataPlaneSpec,
+) *aigatewayv1alpha1.AIGatewayDataPlane {
+	t.Helper()
+
+	aigwcp := &konnectv1alpha1.KonnectAIGateway{
+		ObjectMeta: metav1.ObjectMeta{Name: aigwcpName, Namespace: ns},
+		Spec: konnectv1alpha1.KonnectAIGatewaySpec{
+			KonnectConfiguration: konnectv1alpha2.KonnectConfiguration{
+				APIAuthConfigurationRef: konnectv1alpha2.KonnectAPIAuthConfigurationRef{Name: "unused-auth"},
+			},
+			APISpec: &konnectv1alpha1.KonnectAIGatewayAPISpec{
+				Name:        konnectv1alpha1.AIGatewayEntityIdentifier(aigwcpName),
+				DisplayName: aigwcpName,
+			},
+		},
+	}
+	require.NoError(t, cl.Create(ctx, aigwcp))
+	updateKonnectAIGatewayStatusWithProgrammed(t, ctx, cl, aigwcp, konnectID)
+
+	spec.ControlPlaneRef = aigatewayv1alpha1.ControlPlaneRef{
+		Type:                 aigatewayv1alpha1.ControlPlaneRefTypeKonnectNamespacedRef,
+		KonnectNamespacedRef: &aigatewayv1alpha1.KonnectNamespacedRef{Name: aigwcpName},
+	}
+	aigwdp := &aigatewayv1alpha1.AIGatewayDataPlane{
+		ObjectMeta: metav1.ObjectMeta{Name: aigwdpName, Namespace: ns},
+		Spec:       spec,
+	}
+	require.NoError(t, cl.Create(ctx, aigwdp))
+
+	konnectCert := &configurationv1alpha1.AIGatewayDataPlaneCertificate{}
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		assert.NoError(ct, cl.Get(ctx, client.ObjectKey{Name: aigwdpName, Namespace: ns}, konnectCert))
+	}, waitTime, tickTime)
+	updateAIGatewayDataPlaneCertificateStatusWithProgrammed(t, ctx, cl, konnectCert)
+
+	return aigwdp
+}
+
+// waitForAIGWDeployment waits for exactly one Deployment owned by the given
+// AIGatewayDataPlane name and returns it.
+func waitForAIGWDeployment(t *testing.T, ctx context.Context, cl client.Client, ns, aigwdpName string) appsv1.Deployment {
+	t.Helper()
+	var deployList appsv1.DeploymentList
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		assert.NoError(ct, cl.List(ctx, &deployList,
+			client.InNamespace(ns),
+			client.MatchingLabels{consts.GatewayOperatorManagedByNameLabel: aigwdpName},
+		))
+		assert.Len(ct, deployList.Items, 1)
+	}, waitTime, tickTime)
+	require.Len(t, deployList.Items, 1)
+	return deployList.Items[0]
+}
+
+// updateKonnectAIGatewayStatusWithProgrammed sets aigwcp's status to
+// Programmed=True with endpoints, as the real Konnect controller would once
+// the AI Gateway control plane exists on Konnect.
+func updateKonnectAIGatewayStatusWithProgrammed(
+	t *testing.T,
+	ctx context.Context,
+	cl client.Client,
+	aigwcp *konnectv1alpha1.KonnectAIGateway,
+	id string,
+) {
+	t.Helper()
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		if !assert.NoError(ct, cl.Get(ctx, client.ObjectKeyFromObject(aigwcp), aigwcp)) {
+			return
+		}
+		aigwcp.Status.Endpoints = &konnectv1alpha1.KonnectAIGatewayEndpoints{
+			Configuration: "cp." + id + ".example.com",
+			Telemetry:     "tp." + id + ".example.com",
+		}
+		aigwcp.Status.Conditions = []metav1.Condition{
+			ProgrammedCondition(aigwcp.GetGeneration()),
+		}
+		assert.NoError(ct, cl.Status().Update(ctx, aigwcp))
+	}, waitTime, tickTime)
+}
+
+// updateAIGatewayDataPlaneCertificateStatusWithProgrammed flips the owned
+// AIGatewayDataPlaneCertificate to Programmed=True, as the real Konnect
+// controller would once the certificate is registered on Konnect.
+func updateAIGatewayDataPlaneCertificateStatusWithProgrammed(
+	t *testing.T,
+	ctx context.Context,
+	cl client.Client,
+	obj *configurationv1alpha1.AIGatewayDataPlaneCertificate,
+) {
+	t.Helper()
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		if !assert.NoError(ct, cl.Get(ctx, client.ObjectKeyFromObject(obj), obj)) {
+			return
+		}
+		obj.Status.Conditions = []metav1.Condition{
+			ProgrammedCondition(obj.GetGeneration()),
+		}
+		assert.NoError(ct, cl.Status().Update(ctx, obj))
+	}, waitTime, tickTime)
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

When patching `AIGatewayDataPlane` the label selector didn't include the managed by namespace label so the operation was failing with the following error:

```
{"level":"error","ts":"2026-07-29T12:22:53.688+0200","msg":"Reconciler error","controller":"aigatewaydataplane","controllerGroup":"aigateway.konghq.com","controllerKind":"AIGatewayDataPlane","AIGatewayDataPlane":{"name":"my-ai-gateway-dp","namespace":"default"},"namespace":"default","name":"my-ai-gateway-dp","reconcileID":"8a845c8c-aacc-4d26-a183-2708e120bff4","error":"failed to apply Deployment for AIGatewayDataPlane default/my-ai-gateway-dp: Deployment.apps \"my-ai-gateway-dp\" is invalid: spec.selector: Invalid value: {\"matchLabels\":{\"gateway-operator.konghq.com/managed-by\":\"aigateway-dataplane\",\"gateway-operator.konghq.com/managed-by-name\":\"my-ai-gateway-dp\"}}: field is immutable","stacktrace":"sigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).reconcileHandler\n\t/Users/patryk.malek/.gvm/pkgsets/go1.26.5/global/pkg/mod/sigs.k8s.io/controller-runtime@v0.24.1/pkg/internal/controller/controller.go:494\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).processNextWorkItem\n\t/Users/patryk.malek/.gvm/pkgsets/go1.26.5/global/pkg/mod/sigs.k8s.io/controller-runtime@v0.24.1/pkg/internal/controller/controller.go:437\nsigs.k8s.io/controller-runtime/pkg/internal/controller.(*Controller[...]).Start.func1.1\n\t/Users/patryk.malek/.gvm/pkgsets/go1.26.5/global/pkg/mod/sigs.k8s.io/controller-runtime@v0.24.1/pkg/internal/controller/controller.go:312"}
```

and the following event:

```
action: ApplyDeployment
apiVersion: events.k8s.io/v1
deprecatedFirstTimestamp: null
deprecatedLastTimestamp: null
deprecatedSource: {}
eventTime: "2026-07-29T10:14:47.814316Z"
kind: Event
metadata:
  creationTimestamp: "2026-07-29T10:14:47Z"
  name: my-ai-gateway-dp.18c6bb292c8aa7b0
  namespace: default
  resourceVersion: "348489"
  uid: b16a3227-b567-4fe2-9061-4bfcfd5e150f
note: 'Failed to apply Deployment: Deployment.apps "my-ai-gateway-dp" is invalid:
  spec.selector: Invalid value: {"matchLabels":{"gateway-operator.konghq.com/managed-by":"aigateway-dataplane","gateway-operator.konghq.com/managed-by-name":"my-ai-gateway-dp"}}:
  field is immutable'
reason: DeploymentFailed
regarding:
  apiVersion: aigateway.konghq.com/v1alpha1
  kind: AIGatewayDataPlane
  name: my-ai-gateway-dp
  namespace: default
  resourceVersion: "348486"
  uid: 2496f1c7-a9a9-4783-9b74-f067841be1e9
reportingController: aigw-dataplane
reportingInstance: aigw-dataplane-CLJ1XK6FQ5
series:
  count: 2
  lastObservedTime: "2026-07-29T10:14:47.838201Z"
type: Warning
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
