### PR TITLE
fix(gateway): Support both v1beta1 and v1 in watches on RerferenceGrants in controllers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -78,6 +78,9 @@
   This fixes the `HTTPRouteNoBackendRefs` Gateway API conformance test for the
   hybrid gateway.
   [#5066](https://github.com/Kong/kong-operator/pull/5066)
+- Gateway: Support watching both `v1` and `v1beta1` versions of `ReferenceGrant`
+  to ensure compatability with gateway API 1.3 and 1.4.
+  [#5091](https://github.com/Kong/kong-operator/pull/5091)
 
 ### Added
   

--- a/ingress-controller/internal/controllers/gateway/gateway_controller.go
+++ b/ingress-controller/internal/controllers/gateway/gateway_controller.go
@@ -66,6 +66,9 @@ type GatewayReconciler struct {
 	// to invalidate or allow cross-namespace TLSConfigs in gateways.
 	// It's resolved on SetupWithManager call.
 	enableReferenceGrant bool
+	// referenceGrantVersion is the ReferenceGrant API GroupVersion (v1 or v1beta1)
+	// served by the cluster, resolved on SetupWithManager call.
+	referenceGrantVersion schema.GroupVersion
 
 	// If GatewayNN is set,
 	// only resources managed by the specified Gateway are reconciled.
@@ -84,11 +87,10 @@ func (r *GatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// when reconciling Gateways.
 	// Once the GatewayReconciler is set up without ReferenceGrant, there's no possibility to enable
 	// ReferenceGrant handling again in this reconciler at runtime.
-	r.enableReferenceGrant = ctrlutils.CRDExists(mgr.GetRESTMapper(), schema.GroupVersionResource{
-		Group:    gatewayv1beta1.GroupVersion.Group,
-		Version:  gatewayv1beta1.GroupVersion.Version,
-		Resource: "referencegrants",
-	})
+	r.referenceGrantVersion, r.enableReferenceGrant = ctrlutils.DetectReferenceGrantVersion(mgr.GetRESTMapper())
+	if !r.enableReferenceGrant {
+		r.Log.Error(nil, "Neither v1 nor v1beta1 ReferenceGrant CRD found; cross-namespace references will be rejected")
+	}
 
 	blder := ctrl.NewControllerManagedBy(mgr).
 		// set the controller name
@@ -126,7 +128,7 @@ func (r *GatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 
 	// watch ReferenceGrants, which may invalidate or allow cross-namespace TLSConfigs
 	if r.enableReferenceGrant {
-		blder.Watches(&gatewayapi.ReferenceGrant{},
+		blder.Watches(gatewayapi.NewReferenceGrant(r.referenceGrantVersion),
 			handler.EnqueueRequestsFromMapFunc(r.listReferenceGrantsForGateway),
 			builder.WithPredicates(predicate.NewPredicateFuncs(referenceGrantHasGatewayFrom)),
 		)
@@ -237,7 +239,7 @@ func (r *GatewayReconciler) listGatewaysForGatewayClass(ctx context.Context, gat
 // listReferenceGrantsForGateway is a watch predicate which finds all Gateways mentioned in a From clause for a
 // ReferenceGrant.
 func (r *GatewayReconciler) listReferenceGrantsForGateway(ctx context.Context, obj client.Object) []reconcile.Request {
-	grant, ok := obj.(*gatewayapi.ReferenceGrant)
+	grant, ok := gatewayapi.AsReferenceGrant(obj)
 	if !ok {
 		r.Log.Error(
 			fmt.Errorf("unexpected object type"),
@@ -381,7 +383,7 @@ func (r *GatewayReconciler) isGatewayService(obj client.Object) bool {
 }
 
 func referenceGrantHasGatewayFrom(obj client.Object) bool {
-	grant, ok := obj.(*gatewayapi.ReferenceGrant)
+	grant, ok := gatewayapi.AsReferenceGrant(obj)
 	if !ok {
 		return false
 	}
@@ -648,14 +650,14 @@ func (r *GatewayReconciler) reconcileUnmanagedGateway(ctx context.Context, log l
 
 	// the ReferenceGrants need to be retrieved to ensure that all gateway listeners reference
 	// TLS secrets they are granted for
-	referenceGrantList := &gatewayapi.ReferenceGrantList{}
+	referenceGrantList := gatewayapi.NewReferenceGrantList(r.referenceGrantVersion)
 	if r.enableReferenceGrant {
 		if err := r.List(ctx, referenceGrantList); err != nil {
 			return ctrl.Result{}, err
 		}
 	}
 
-	listenerStatuses, err := getListenerStatus(ctx, gateway, combinedListeners, referenceGrantList.Items, r.Client)
+	listenerStatuses, err := getListenerStatus(ctx, gateway, combinedListeners, gatewayapi.ReferenceGrantItems(referenceGrantList), r.Client)
 	if err != nil {
 		return ctrl.Result{}, err
 	}

--- a/ingress-controller/internal/controllers/gateway/gateway_controller_test.go
+++ b/ingress-controller/internal/controllers/gateway/gateway_controller_test.go
@@ -386,7 +386,7 @@ func TestGetReferenceGrantConditionReason(t *testing.T) {
 		name             string
 		gatewayNamespace string
 		certRef          gatewayapi.SecretObjectReference
-		referenceGrants  []gatewayapi.ReferenceGrant
+		referenceGrants  []*gatewayapi.ReferenceGrant
 		expectedReason   string
 	}{
 		{
@@ -411,7 +411,7 @@ func TestGetReferenceGrantConditionReason(t *testing.T) {
 				Name:      "testSecret",
 				Namespace: new(gatewayapi.Namespace("otherNamespace")),
 			},
-			referenceGrants: []gatewayapi.ReferenceGrant{
+			referenceGrants: []*gatewayapi.ReferenceGrant{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "otherNamespace",
@@ -454,7 +454,7 @@ func TestGetReferenceGrantConditionReason(t *testing.T) {
 				Name:      "testSecret",
 				Namespace: new(gatewayapi.Namespace("otherNamespace")),
 			},
-			referenceGrants: []gatewayapi.ReferenceGrant{
+			referenceGrants: []*gatewayapi.ReferenceGrant{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "otherNamespace",
@@ -493,7 +493,7 @@ func TestGetReferenceGrantConditionReason(t *testing.T) {
 				Name:      "testSecret",
 				Namespace: new(gatewayapi.Namespace("otherNamespace")),
 			},
-			referenceGrants: []gatewayapi.ReferenceGrant{
+			referenceGrants: []*gatewayapi.ReferenceGrant{
 				{
 					ObjectMeta: metav1.ObjectMeta{
 						Namespace: "otherNamespace",

--- a/ingress-controller/internal/controllers/gateway/gateway_utils.go
+++ b/ingress-controller/internal/controllers/gateway/gateway_utils.go
@@ -232,7 +232,7 @@ func getListenerStatus(
 	ctx context.Context,
 	gateway *gatewayapi.Gateway,
 	kongListens []gatewayapi.Listener,
-	referenceGrants []gatewayapi.ReferenceGrant,
+	referenceGrants []*gatewayapi.ReferenceGrant,
 	client client.Client,
 ) ([]gatewayapi.ListenerStatus, error) {
 	statuses := make(map[gatewayapi.SectionName]gatewayapi.ListenerStatus, len(gateway.Spec.Listeners))
@@ -528,7 +528,7 @@ func getListenerStatus(
 func getReferenceGrantConditionReason(
 	gatewayNamespace string,
 	certRef gatewayapi.SecretObjectReference,
-	referenceGrants []gatewayapi.ReferenceGrant,
+	referenceGrants []*gatewayapi.ReferenceGrant,
 ) string {
 	// no need to have this reference granted
 	if certRef.Namespace == nil || *certRef.Namespace == (gatewayapi.Namespace)(gatewayNamespace) {

--- a/ingress-controller/internal/controllers/gateway/httproute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/httproute_controller.go
@@ -26,7 +26,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	configurationv1 "github.com/kong/kong-operator/v2/api/configuration/v1"
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/controllers"
@@ -59,6 +58,9 @@ type HTTPRouteReconciler struct {
 	// If it is false, referencing backend in different namespace will be rejected.
 	// It's resolved on SetupWithManager call.
 	enableReferenceGrant bool
+	// referenceGrantVersion is the ReferenceGrant API GroupVersion (v1 or v1beta1)
+	// served by the cluster, resolved on SetupWithManager call.
+	referenceGrantVersion schema.GroupVersion
 
 	// If GatewayNN is set,
 	// only resources managed by the specified Gateway are reconciled.
@@ -72,11 +74,10 @@ func (r *HTTPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// when reconciling HTTPRoutes.
 	// Once the HTTPRouteReconciler is set up without ReferenceGrant, there's no possibility to enable
 	// ReferenceGrant handling again in this reconciler at runtime.
-	r.enableReferenceGrant = ctrlutils.CRDExists(mgr.GetRESTMapper(), schema.GroupVersionResource{
-		Group:    gatewayv1beta1.GroupVersion.Group,
-		Version:  gatewayv1beta1.GroupVersion.Version,
-		Resource: "referencegrants",
-	})
+	r.referenceGrantVersion, r.enableReferenceGrant = ctrlutils.DetectReferenceGrantVersion(mgr.GetRESTMapper())
+	if !r.enableReferenceGrant {
+		r.Log.Error(nil, "Neither v1 nor v1beta1 ReferenceGrant CRD found; cross-namespace references will be rejected")
+	}
 
 	if err := setupHTTPRouteIndices(mgr); err != nil {
 		return err
@@ -117,7 +118,7 @@ func (r *HTTPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	)
 
 	if r.enableReferenceGrant {
-		blder.Watches(&gatewayapi.ReferenceGrant{},
+		blder.Watches(gatewayapi.NewReferenceGrant(r.referenceGrantVersion),
 			handler.EnqueueRequestsFromMapFunc(r.listHTTPRoutesForReferenceGrant),
 			builder.WithPredicates(predicate.NewPredicateFuncs(referenceGrantHasHTTPRouteFrom)),
 		)
@@ -157,7 +158,7 @@ func (r *HTTPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // listHTTPRoutesForReferenceGrant is a watch predicate which finds all HTTPRoutes
 // mentioned in a From clause for a ReferenceGrant.
 func (r *HTTPRouteReconciler) listHTTPRoutesForReferenceGrant(ctx context.Context, obj client.Object) []reconcile.Request {
-	grant, ok := obj.(*gatewayapi.ReferenceGrant)
+	grant, ok := gatewayapi.AsReferenceGrant(obj)
 	if !ok {
 		r.Log.Error(
 			errInvalidType,
@@ -190,7 +191,7 @@ func (r *HTTPRouteReconciler) listHTTPRoutesForReferenceGrant(ctx context.Contex
 }
 
 func referenceGrantHasHTTPRouteFrom(obj client.Object) bool {
-	grant, ok := obj.(*gatewayapi.ReferenceGrant)
+	grant, ok := gatewayapi.AsReferenceGrant(obj)
 	if !ok {
 		return false
 	}
@@ -685,16 +686,17 @@ func (r *HTTPRouteReconciler) getHTTPRouteRuleReason(ctx context.Context, httpRo
 						nil
 				}
 
-				referenceGrantList := &gatewayapi.ReferenceGrantList{}
+				referenceGrantList := gatewayapi.NewReferenceGrantList(r.referenceGrantVersion)
 				if err := r.List(ctx, referenceGrantList, client.InNamespace(backendNamespace)); err != nil {
 					return "", "", err
 				}
+				referenceGrants := gatewayapi.ReferenceGrantItems(referenceGrantList)
 				notGrantedMsg := differentNamespaceMsg + " and no ReferenceGrant allowing reference is configured"
-				if len(referenceGrantList.Items) == 0 {
+				if len(referenceGrants) == 0 {
 					return gatewayapi.RouteReasonRefNotPermitted, notGrantedMsg, nil
 				}
 				var isGranted bool
-				for _, grant := range referenceGrantList.Items {
+				for _, grant := range referenceGrants {
 					if isHTTPReferenceGranted(grant.Spec, backendRef, httpRoute.Namespace) {
 						isGranted = true
 						break
@@ -828,15 +830,11 @@ func (r *HTTPRouteReconciler) validateAnnotationPluginReferences(
 }
 
 func (r *HTTPRouteReconciler) listReferenceGrants(ctx context.Context, namespace string) ([]*gatewayapi.ReferenceGrant, error) {
-	referenceGrantList := &gatewayapi.ReferenceGrantList{}
+	referenceGrantList := gatewayapi.NewReferenceGrantList(r.referenceGrantVersion)
 	if err := r.List(ctx, referenceGrantList, client.InNamespace(namespace)); err != nil {
 		return nil, err
 	}
-	grants := make([]*gatewayapi.ReferenceGrant, 0, len(referenceGrantList.Items))
-	for i := range referenceGrantList.Items {
-		grants = append(grants, &referenceGrantList.Items[i])
-	}
-	return grants, nil
+	return gatewayapi.ReferenceGrantItems(referenceGrantList), nil
 }
 
 func (r *HTTPRouteReconciler) isPluginReferenceGranted(

--- a/ingress-controller/internal/controllers/gateway/referencegrant_controller.go
+++ b/ingress-controller/internal/controllers/gateway/referencegrant_controller.go
@@ -18,17 +18,20 @@ package gateway
 
 import (
 	"context"
+	"fmt"
 	"time"
 
 	"github.com/go-logr/logr"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/controllers"
+	ctrlutils "github.com/kong/kong-operator/v2/ingress-controller/internal/controllers/utils"
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/gatewayapi"
 )
 
@@ -41,10 +44,20 @@ type ReferenceGrantReconciler struct {
 	DataplaneClient controllers.DataPlane
 
 	CacheSyncTimeout time.Duration
+
+	// referenceGrantVersion is the ReferenceGrant API GroupVersion (v1 or
+	// v1beta1) served by the cluster, resolved on SetupWithManager call.
+	referenceGrantVersion schema.GroupVersion
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ReferenceGrantReconciler) SetupWithManager(mgr ctrl.Manager) error {
+	gv, ok := ctrlutils.DetectReferenceGrantVersion(mgr.GetRESTMapper())
+	if !ok {
+		return fmt.Errorf("neither v1 nor v1beta1 ReferenceGrant CRD found")
+	}
+	r.referenceGrantVersion = gv
+
 	return ctrl.NewControllerManagedBy(mgr).
 		// set the controller name
 		Named("referencegrant-controller").
@@ -55,7 +68,7 @@ func (r *ReferenceGrantReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			CacheSyncTimeout: r.CacheSyncTimeout,
 		}).
 		// watch Referencegrant objects
-		For(&gatewayapi.ReferenceGrant{}).
+		For(gatewayapi.NewReferenceGrant(r.referenceGrantVersion)).
 		Complete(r)
 }
 
@@ -66,11 +79,12 @@ func (r *ReferenceGrantReconciler) SetupWithManager(mgr ctrl.Manager) error {
 // move the current state of the cluster closer to the desired state.
 func (r *ReferenceGrantReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Result, error) {
 	log := r.Log.WithValues("GatewayV1ReferenceGrant", req.NamespacedName)
-	grant := new(gatewayapi.ReferenceGrant)
-	if err := r.Get(ctx, req.NamespacedName, grant); err != nil {
+	obj := gatewayapi.NewReferenceGrant(r.referenceGrantVersion)
+	if err := r.Get(ctx, req.NamespacedName, obj); err != nil {
 		// if the queued object is no longer present in the proxy cache we need
 		// to ensure that if it was ever added to the cache, it gets removed.
 		if apierrors.IsNotFound(err) {
+			grant, _ := gatewayapi.AsReferenceGrant(obj)
 			debug(log, grant, "Object does not exist, ensuring it is not present in the proxy cache")
 			grant.Namespace = req.Namespace
 			grant.Name = req.Name
@@ -79,6 +93,10 @@ func (r *ReferenceGrantReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 		// for any error other than 404, requeue
 		return ctrl.Result{}, err
+	}
+	grant, ok := gatewayapi.AsReferenceGrant(obj)
+	if !ok {
+		return ctrl.Result{}, fmt.Errorf("unexpected object type %T", obj)
 	}
 
 	debug(log, grant, "Processing referencegrant")

--- a/ingress-controller/internal/controllers/gateway/tcproute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/tcproute_controller.go
@@ -24,7 +24,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/controllers"
 	ctrlutils "github.com/kong/kong-operator/v2/ingress-controller/internal/controllers/utils"
@@ -53,6 +52,9 @@ type TCPRouteReconciler struct {
 	// If it is false, referencing backend in different namespace will be rejected.
 	// It's resolved on SetupWithManager call.
 	enableReferenceGrant bool
+	// referenceGrantVersion is the ReferenceGrant API GroupVersion (v1 or v1beta1)
+	// served by the cluster, resolved on SetupWithManager call.
+	referenceGrantVersion schema.GroupVersion
 
 	// If GatewayNN is set,
 	// only resources managed by the specified Gateway are reconciled.
@@ -66,11 +68,10 @@ func (r *TCPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// when reconciling TCPRoutes.
 	// Once the TCPRouteReconciler is set up without ReferenceGrant, there's no possibility to enable
 	// ReferenceGrant handling again in this reconciler at runtime.
-	r.enableReferenceGrant = ctrlutils.CRDExists(mgr.GetRESTMapper(), schema.GroupVersionResource{
-		Group:    gatewayv1beta1.GroupVersion.Group,
-		Version:  gatewayv1beta1.GroupVersion.Version,
-		Resource: "referencegrants",
-	})
+	r.referenceGrantVersion, r.enableReferenceGrant = ctrlutils.DetectReferenceGrantVersion(mgr.GetRESTMapper())
+	if !r.enableReferenceGrant {
+		r.Log.Error(nil, "Neither v1 nor v1beta1 ReferenceGrant CRD found; cross-namespace references will be rejected")
+	}
 
 	blder := ctrl.NewControllerManagedBy(mgr).
 		Named("tcproute-controller").
@@ -102,7 +103,7 @@ func (r *TCPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		)
 
 	if r.enableReferenceGrant {
-		blder.Watches(&gatewayapi.ReferenceGrant{},
+		blder.Watches(gatewayapi.NewReferenceGrant(r.referenceGrantVersion),
 			handler.EnqueueRequestsFromMapFunc(r.listTCPRoutesForReferenceGrant),
 			builder.WithPredicates(predicate.NewPredicateFuncs(referenceGrantHasTCPRouteFrom)),
 		)
@@ -282,7 +283,7 @@ func (r *TCPRouteReconciler) listTCPRoutesForGateway(ctx context.Context, obj cl
 // listTCPRoutesForReferenceGrant is a watch predicate which finds all TCPRoutes
 // mentioned in a From clause for a ReferenceGrant.
 func (r *TCPRouteReconciler) listTCPRoutesForReferenceGrant(ctx context.Context, obj client.Object) []reconcile.Request {
-	grant, ok := obj.(*gatewayapi.ReferenceGrant)
+	grant, ok := gatewayapi.AsReferenceGrant(obj)
 	if !ok {
 		r.Log.Error(
 			errInvalidType,
@@ -315,7 +316,7 @@ func (r *TCPRouteReconciler) listTCPRoutesForReferenceGrant(ctx context.Context,
 }
 
 func referenceGrantHasTCPRouteFrom(obj client.Object) bool {
-	grant, ok := obj.(*gatewayapi.ReferenceGrant)
+	grant, ok := gatewayapi.AsReferenceGrant(obj)
 	if !ok {
 		return false
 	}
@@ -637,16 +638,17 @@ func (r *TCPRouteReconciler) getTCPRouteRuleReason(ctx context.Context, tcpRoute
 						nil
 				}
 
-				referenceGrantList := &gatewayapi.ReferenceGrantList{}
+				referenceGrantList := gatewayapi.NewReferenceGrantList(r.referenceGrantVersion)
 				if err := r.List(ctx, referenceGrantList, client.InNamespace(backendNamespace)); err != nil {
 					return "", "", err
 				}
+				referenceGrants := gatewayapi.ReferenceGrantItems(referenceGrantList)
 				notGrantedMsg := differentNamespaceMsg + " and no ReferenceGrant allowing reference is configured"
-				if len(referenceGrantList.Items) == 0 {
+				if len(referenceGrants) == 0 {
 					return gatewayapi.RouteReasonRefNotPermitted, notGrantedMsg, nil
 				}
 				var isGranted bool
-				for _, grant := range referenceGrantList.Items {
+				for _, grant := range referenceGrants {
 					if isTCPReferenceGranted(grant.Spec, backendRef, tcpRoute.Namespace) {
 						isGranted = true
 						break

--- a/ingress-controller/internal/controllers/gateway/tlsroute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/tlsroute_controller.go
@@ -24,7 +24,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/controllers"
 	ctrlutils "github.com/kong/kong-operator/v2/ingress-controller/internal/controllers/utils"
@@ -53,6 +52,9 @@ type TLSRouteReconciler struct {
 	// If it is false, referencing backend in different namespace will be rejected.
 	// It's resolved on SetupWithManager call.
 	enableReferenceGrant bool
+	// referenceGrantVersion is the ReferenceGrant API GroupVersion (v1 or v1beta1)
+	// served by the cluster, resolved on SetupWithManager call.
+	referenceGrantVersion schema.GroupVersion
 
 	// If GatewayNN is set,
 	// only resources managed by the specified Gateway are reconciled.
@@ -66,11 +68,10 @@ func (r *TLSRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// when reconciling TLSRoutes.
 	// Once the TLSRouteReconciler is set up without ReferenceGrant, there's no possibility to enable
 	// ReferenceGrant handling again in this reconciler at runtime.
-	r.enableReferenceGrant = ctrlutils.CRDExists(mgr.GetRESTMapper(), schema.GroupVersionResource{
-		Group:    gatewayv1beta1.GroupVersion.Group,
-		Version:  gatewayv1beta1.GroupVersion.Version,
-		Resource: "referencegrants",
-	})
+	r.referenceGrantVersion, r.enableReferenceGrant = ctrlutils.DetectReferenceGrantVersion(mgr.GetRESTMapper())
+	if !r.enableReferenceGrant {
+		r.Log.Error(nil, "Neither v1 nor v1beta1 ReferenceGrant CRD found; cross-namespace references will be rejected")
+	}
 
 	blder := ctrl.NewControllerManagedBy(mgr).
 		Named("tlsroute-controller").
@@ -98,7 +99,7 @@ func (r *TLSRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		)
 
 	if r.enableReferenceGrant {
-		blder.Watches(&gatewayapi.ReferenceGrant{},
+		blder.Watches(gatewayapi.NewReferenceGrant(r.referenceGrantVersion),
 			handler.EnqueueRequestsFromMapFunc(r.listTLSRoutesForReferenceGrant),
 			builder.WithPredicates(predicate.NewPredicateFuncs(referenceGrantHasTLSRouteFrom)),
 		)
@@ -278,7 +279,7 @@ func (r *TLSRouteReconciler) listTLSRoutesForGateway(ctx context.Context, obj cl
 // listTLSRoutesForReferenceGrant is a watch predicate which finds all TLSRoutes
 // mentioned in a From clause for a ReferenceGrant.
 func (r *TLSRouteReconciler) listTLSRoutesForReferenceGrant(ctx context.Context, obj client.Object) []reconcile.Request {
-	grant, ok := obj.(*gatewayapi.ReferenceGrant)
+	grant, ok := gatewayapi.AsReferenceGrant(obj)
 	if !ok {
 		r.Log.Error(
 			errInvalidType,
@@ -311,7 +312,7 @@ func (r *TLSRouteReconciler) listTLSRoutesForReferenceGrant(ctx context.Context,
 }
 
 func referenceGrantHasTLSRouteFrom(obj client.Object) bool {
-	grant, ok := obj.(*gatewayapi.ReferenceGrant)
+	grant, ok := gatewayapi.AsReferenceGrant(obj)
 	if !ok {
 		return false
 	}
@@ -652,16 +653,17 @@ func (r *TLSRouteReconciler) getTLSRouteRuleReason(ctx context.Context, tlsRoute
 						nil
 				}
 
-				referenceGrantList := &gatewayapi.ReferenceGrantList{}
+				referenceGrantList := gatewayapi.NewReferenceGrantList(r.referenceGrantVersion)
 				if err := r.List(ctx, referenceGrantList, client.InNamespace(backendNamespace)); err != nil {
 					return "", "", err
 				}
+				referenceGrants := gatewayapi.ReferenceGrantItems(referenceGrantList)
 				notGrantedMsg := differentNamespaceMsg + " and no ReferenceGrant allowing reference is configured"
-				if len(referenceGrantList.Items) == 0 {
+				if len(referenceGrants) == 0 {
 					return gatewayapi.RouteReasonRefNotPermitted, notGrantedMsg, nil
 				}
 				var isGranted bool
-				for _, grant := range referenceGrantList.Items {
+				for _, grant := range referenceGrants {
 					if isTLSReferenceGranted(grant.Spec, backendRef, tlsRoute.Namespace) {
 						isGranted = true
 						break

--- a/ingress-controller/internal/controllers/gateway/udproute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/udproute_controller.go
@@ -24,7 +24,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/controllers"
 	ctrlutils "github.com/kong/kong-operator/v2/ingress-controller/internal/controllers/utils"
@@ -53,6 +52,9 @@ type UDPRouteReconciler struct {
 	// If it is false, referencing backend in different namespace will be rejected.
 	// It's resolved on SetupWithManager call.
 	enableReferenceGrant bool
+	// referenceGrantVersion is the ReferenceGrant API GroupVersion (v1 or v1beta1)
+	// served by the cluster, resolved on SetupWithManager call.
+	referenceGrantVersion schema.GroupVersion
 
 	// If GatewayNN is set,
 	// only resources managed by the specified Gateway are reconciled.
@@ -66,11 +68,10 @@ func (r *UDPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// when reconciling UDPRoutes.
 	// Once the UDPRouteReconciler is set up without ReferenceGrant, there's no possibility to enable
 	// ReferenceGrant handling again in this reconciler at runtime.
-	r.enableReferenceGrant = ctrlutils.CRDExists(mgr.GetRESTMapper(), schema.GroupVersionResource{
-		Group:    gatewayv1beta1.GroupVersion.Group,
-		Version:  gatewayv1beta1.GroupVersion.Version,
-		Resource: "referencegrants",
-	})
+	r.referenceGrantVersion, r.enableReferenceGrant = ctrlutils.DetectReferenceGrantVersion(mgr.GetRESTMapper())
+	if !r.enableReferenceGrant {
+		r.Log.Error(nil, "Neither v1 nor v1beta1 ReferenceGrant CRD found; cross-namespace references will be rejected")
+	}
 
 	blder := ctrl.NewControllerManagedBy(mgr).
 		Named("udproute-controller").
@@ -102,7 +103,7 @@ func (r *UDPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		)
 
 	if r.enableReferenceGrant {
-		blder.Watches(&gatewayapi.ReferenceGrant{},
+		blder.Watches(gatewayapi.NewReferenceGrant(r.referenceGrantVersion),
 			handler.EnqueueRequestsFromMapFunc(r.listUDPRoutesForReferenceGrant),
 			builder.WithPredicates(predicate.NewPredicateFuncs(referenceGrantHasUDPRouteFrom)),
 		)
@@ -282,7 +283,7 @@ func (r *UDPRouteReconciler) listUDPRoutesForGateway(ctx context.Context, obj cl
 // listUDPRoutesForReferenceGrant is a watch predicate which finds all UDPRoutes
 // mentioned in a From clause for a ReferenceGrant.
 func (r *UDPRouteReconciler) listUDPRoutesForReferenceGrant(ctx context.Context, obj client.Object) []reconcile.Request {
-	grant, ok := obj.(*gatewayapi.ReferenceGrant)
+	grant, ok := gatewayapi.AsReferenceGrant(obj)
 	if !ok {
 		r.Log.Error(
 			errInvalidType,
@@ -315,7 +316,7 @@ func (r *UDPRouteReconciler) listUDPRoutesForReferenceGrant(ctx context.Context,
 }
 
 func referenceGrantHasUDPRouteFrom(obj client.Object) bool {
-	grant, ok := obj.(*gatewayapi.ReferenceGrant)
+	grant, ok := gatewayapi.AsReferenceGrant(obj)
 	if !ok {
 		return false
 	}
@@ -632,16 +633,17 @@ func (r *UDPRouteReconciler) getUDPRouteRuleReason(ctx context.Context, udpRoute
 						nil
 				}
 
-				referenceGrantList := &gatewayapi.ReferenceGrantList{}
+				referenceGrantList := gatewayapi.NewReferenceGrantList(r.referenceGrantVersion)
 				if err := r.List(ctx, referenceGrantList, client.InNamespace(backendNamespace)); err != nil {
 					return "", "", err
 				}
+				referenceGrants := gatewayapi.ReferenceGrantItems(referenceGrantList)
 				notGrantedMsg := differentNamespaceMsg + " and no ReferenceGrant allowing reference is configured"
-				if len(referenceGrantList.Items) == 0 {
+				if len(referenceGrants) == 0 {
 					return gatewayapi.RouteReasonRefNotPermitted, notGrantedMsg, nil
 				}
 				var isGranted bool
-				for _, grant := range referenceGrantList.Items {
+				for _, grant := range referenceGrants {
 					if isUDPReferenceGranted(grant.Spec, backendRef, udpRoute.Namespace) {
 						isGranted = true
 						break

--- a/ingress-controller/internal/controllers/utils/ingress_predicates.go
+++ b/ingress-controller/internal/controllers/utils/ingress_predicates.go
@@ -7,6 +7,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	configurationv1alpha1 "github.com/kong/kong-operator/v2/api/configuration/v1alpha1"
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/annotations"
@@ -90,4 +92,20 @@ func CRDExists(restMapper meta.RESTMapper, gvr schema.GroupVersionResource) bool
 		}
 	}
 	return false
+}
+
+// DetectReferenceGrantVersion returns the GroupVersion of whichever ReferenceGrant
+// API version is served by the cluster, preferring v1 and falling back to v1beta1
+// (ReferenceGrant was promoted from v1beta1 to v1 in gateway-api v1.5.0; older
+// clusters only serve v1beta1). ok is false if neither is installed.
+func DetectReferenceGrantVersion(restMapper meta.RESTMapper) (gv schema.GroupVersion, ok bool) {
+	v1GV := schema.GroupVersion(gatewayv1.GroupVersion)
+	if CRDExists(restMapper, v1GV.WithResource("referencegrants")) {
+		return v1GV, true
+	}
+	v1beta1GV := schema.GroupVersion(gatewayv1beta1.GroupVersion)
+	if CRDExists(restMapper, v1beta1GV.WithResource("referencegrants")) {
+		return v1beta1GV, true
+	}
+	return schema.GroupVersion{}, false
 }

--- a/ingress-controller/internal/controllers/utils/referencegrant_version_test.go
+++ b/ingress-controller/internal/controllers/utils/referencegrant_version_test.go
@@ -1,0 +1,66 @@
+package utils
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+var (
+	v1GroupVersion      = schema.GroupVersion(gatewayv1.GroupVersion)
+	v1beta1GroupVersion = schema.GroupVersion(gatewayv1beta1.GroupVersion)
+)
+
+func restMapperWithReferenceGrant(gvs ...schema.GroupVersion) meta.RESTMapper {
+	mapper := meta.NewDefaultRESTMapper(gvs)
+	for _, gv := range gvs {
+		mapper.Add(gv.WithKind("ReferenceGrant"), meta.RESTScopeNamespace)
+	}
+	return mapper
+}
+
+func TestDetectReferenceGrantVersion(t *testing.T) {
+	tests := []struct {
+		name       string
+		mapper     meta.RESTMapper
+		expectedGV schema.GroupVersion
+		expectedOK bool
+	}{
+		{
+			name:       "only v1 is served",
+			mapper:     restMapperWithReferenceGrant(v1GroupVersion),
+			expectedGV: v1GroupVersion,
+			expectedOK: true,
+		},
+		{
+			name:       "only v1beta1 is served",
+			mapper:     restMapperWithReferenceGrant(v1beta1GroupVersion),
+			expectedGV: v1beta1GroupVersion,
+			expectedOK: true,
+		},
+		{
+			name:       "both versions served, v1 is preferred",
+			mapper:     restMapperWithReferenceGrant(v1GroupVersion, v1beta1GroupVersion),
+			expectedGV: v1GroupVersion,
+			expectedOK: true,
+		},
+		{
+			name:       "neither version served",
+			mapper:     restMapperWithReferenceGrant(),
+			expectedGV: schema.GroupVersion{},
+			expectedOK: false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			gv, ok := DetectReferenceGrantVersion(tc.mapper)
+			require.Equal(t, tc.expectedOK, ok)
+			require.Equal(t, tc.expectedGV, gv)
+		})
+	}
+}

--- a/ingress-controller/internal/gatewayapi/referencegrant_version.go
+++ b/ingress-controller/internal/gatewayapi/referencegrant_version.go
@@ -1,0 +1,69 @@
+package gatewayapi
+
+import (
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+// v1beta1GroupVersion is gatewayv1beta1.GroupVersion converted to
+// schema.GroupVersion for comparison purposes.
+var v1beta1GroupVersion = schema.GroupVersion(gatewayv1beta1.GroupVersion)
+
+// NewReferenceGrant returns an empty ReferenceGrant object of the given API
+// version. Any GroupVersion other than v1beta1 (including the zero value)
+// resolves to v1.
+func NewReferenceGrant(gv schema.GroupVersion) client.Object {
+	if gv == v1beta1GroupVersion {
+		return &gatewayv1beta1.ReferenceGrant{}
+	}
+	return &ReferenceGrant{}
+}
+
+// NewReferenceGrantList returns an empty ReferenceGrantList object of the
+// given API version. Any GroupVersion other than v1beta1 (including the zero
+// value) resolves to v1.
+func NewReferenceGrantList(gv schema.GroupVersion) client.ObjectList {
+	if gv == v1beta1GroupVersion {
+		return &gatewayv1beta1.ReferenceGrantList{}
+	}
+	return &ReferenceGrantList{}
+}
+
+// AsReferenceGrant normalizes a ReferenceGrant received from a watch or
+// predicate (which may be v1 or v1beta1) into the common v1 type. This
+// conversion is safe because v1beta1.ReferenceGrant is defined as
+// `type ReferenceGrant v1.ReferenceGrant` - an identical underlying type
+// under a distinct name.
+func AsReferenceGrant(obj client.Object) (*ReferenceGrant, bool) {
+	switch rg := obj.(type) {
+	case *ReferenceGrant:
+		return rg, true
+	case *gatewayv1beta1.ReferenceGrant:
+		return (*ReferenceGrant)(rg), true
+	default:
+		return nil, false
+	}
+}
+
+// ReferenceGrantItems normalizes every item in a v1 or v1beta1
+// ReferenceGrantList into the common v1 type, the same way AsReferenceGrant
+// does for a single object.
+func ReferenceGrantItems(list client.ObjectList) []*ReferenceGrant {
+	switch l := list.(type) {
+	case *ReferenceGrantList:
+		grants := make([]*ReferenceGrant, len(l.Items))
+		for i := range l.Items {
+			grants[i] = &l.Items[i]
+		}
+		return grants
+	case *gatewayv1beta1.ReferenceGrantList:
+		grants := make([]*ReferenceGrant, len(l.Items))
+		for i := range l.Items {
+			grants[i] = (*ReferenceGrant)(&l.Items[i])
+		}
+		return grants
+	default:
+		return nil
+	}
+}

--- a/ingress-controller/internal/gatewayapi/referencegrant_version_test.go
+++ b/ingress-controller/internal/gatewayapi/referencegrant_version_test.go
@@ -1,0 +1,60 @@
+package gatewayapi
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
+)
+
+var (
+	testV1GroupVersion      = schema.GroupVersion(gatewayv1.GroupVersion)
+	testV1beta1GroupVersion = schema.GroupVersion(gatewayv1beta1.GroupVersion)
+)
+
+func TestNewReferenceGrant(t *testing.T) {
+	require.IsType(t, &gatewayv1beta1.ReferenceGrant{}, NewReferenceGrant(testV1beta1GroupVersion))
+	require.IsType(t, &ReferenceGrant{}, NewReferenceGrant(testV1GroupVersion))
+	require.IsType(t, &ReferenceGrant{}, NewReferenceGrant(schema.GroupVersion{}), "zero value must default to v1")
+}
+
+func TestNewReferenceGrantList(t *testing.T) {
+	require.IsType(t, &gatewayv1beta1.ReferenceGrantList{}, NewReferenceGrantList(testV1beta1GroupVersion))
+	require.IsType(t, &ReferenceGrantList{}, NewReferenceGrantList(testV1GroupVersion))
+	require.IsType(t, &ReferenceGrantList{}, NewReferenceGrantList(schema.GroupVersion{}), "zero value must default to v1")
+}
+
+func TestAsReferenceGrant(t *testing.T) {
+	v1Grant := &ReferenceGrant{Spec: ReferenceGrantSpec{From: []ReferenceGrantFrom{{Kind: "HTTPRoute"}}}}
+	got, ok := AsReferenceGrant(v1Grant)
+	require.True(t, ok)
+	require.Same(t, v1Grant, got)
+
+	v1beta1Grant := &gatewayv1beta1.ReferenceGrant{Spec: ReferenceGrantSpec{From: []ReferenceGrantFrom{{Kind: "TCPRoute"}}}}
+	got, ok = AsReferenceGrant(v1beta1Grant)
+	require.True(t, ok)
+	require.Equal(t, "TCPRoute", string(got.Spec.From[0].Kind))
+
+	_, ok = AsReferenceGrant(&Gateway{})
+	require.False(t, ok)
+}
+
+func TestReferenceGrantItems(t *testing.T) {
+	v1List := &ReferenceGrantList{Items: []ReferenceGrant{
+		{Spec: ReferenceGrantSpec{From: []ReferenceGrantFrom{{Kind: "HTTPRoute"}}}},
+	}}
+	items := ReferenceGrantItems(v1List)
+	require.Len(t, items, 1)
+	require.Equal(t, "HTTPRoute", string(items[0].Spec.From[0].Kind))
+
+	v1beta1List := &gatewayv1beta1.ReferenceGrantList{Items: []gatewayv1beta1.ReferenceGrant{
+		{Spec: ReferenceGrantSpec{From: []ReferenceGrantFrom{{Kind: "TCPRoute"}}}},
+	}}
+	items = ReferenceGrantItems(v1beta1List)
+	require.Len(t, items, 1)
+	require.Equal(t, "TCPRoute", string(items[0].Spec.From[0].Kind))
+
+	require.Nil(t, ReferenceGrantItems(&GatewayList{}))
+}

--- a/ingress-controller/internal/manager/controllerdef.go
+++ b/ingress-controller/internal/manager/controllerdef.go
@@ -9,7 +9,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 	gatewayv1alpha3 "sigs.k8s.io/gateway-api/apis/v1alpha3"
-	gatewayv1beta1 "sigs.k8s.io/gateway-api/apis/v1beta1"
 
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/controllers"
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/controllers/configuration"
@@ -67,6 +66,15 @@ func setupControllers(
 	kongAdminAPIEndpointsNotifier configuration.EndpointsNotifier,
 	adminAPIsDiscoverer configuration.AdminAPIsDiscoverer,
 ) []ControllerDef {
+	// Resolve which ReferenceGrant API version (v1 or v1beta1) is served by the
+	// cluster, so the ReferenceGrant DynamicCRDController waits on the version
+	// that's actually installed. Default to v1 (the GA version) as the
+	// wait-target if the CRD isn't installed yet at all.
+	referenceGrantGV, referenceGrantFound := utils.DetectReferenceGrantVersion(mgr.GetRESTMapper())
+	if !referenceGrantFound {
+		referenceGrantGV = schema.GroupVersion(gatewayv1.GroupVersion)
+	}
+
 	controllers := []ControllerDef{
 		// ---------------------------------------------------------------------------
 		// Kong Gateway Admin API Service discovery
@@ -348,8 +356,8 @@ func setupControllers(
 				Log:              ctrl.LoggerFrom(ctx).WithName("controllers").WithName("Dynamic/ReferenceGrant"),
 				CacheSyncTimeout: c.CacheSyncTimeout,
 				RequiredCRDs: append(baseGatewayCRDs(), schema.GroupVersionResource{
-					Group:    gatewayv1beta1.GroupVersion.Group,
-					Version:  gatewayv1beta1.GroupVersion.Version,
+					Group:    referenceGrantGV.Group,
+					Version:  referenceGrantGV.Version,
 					Resource: "referencegrants",
 				}),
 				Controller: &gateway.ReferenceGrantReconciler{

--- a/modules/manager/controller_setup.go
+++ b/modules/manager/controller_setup.go
@@ -213,7 +213,27 @@ func SetupCacheIndexes(ctx context.Context, mgr manager.Manager, cfg Config) err
 
 type requiredCRDCheck struct {
 	condition bool
-	gvrs      []schema.GroupVersionResource
+	// gvrs must all exist (AND semantics).
+	gvrs []schema.GroupVersionResource
+	// anyOfGVRs: for each inner slice, at least one GVR must exist (OR semantics),
+	// e.g. to accept either the v1 or v1beta1 version of a resource.
+	anyOfGVRs [][]schema.GroupVersionResource
+}
+
+// referenceGrantAnyOfGVRs accepts either the v1 (GA since gateway-api v1.5.0)
+// or v1beta1 version of the ReferenceGrant CRD - older clusters may only
+// serve v1beta1.
+var referenceGrantAnyOfGVRs = []schema.GroupVersionResource{
+	{
+		Group:    gatewayv1.GroupVersion.Group,
+		Version:  gatewayv1.GroupVersion.Version,
+		Resource: "referencegrants",
+	},
+	{
+		Group:    gatewayv1beta1.GroupVersion.Group,
+		Version:  gatewayv1beta1.GroupVersion.Version,
+		Resource: "referencegrants",
+	},
 }
 
 // requiredCRDChecks prevents controller-runtime spamming in logs about failing
@@ -265,11 +285,6 @@ func requiredCRDChecks(c *Config) []requiredCRDCheck {
 				{
 					Group:    gatewayv1beta1.GroupVersion.Group,
 					Version:  gatewayv1beta1.GroupVersion.Version,
-					Resource: "referencegrants",
-				},
-				{
-					Group:    gatewayv1beta1.GroupVersion.Group,
-					Version:  gatewayv1beta1.GroupVersion.Version,
 					Resource: "httproutes",
 				},
 				gwtypes.GatewayConfigurationGVR(),
@@ -279,17 +294,14 @@ func requiredCRDChecks(c *Config) []requiredCRDCheck {
 					Resource: "kongreferencegrants",
 				},
 			},
+			anyOfGVRs: [][]schema.GroupVersionResource{referenceGrantAnyOfGVRs},
 		},
 		{
 			condition: c.AIGatewayControllerEnabled,
 			gvrs: []schema.GroupVersionResource{
 				operatorv1alpha1.AIGatewayGVR(),
-				{
-					Group:    gatewayv1beta1.GroupVersion.Group,
-					Version:  gatewayv1beta1.GroupVersion.Version,
-					Resource: "referencegrants",
-				},
 			},
+			anyOfGVRs: [][]schema.GroupVersionResource{referenceGrantAnyOfGVRs},
 		},
 		{
 			condition: c.FeatureGates.Enabled(FeatureGateMCPServer),
@@ -305,12 +317,8 @@ func requiredCRDChecks(c *Config) []requiredCRDCheck {
 			condition: c.KongPluginInstallationControllerEnabled,
 			gvrs: []schema.GroupVersionResource{
 				operatorv1alpha1.KongPluginInstallationGVR(),
-				{
-					Group:    gatewayv1beta1.GroupVersion.Group,
-					Version:  gatewayv1beta1.GroupVersion.Version,
-					Resource: "referencegrants",
-				},
 			},
+			anyOfGVRs: [][]schema.GroupVersionResource{referenceGrantAnyOfGVRs},
 		},
 		{
 			condition: c.ControlPlaneExtensionsControllerEnabled,
@@ -532,6 +540,23 @@ func ensureRequiredCRDs(c *Config, checker crdExistenceChecker) error {
 				return err
 			} else if !ok {
 				return fmt.Errorf("missing a required CRD: %v", gvr)
+			}
+		}
+
+		for _, gvrGroup := range check.anyOfGVRs {
+			found := false
+			for _, gvr := range gvrGroup {
+				ok, err := checker.CRDExists(gvr)
+				if err != nil {
+					return err
+				}
+				if ok {
+					found = true
+					break
+				}
+			}
+			if !found {
+				return fmt.Errorf("missing a required CRD: one of %v", gvrGroup)
 			}
 		}
 	}


### PR DESCRIPTION

**What this PR does / why we need it**:

Support watching both `v1` and `v1beta1` versions of `ReferenceGrant`s in controllers for on-prem gateway.

**Which issue this PR fixes**

Fixes #5087 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
