### PR TITLE
chore: bump Kong Gateway to 3.15 and adjust test suites

### DIFF
--- a/.github/workflows/__conformance_tests.yaml
+++ b/.github/workflows/__conformance_tests.yaml
@@ -47,6 +47,11 @@ jobs:
       with:
         install: false
 
+    - uses: Kong/kong-license@ddccb487a0b319cef85f348b16a1ad2b6d9c1df7 # master @ 20260529
+      id: license
+      with:
+        op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+
     - run: echo "GO_MOD_CACHE=$(go env GOMODCACHE)" >> $GITHUB_ENV
     - run: echo "GO_BUILD_CACHE=$(go env GOCACHE)" >> $GITHUB_ENV
 
@@ -95,6 +100,7 @@ jobs:
         KONG_TEST_KONNECT_ACCESS_TOKEN: ${{ matrix.gateway-type == 'hybrid' && secrets.KONG_TEST_KONNECT_ACCESS_TOKEN || '' }}
         KONG_TEST_KONNECT_SERVER_URL: ${{ matrix.gateway-type == 'hybrid' && 'us.api.konghq.tech' || '' }}
         KONG_TEST_FORCE_CLEANUP: "true"
+        KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
 
     - name: upload diagnostics
       if: ${{ always() }}

--- a/.github/workflows/__e2e_chainsaw_tests.yaml
+++ b/.github/workflows/__e2e_chainsaw_tests.yaml
@@ -55,6 +55,11 @@ jobs:
       with:
         install_args: github:Kong/kubernetes-testing-framework aqua:helm/helm kind
 
+    - uses: Kong/kong-license@ddccb487a0b319cef85f348b16a1ad2b6d9c1df7 # master @ 20260529
+      id: license
+      with:
+        op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+
     - uses: ./.github/actions/bump-inotify
 
     - name: Create k8s KinD Cluster with ktf
@@ -93,6 +98,7 @@ jobs:
     - name: Apply chainsaw suite prerequisites
       env:
         SUITE: ${{ matrix.suite }}
+        KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
       run: make test.e2e.chainsaw.prereq DIRNAME="$SUITE"
 
     - name: run chainsaw e2e tests

--- a/.github/workflows/__e2e_tests.yaml
+++ b/.github/workflows/__e2e_tests.yaml
@@ -41,6 +41,11 @@ jobs:
       with:
         install: false
 
+    - uses: Kong/kong-license@ddccb487a0b319cef85f348b16a1ad2b6d9c1df7 # master @ 20260529
+      id: license
+      with:
+        op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+
     - run: echo "GO_MOD_CACHE=$(go env GOMODCACHE)" >> $GITHUB_ENV
     - run: echo "GO_BUILD_CACHE=$(go env GOCACHE)" >> $GITHUB_ENV
 
@@ -84,6 +89,7 @@ jobs:
       env:
         KONG_TEST_KONG_OPERATOR_IMAGE_LOAD: kong-operator:e2e-${{ github.sha }}
         GOTESTSUM_JUNITFILE: "e2e-tests.xml"
+        KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
         # This is needed for ktf to find latest releases of addons.
         # This could be changed so that ktf addons have their versions pinned
         # in the test Makefile instead.

--- a/.github/workflows/__integration_tests.yaml
+++ b/.github/workflows/__integration_tests.yaml
@@ -33,13 +33,16 @@ jobs:
   integration-tests:
     timeout-minutes: ${{ fromJSON(vars.GHA_EXTENDED_TIMEOUT_MINUTES || 60) }}
     runs-on: ubuntu-latest
-    name: ${{ format('{0} {1} - {2}', matrix.suite, matrix.router_flavor, inputs.cluster_version) }}
+    name: ${{ format('{0} {1} {2} - {3}', matrix.suite, matrix.kong-variant, matrix.router_flavor, inputs.cluster_version) }}
     strategy:
       matrix:
         include:
           - suite: ko
           - suite: konnect
           - suite: kic
+            kong-variant: enterprise
+          - suite: kic
+            kong-variant: oss
           - suite: bluegreen
           - suite: validatingwebhook
             router_flavor: traditional_compatible
@@ -60,6 +63,34 @@ jobs:
     - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
       with:
         install: false
+
+    - uses: Kong/kong-license@ddccb487a0b319cef85f348b16a1ad2b6d9c1df7 # master @ 20260529
+      id: license
+      with:
+        op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+
+    - name: set kong oss version
+      if: ${{ matrix.suite == 'kic' && matrix.kong-variant == 'oss' && inputs.kong-image-repo == '' }}
+      run: |
+        echo "TEST_KONG_IMAGE=kong" >> $GITHUB_ENV
+        echo "TEST_KONG_TAG=$(yq -ojson -r '.integration.kong-oss' < test/test_dependencies.yaml )" >> $GITHUB_ENV
+
+    - name: set kong ee version
+      if: ${{ matrix.suite == 'kic' && matrix.kong-variant == 'enterprise' && inputs.kong-image-repo == '' }}
+      run: |
+        echo "TEST_KONG_IMAGE=kong/kong-gateway" >> $GITHUB_ENV
+        echo "TEST_KONG_TAG=$(yq -ojson -r '.integration.kong-ee' < test/test_dependencies.yaml )" >> $GITHUB_ENV
+
+    - name: set kong image override
+      if: ${{ inputs.kong-image-repo != '' }}
+      run: |
+        echo "TEST_KONG_IMAGE=${{ inputs.kong-image-repo }}" >> $GITHUB_ENV
+        echo "TEST_KONG_TAG=${{ inputs.kong-image-tag }}" >> $GITHUB_ENV
+
+    - name: set kong effective version
+      if: ${{ inputs.kong-effective-version != '' }}
+      run: |
+        echo "TEST_KONG_EFFECTIVE_VERSION=${{ inputs.kong-effective-version }}" >> $GITHUB_ENV
 
     - run: echo "GO_MOD_CACHE=$(go env GOMODCACHE)" >> $GITHUB_ENV
     - run: echo "GO_BUILD_CACHE=$(go env GOCACHE)" >> $GITHUB_ENV
@@ -111,9 +142,10 @@ jobs:
     - name: start tcpdump capture
       env:
         SUITE: ${{ matrix.suite }}
+        KONG_VARIANT: ${{ matrix.kong-variant }}
         ROUTER_FLAVOR: ${{ matrix.router_flavor }}
       run: |
-        sudo tcpdump -i any 'dst port 443' -w "/tmp/capture-$SUITE-$ROUTER_FLAVOR.pcap" &
+        sudo tcpdump -i any 'dst port 443' -w "/tmp/capture-$SUITE-$KONG_VARIANT-$ROUTER_FLAVOR.pcap" &
         echo $! > /tmp/tcpdump.pid
 
     - uses: ./.github/actions/bump-inotify
@@ -124,13 +156,11 @@ jobs:
         SUITE: ${{ matrix.suite }}
         KONG_PLUGIN_IMAGE_REGISTRY_CREDENTIALS: ${{ secrets.KONG_PLUGIN_IMAGE_REGISTRY_CREDENTIALS }}
         KONG_CONTROLLER_OUT: stdout
-        GOTESTSUM_JUNITFILE: "integration-tests-${{ matrix.suite }}-${{ matrix.router_flavor }}.xml"
+        GOTESTSUM_JUNITFILE: "integration-tests-${{ matrix.suite }}-${{ matrix.kong-variant }}-${{ matrix.router_flavor }}.xml"
         KONG_TEST_KONNECT_ACCESS_TOKEN: ${{ secrets.KONG_TEST_KONNECT_ACCESS_TOKEN }}
         KONG_TEST_KONNECT_SERVER_URL: us.api.konghq.tech
+        KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
         KONG_CLUSTER_VERSION: ${{ inputs.cluster_version }}
-        TEST_KONG_IMAGE: ${{ inputs.kong-image-repo }}
-        TEST_KONG_TAG: ${{ inputs.kong-image-tag }}
-        TEST_KONG_EFFECTIVE_VERSION: ${{ inputs.kong-effective-version }}
         # This is needed for ktf to find latest releases of addons.
         # This could be changed so that ktf addons have their versions pinned
         # in the test Makefile instead.
@@ -147,27 +177,27 @@ jobs:
       if: failure()
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: pcap-integration-${{ matrix.suite }}-${{ matrix.router_flavor }}
-        path: /tmp/capture-${{ matrix.suite }}-${{ matrix.router_flavor }}.pcap
+        name: pcap-integration-${{ matrix.suite }}-${{ matrix.kong-variant }}-${{ matrix.router_flavor }}
+        path: /tmp/capture-${{ matrix.suite }}-${{ matrix.kong-variant }}-${{ matrix.router_flavor }}.pcap
         if-no-files-found: ignore
 
     - name: upload diagnostics
       if: always()
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: diagnostics-integration-${{ matrix.suite }}
+        name: diagnostics-integration-${{ matrix.suite }}-${{ matrix.kong-variant }}
         path: /tmp/ktf-diag*
         if-no-files-found: ignore
 
     - name: collect test coverage
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: ${{ matrix.suite }}-coverage-integration
-        path: coverage.integration.${{ matrix.suite }}-${{ matrix.router_flavor }}.out
+        name: ${{ matrix.suite }}-${{ matrix.kong-variant }}-coverage-integration
+        path: coverage.integration.${{ matrix.suite }}-${{ matrix.kong-variant }}-${{ matrix.router_flavor }}.out
 
     - name: collect test report
       if: ${{ always() }}
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
-        name: ${{ matrix.suite }}-tests-report-integration
-        path: integration-tests-${{ matrix.suite }}-${{ matrix.router_flavor }}.xml
+        name: ${{ matrix.suite }}-${{ matrix.kong-variant }}-tests-report-integration
+        path: integration-tests-${{ matrix.suite }}-${{ matrix.kong-variant }}-${{ matrix.router_flavor }}.xml

--- a/.github/workflows/__kongintegration_tests.yaml
+++ b/.github/workflows/__kongintegration_tests.yaml
@@ -132,7 +132,6 @@ jobs:
           KONG_TEST_KONNECT_SERVER_URL: us.api.konghq.tech
           KONG_TEST_KONNECT_ACCESS_TOKEN: ${{ secrets.KONG_TEST_KONNECT_ACCESS_TOKEN }}
           KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
-          TEST_KONG_ENTERPRISE: ${{ matrix.enterprise }}
 
       - name: collect test coverage
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -85,6 +85,10 @@
 - Gateway: Support watching both `v1` and `v1beta1` versions of `ReferenceGrant`
   to ensure compatability with gateway API 1.3 and 1.4.
   [#5091](https://github.com/Kong/kong-operator/pull/5091)
+- Admission webhook maintains its semantic to provide best effort validation
+  to not block potentially valid `Ingress` or `HTTPRoute` resources when the
+  webhook is not able to reach Kong Gateway.
+  [#5095](https://github.com/Kong/kong-operator/pull/5095)
 
 ### Added
   
@@ -146,6 +150,8 @@
   and its controller. Use `AIGateway*` CRDs in `konnect.konghq.com/v1alpha1`
   instead.
   [#5114](https://github.com/Kong/kong-operator/pull/5114)
+- Gateway: update the default DataPlane image to `kong/kong-gateway:3.15`.
+  [#5095](https://github.com/Kong/kong-operator/pull/5095)
 
 ## [v2.3.0-rc.2]
 

--- a/config/samples/dataplane-with-nodeport.yaml
+++ b/config/samples/dataplane-with-nodeport.yaml
@@ -9,7 +9,7 @@ spec:
         containers:
         - name: proxy
           # renovate: datasource=docker versioning=docker
-          image: kong/kong-gateway:3.14
+          image: kong/kong-gateway:3.15
           env:
           - name: KONG_LOG_LEVEL
             value: debug

--- a/config/samples/gateway-hybrid-static-naming-with-kongconsumer.yaml
+++ b/config/samples/gateway-hybrid-static-naming-with-kongconsumer.yaml
@@ -23,7 +23,7 @@ spec:
           containers:
           - name: proxy
             # renovate: datasource=docker versioning=docker
-            image: kong/kong-gateway:3.14
+            image: kong/kong-gateway:3.15
 ---
 kind: GatewayClass
 apiVersion: gateway.networking.k8s.io/v1

--- a/config/samples/gateway-hybrid-tls.yaml
+++ b/config/samples/gateway-hybrid-tls.yaml
@@ -32,7 +32,7 @@ spec:
         spec:
           containers:
             # renovate: datasource=docker versioning=docker
-            - image: kong/kong-gateway:3.14
+            - image: kong/kong-gateway:3.15
               name: proxy
   konnect:
     authRef:

--- a/config/samples/gateway-hybrid-with-gatewayconfiguration-and-per-gateway-infrastructure_v2.yaml
+++ b/config/samples/gateway-hybrid-with-gatewayconfiguration-and-per-gateway-infrastructure_v2.yaml
@@ -34,7 +34,7 @@ spec:
           containers:
             - name: proxy
               # renovate: datasource=docker versioning=docker
-              image: kong/kong-gateway:3.14
+              image: kong/kong-gateway:3.15
               readinessProbe:
                 initialDelaySeconds: 1
                 periodSeconds: 1

--- a/config/samples/gateway-hybrid-with-httproute.yaml
+++ b/config/samples/gateway-hybrid-with-httproute.yaml
@@ -25,7 +25,7 @@ spec:
           containers:
           - name: proxy
             # renovate: datasource=docker versioning=docker
-            image: kong/kong-gateway:3.14
+            image: kong/kong-gateway:3.15
             readinessProbe:
               initialDelaySeconds: 1
               periodSeconds: 1

--- a/config/samples/gateway-hybrid-xns-konnectapiauth-gwconfig.yaml
+++ b/config/samples/gateway-hybrid-xns-konnectapiauth-gwconfig.yaml
@@ -36,7 +36,7 @@ spec:
           containers:
           - name: proxy
             # renovate: datasource=docker versioning=docker
-            image: kong/kong-gateway:3.14
+            image: kong/kong-gateway:3.15
 ---
 kind: GatewayClass
 apiVersion: gateway.networking.k8s.io/v1

--- a/config/samples/gateway-hybrid-xns-konnectapiauth.yaml
+++ b/config/samples/gateway-hybrid-xns-konnectapiauth.yaml
@@ -36,7 +36,7 @@ spec:
           containers:
           - name: proxy
             # renovate: datasource=docker versioning=docker
-            image: kong/kong-gateway:3.14
+            image: kong/kong-gateway:3.15
 ---
 kind: GatewayClass
 apiVersion: gateway.networking.k8s.io/v1

--- a/config/samples/gateway-with-gatewayconfiguration_v2.yaml
+++ b/config/samples/gateway-with-gatewayconfiguration_v2.yaml
@@ -11,7 +11,7 @@ spec:
           containers:
           - name: proxy
             # renovate: datasource=docker versioning=docker
-            image: kong/kong-gateway:3.14
+            image: kong/kong-gateway:3.15
             readinessProbe:
               initialDelaySeconds: 1
               periodSeconds: 1

--- a/config/samples/gateway-with-gatewayconfiguration_with_httproute_v2.yaml
+++ b/config/samples/gateway-with-gatewayconfiguration_with_httproute_v2.yaml
@@ -11,7 +11,7 @@ spec:
           containers:
           - name: proxy
             # renovate: datasource=docker versioning=docker
-            image: kong/kong-gateway:3.14
+            image: kong/kong-gateway:3.15
             readinessProbe:
               initialDelaySeconds: 1
               periodSeconds: 1

--- a/config/samples/gateway-with-infrastructure-labels_v2.yaml
+++ b/config/samples/gateway-with-infrastructure-labels_v2.yaml
@@ -21,7 +21,7 @@ spec:
           containers:
             - name: proxy
               # renovate: datasource=docker versioning=docker
-              image: kong/kong-gateway:3.14
+              image: kong/kong-gateway:3.15
               readinessProbe:
                 initialDelaySeconds: 1
                 periodSeconds: 1

--- a/config/samples/gateway-with-listener-nodeport-in-gatewayconfiguration_v2.yaml
+++ b/config/samples/gateway-with-listener-nodeport-in-gatewayconfiguration_v2.yaml
@@ -11,7 +11,7 @@ spec:
           containers:
           - name: proxy
             # renovate: datasource=docker versioning=docker
-            image: kong/kong-gateway:3.14
+            image: kong/kong-gateway:3.15
             readinessProbe:
               initialDelaySeconds: 1
               periodSeconds: 1

--- a/ingress-controller/internal/admission/validation/gateway/httproute.go
+++ b/ingress-controller/internal/admission/validation/gateway/httproute.go
@@ -11,6 +11,7 @@ import (
 	"github.com/kong/go-kong/kong"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/admission/validation"
 	gatewaycontroller "github.com/kong/kong-operator/v2/ingress-controller/internal/controllers/gateway"
@@ -260,9 +261,11 @@ func validateWithKongGateway(
 			route.Override(logr.Discard(), kongVersion)
 			ok, msg, err := routesValidator.Validate(ctx, &route.Route)
 			if err != nil {
-				return false, fmt.Sprintf("Unable to validate HTTPRoute schema: %s", err.Error())
-			}
-			if !ok {
+				// Validation against the Kong Gateway Admin API is best-effort: a failure here
+				// (e.g. DataPlane with license not yet provisioned) shouldn't block the HTTPRoute.
+				ctrllog.FromContext(ctx).Info(fmt.Sprintf("Unable to validate HTTPRoute schema due to: %s, allowing", err))
+				continue
+			} else if !ok {
 				errMsgs = append(errMsgs, msg)
 			}
 		}

--- a/ingress-controller/internal/admission/validation/ingress/ingress.go
+++ b/ingress-controller/internal/admission/validation/ingress/ingress.go
@@ -9,6 +9,7 @@ import (
 	"github.com/go-logr/logr"
 	"github.com/kong/go-kong/kong"
 	netv1 "k8s.io/api/networking/v1"
+	ctrllog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	configurationv1alpha1 "github.com/kong/kong-operator/v2/api/configuration/v1alpha1"
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/admission/validation"
@@ -44,9 +45,10 @@ func ValidateIngress(
 		// Validate by using feature of Kong Gateway.
 		ok, msg, err := routesValidator.Validate(ctx, &kg)
 		if err != nil {
-			return false, fmt.Sprintf("Unable to validate Ingress schema: %s", err.Error()), nil
-		}
-		if !ok {
+			// Validation against the Kong Gateway Admin API is best-effort: a failure here
+			// (e.g. DataPlane with license not yet provisioned) shouldn't block the Ingress.
+			ctrllog.FromContext(ctx).Info(fmt.Sprintf("Unable to validate Ingress schema due to: %s, allowing", err))
+		} else if !ok {
 			errMsgs = append(errMsgs, msg)
 		}
 	}

--- a/ingress-controller/test/helpers/ktf.go
+++ b/ingress-controller/test/helpers/ktf.go
@@ -16,7 +16,7 @@ import (
 func GenerateKongBuilder(_ context.Context) (*kong.Builder, []string, error) {
 	kongbuilder := kong.NewBuilder().WithNamespace(consts.ControllerNamespace)
 	extraControllerArgs := []string{}
-	if testenv.KongEnterpriseEnabled() {
+	if testenv.KongEnterpriseImageUsed() {
 		licenseJSON, err := kong.GetLicenseJSONFromEnv()
 		if err != nil {
 			return nil, nil, err
@@ -71,7 +71,7 @@ func GenerateKongBuilder(_ context.Context) (*kong.Builder, []string, error) {
 func GenerateKongBuilderWithController() (*kong.Builder, error) {
 	kongbuilder := kong.NewBuilder().WithNamespace(consts.ControllerNamespace)
 
-	if testenv.KongEnterpriseEnabled() {
+	if testenv.KongEnterpriseImageUsed() {
 		licenseJSON, err := kong.GetLicenseJSONFromEnv()
 		if err != nil {
 			return nil, err

--- a/ingress-controller/test/kongintegration/containers/kong.go
+++ b/ingress-controller/test/kongintegration/containers/kong.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net"
 	"net/url"
-	"os"
 	"testing"
 	"time"
 
@@ -20,6 +19,7 @@ import (
 	"github.com/kong/kong-operator/v2/ingress-controller/test/consts"
 	"github.com/kong/kong-operator/v2/ingress-controller/test/helpers"
 	"github.com/kong/kong-operator/v2/ingress-controller/test/testenv"
+	testhelpers "github.com/kong/kong-operator/v2/test"
 )
 
 const (
@@ -68,7 +68,7 @@ func NewKong(ctx context.Context, t *testing.T, opts ...KongOpt) Kong {
 			"KONG_ADMIN_LISTEN":  fmt.Sprintf("0.0.0.0:%s", kongAdminPort),
 			"KONG_PROXY_LISTEN":  fmt.Sprintf("0.0.0.0:%s", kongProxyPort),
 			"KONG_ROUTER_FLAVOR": defaultRouterFlavor,
-			"KONG_LICENSE_DATA":  os.Getenv("KONG_LICENSE_DATA"),
+			"KONG_LICENSE_DATA":  testhelpers.KongLicenseData(),
 		},
 		WaitingFor: wait.ForAll(
 			wait.ForListeningPort(kongAdminPort),
@@ -179,7 +179,7 @@ func (c Kong) Terminate(ctx context.Context) error {
 
 // kongImageUnderTest returns the Kong image to be used for integration tests. If both TEST_KONG_IMAGE and
 // TEST_KONG_TAG are set, it will return the image and tag specified by them. Otherwise, it will return
-// the default image (kong:latest or kong/kong-gateway if EE tests enabled).
+// the default Enterprise image.
 func kongImageUnderTest(t *testing.T) string {
 	t.Helper()
 
@@ -187,12 +187,7 @@ func kongImageUnderTest(t *testing.T) string {
 		return fmt.Sprintf("%s:%s", testenv.KongImage(), testenv.KongTag())
 	}
 
-	if testenv.KongEnterpriseEnabled() {
-		gatewayTag, err := testenv.GetDependencyVersion("kongintegration.kong-ee")
-		require.NoError(t, err)
-		return "kong/kong-gateway:" + gatewayTag
-	}
-	gatewayTag, err := testenv.GetDependencyVersion("kongintegration.kong-oss")
+	gatewayTag, err := testenv.GetDependencyVersion("kongintegration.kong-ee")
 	require.NoError(t, err)
-	return "kong:" + gatewayTag
+	return "kong/kong-gateway:" + gatewayTag
 }

--- a/ingress-controller/test/kongintegration/kong_client_golden_tests_outputs_test.go
+++ b/ingress-controller/test/kongintegration/kong_client_golden_tests_outputs_test.go
@@ -47,10 +47,7 @@ func TestKongClientGoldenTestsOutputs(t *testing.T) {
 		return !strings.Contains(path, "-ee/") // Skip Enterprise tests.
 	})
 	// If the Kong Enterprise is enabled, run all tests.
-	if testenv.KongEnterpriseEnabled() {
-		if testenv.KongLicenseData() == "" {
-			t.Skip("Kong Enterprise enabled, but no license data provided")
-		}
+	if testenv.KongEnterpriseImageUsed() {
 		goldenTestsOutputsPaths = allGoldenTestsOutputsPaths(t)
 	}
 

--- a/ingress-controller/test/testenv/testenv.go
+++ b/ingress-controller/test/testenv/testenv.go
@@ -86,6 +86,12 @@ func KongTag() string {
 	return os.Getenv("TEST_KONG_TAG")
 }
 
+// KongEnterpriseImageUsed reports whether the Kong Gateway image configured for
+// this test run (via TEST_KONG_IMAGE) is a Kong Enterprise image.
+func KongEnterpriseImageUsed() bool {
+	return KongImage() == "kong/kong-gateway"
+}
+
 // KongImageTag is the combined Kong image and tag if both are set, or empty string if not.
 func KongImageTag() string {
 	if KongImage() != "" && KongTag() != "" {
@@ -138,11 +144,6 @@ func KongPullUsername() string {
 // KongPullPassword is the Docker password to use for the Kong image pull secret.
 func KongPullPassword() string {
 	return os.Getenv("TEST_KONG_PULL_PASSWORD")
-}
-
-// KongEnterpriseEnabled enables Enterprise-specific tests when set to "true".
-func KongEnterpriseEnabled() bool {
-	return os.Getenv("TEST_KONG_ENTERPRISE") == "true"
 }
 
 // ClusterVersion indicates the Kubernetes cluster version to use when
@@ -238,9 +239,4 @@ func IsCI() bool {
 	// It's a common convention that e.g. GitHub, GitLab, and other CI providers
 	// set the CI environment variable.
 	return os.Getenv("CI") == "true"
-}
-
-// KongLicenseData returns the Kong license data to use in tests.
-func KongLicenseData() string {
-	return os.Getenv("KONG_LICENSE_DATA")
 }

--- a/pkg/consts/dataplane.go
+++ b/pkg/consts/dataplane.go
@@ -97,7 +97,7 @@ const (
 	// DefaultDataPlaneTag is the base container image tag that can be used
 	// by default for a DataPlane resource if all other attempts to dynamically
 	// decide an image tag fail.
-	DefaultDataPlaneTag = "3.14" // renovate: datasource=docker depName=kong/kong-gateway
+	DefaultDataPlaneTag = "3.15" // renovate: datasource=docker depName=kong/kong-gateway
 
 	// DefaultDataPlaneImage is the default container image that can be used if
 	// all other attempts to dynamically decide the default image fail.

--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -32,6 +32,7 @@ import (
 	gatewayapipkg "github.com/kong/kong-operator/v2/pkg/gatewayapi"
 	"github.com/kong/kong-operator/v2/pkg/vars"
 	"github.com/kong/kong-operator/v2/test"
+	"github.com/kong/kong-operator/v2/test/helpers"
 	"github.com/kong/kong-operator/v2/test/helpers/kcfg"
 )
 
@@ -96,6 +97,7 @@ func runConformance(
 ) {
 	t.Helper()
 	ensureConformanceNamespace(ctx, t)
+	helpers.CreateKongLicenseForTest(t, ctx, clients.MgrClient, "ko-conformance-license-")
 
 	if cleanupResources {
 		t.Cleanup(func() {

--- a/test/e2e/chainsaw/common/_step_templates/apply-assert-dataPlane.yaml
+++ b/test/e2e/chainsaw/common/_step_templates/apply-assert-dataPlane.yaml
@@ -4,7 +4,7 @@
 #   - dataplane_name: Name of the DataPlane to create.
 #   - dataplane_namespace: Namespace where the DataPlane will be created.
 #   - extension_name: Name of the KonnectExtension to reference.
-#   - dataplane_image: (optional) Container image for the proxy. Default: "kong/kong-gateway:3.13".
+#   - dataplane_image: (optional) Container image for the proxy.
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: StepTemplate
 metadata:

--- a/test/e2e/chainsaw/fixtures/run-prereq.sh
+++ b/test/e2e/chainsaw/fixtures/run-prereq.sh
@@ -1,12 +1,18 @@
 #!/usr/bin/env bash
 # Generic dispatcher for chainsaw suite prerequisites.
 #
-# Runs the prerequisite script for a suite (test/e2e/chainsaw/fixtures/<DIRNAME>/prereq.sh)
-# if it exists. No-ops for suites that have no prerequisites, so a single CI step can call
-# this for every matrix suite unconditionally.
+# Always (idempotently) applies the common prerequisites shared by every suite
+# (currently: a KongLicense resource), then runs the prerequisite script for
+# the suite (test/e2e/chainsaw/fixtures/<DIRNAME>/prereq.sh) if it exists.
+# No-ops for suites that have no prerequisites of their own, so a single CI
+# step can call this for every matrix suite unconditionally.
 #
 # Required env:
-#   DIRNAME   Suite/fixtures directory name (e.g. "aigateway"). Strictly validated.
+#   DIRNAME             Suite/fixtures directory name (e.g. "aigateway"). Strictly validated.
+# Optional env:
+#   KONG_LICENSE_DATA   Raw Kong Enterprise license JSON. Treated as a secret: only ever
+#                        read via env var, never echoed, logged, or passed as an argument.
+#                        Skips KongLicense creation if unset.
 set -o errexit
 set -o nounset
 set -o pipefail
@@ -21,23 +27,51 @@ if ! printf '%s' "${DIRNAME}" | grep -Eq '^[a-z0-9]([a-z0-9-]*[a-z0-9])?$'; then
   exit 1
 fi
 
+case "${1:-}" in
+  install|uninstall)
+    ;;
+  *)
+    echo "[run-prereq] unknown action '${1:-}', must be 'install' or 'uninstall'" >&2
+    exit 1
+    ;;
+esac
+
+KONG_LICENSE_NAME="e2e-chainsaw-license"
+
+case "$1" in
+  install)
+    if [ -n "${KONG_LICENSE_DATA:-}" ]; then
+      echo "[run-prereq] applying KongLicense '${KONG_LICENSE_NAME}'"
+      jq -n --arg name "${KONG_LICENSE_NAME}" --arg license "${KONG_LICENSE_DATA}" '{
+        apiVersion: "configuration.konghq.com/v1alpha1",
+        kind: "KongLicense",
+        metadata: { name: $name },
+        rawLicenseString: $license,
+        enabled: true
+      }' | kubectl apply -f - >/dev/null
+    else
+      echo "[run-prereq] KONG_LICENSE_DATA not set, skipping KongLicense creation"
+    fi
+    ;;
+  uninstall)
+    echo "[run-prereq] removing KongLicense '${KONG_LICENSE_NAME}' (if present)"
+    kubectl delete konglicense "${KONG_LICENSE_NAME}" --ignore-not-found=true >/dev/null
+    ;;
+esac
+
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 SUITE_SCRIPT="${SCRIPT_DIR}/${DIRNAME}/prereq.sh"
 
 if [ -f "${SUITE_SCRIPT}" ]; then
-  case $1 in
+  case "$1" in
     install)
       echo "[run-prereq] installing prerequisites for suite '${DIRNAME}'"
       ;;
     uninstall)
       echo "[run-prereq] uninstalling prerequisites for suite '${DIRNAME}'"
       ;;
-    *)
-      echo "[run-prereq] unknown action '$1', must be 'install' or 'uninstall'" >&2
-      exit 1
-      ;;
   esac
   bash "${SUITE_SCRIPT}" "$1"
 else
-  echo "[run-prereq] no prerequisites for suite '${DIRNAME}', skipping"
+  echo "[run-prereq] no suite-specific prerequisites for suite '${DIRNAME}', skipping"
 fi

--- a/test/e2e/helm_install_upgrade_test.go
+++ b/test/e2e/helm_install_upgrade_test.go
@@ -294,6 +294,9 @@ func TestHelmUpgrade(t *testing.T) {
 			})
 			ensureBasicReadiness(t, ctx, e, releaseName)
 
+			t.Log("Applying KongLicense")
+			helpers.CreateKongLicenseForTest(t, ctx, e.Clients.MgrClient, "ko-e2e-license-")
+
 			// Deploy the objects that should be present before the upgrade.
 			cl := client.NewNamespacedClient(e.Clients.MgrClient, e.Namespace.Name)
 			for _, suite := range suitesToRun {

--- a/test/envtest/control_plane_reference_test.go
+++ b/test/envtest/control_plane_reference_test.go
@@ -37,7 +37,7 @@ func TestControlPlaneReferenceHandling(t *testing.T) {
 	ns := CreateNamespace(ctx, t, ctrlClient)
 
 	var (
-		kongContainer = runKongEnterprise(ctx, t)
+		kongContainer = runKong(ctx, t)
 	)
 
 	logs := RunManager(ctx, t, envcfg,

--- a/test/envtest/kong.go
+++ b/test/envtest/kong.go
@@ -12,8 +12,8 @@ import (
 	"github.com/kong/kong-operator/v2/ingress-controller/test/testenv"
 )
 
-// runKongEnterprise runs a Kong EE container using the version from `./test/test_dependencies.yaml`.
-func runKongEnterprise(ctx context.Context, t *testing.T) containers.Kong {
+// runKong runs a Kong EE container using the version from `./test/test_dependencies.yaml`.
+func runKong(ctx context.Context, t *testing.T) containers.Kong {
 	// Get the Kong Gateway version to use for the test from `./test/test_dependencies.yaml` file.
 	gatewayTag, err := testenv.GetDependencyVersion("envtests.kong-ee")
 	require.NoError(t, err)

--- a/test/envvars.go
+++ b/test/envvars.go
@@ -67,6 +67,14 @@ func KonnectAccessToken() string {
 	return os.Getenv("KONG_TEST_KONNECT_ACCESS_TOKEN")
 }
 
+// KongLicenseData returns the raw Kong Enterprise license JSON for the test
+// environment, as provided by the KONG_LICENSE_DATA environment variable
+// (e.g. by the Kong/kong-license GitHub Action). Returns an empty string if
+// no license is configured.
+func KongLicenseData() string {
+	return os.Getenv("KONG_LICENSE_DATA")
+}
+
 // KonnectServerURL returns the Konnect server URL for the test environment.
 func KonnectServerURL() string {
 	return os.Getenv("KONG_TEST_KONNECT_SERVER_URL")

--- a/test/helpers/license.go
+++ b/test/helpers/license.go
@@ -1,0 +1,72 @@
+package helpers
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"testing"
+	"time"
+
+	"github.com/avast/retry-go/v5"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	configurationv1alpha1 "github.com/kong/kong-operator/v2/api/configuration/v1alpha1"
+	"github.com/kong/kong-operator/v2/test"
+)
+
+// CreateKongLicense creates a KongLicense resource
+// read from the KONG_LICENSE_DATA environment variable, retrying creation
+// a few times in case the cluster isn't fully ready yet.
+// It returns an error if KONG_LICENSE_DATA is not set.
+func CreateKongLicense(ctx context.Context, cl client.Client, generateNamePrefix string) (cleanup func() error, err error) {
+	licenseData := test.KongLicenseData()
+	if licenseData == "" {
+		return nil, errors.New("KONG_LICENSE_DATA not set")
+	}
+
+	fmt.Println("INFO: creating KongLicense for tests")
+	kongLicense := &configurationv1alpha1.KongLicense{
+		ObjectMeta: metav1.ObjectMeta{
+			GenerateName: generateNamePrefix,
+		},
+		RawLicenseString: licenseData,
+		Enabled:          true,
+	}
+
+	const attempts = 5
+	if err := retry.New(
+		retry.OnRetry(func(n uint, err error) {
+			fmt.Printf("WARNING: creating KongLicense attempt %d/%d - error: %s\n", n+1, attempts, err)
+		}),
+		retry.LastErrorOnly(true),
+		retry.Delay(2*time.Second),
+		retry.Attempts(attempts),
+	).Do(func() error {
+		return cl.Create(ctx, kongLicense)
+	}); err != nil {
+		return nil, fmt.Errorf("failed to create KongLicense: %w", err)
+	}
+
+	return func() error {
+		if err := cl.Delete(context.Background(), kongLicense); err != nil && !apierrors.IsNotFound(err) {
+			return fmt.Errorf("failed to delete KongLicense %s: %w", kongLicense.Name, err)
+		}
+		return nil
+	}, nil
+}
+
+// CreateKongLicenseForTest is a [*testing.T] friendly wrapper around
+// CreateKongLicense.
+func CreateKongLicenseForTest(t *testing.T, ctx context.Context, cl client.Client, generateNamePrefix string) {
+	t.Helper()
+
+	cleanup, err := CreateKongLicense(ctx, cl, generateNamePrefix)
+	require.NoError(t, err)
+
+	t.Cleanup(func() {
+		require.NoError(t, cleanup())
+	})
+}

--- a/test/integration/kic/consumer_group_test.go
+++ b/test/integration/kic/consumer_group_test.go
@@ -184,6 +184,7 @@ func TestConsumerGroup(t *testing.T) {
 	}, service)
 	multiIngress.Spec.IngressClassName = kong.String(consts.IngressClass)
 	multiIngress.Name = "multi"
+	multiIngress.Namespace = ns.Name
 	require.NoError(t, clusters.DeployIngress(ctx, env.Cluster(), ns.Name, multiIngress))
 	cleaner.Add(multiIngress)
 
@@ -271,6 +272,7 @@ func deployMinimalSvcWithKeyAuth(
 
 	t.Logf("exposing deployment %q via service", deployment.Name)
 	service := generators.NewServiceForDeployment(deployment, corev1.ServiceTypeClusterIP)
+	service.Namespace = namespace
 	_, err = env.Cluster().Client().CoreV1().Services(namespace).Create(ctx, service, metav1.CreateOptions{})
 	require.NoError(t, err)
 
@@ -279,6 +281,7 @@ func deployMinimalSvcWithKeyAuth(
 		annotations.AnnotationPrefix + annotations.StripPathKey: "true",
 		annotations.AnnotationPrefix + annotations.PluginsKey:   pluginKeyAuthName,
 	}, service)
+	ingress.Namespace = namespace
 	ingress.Spec.IngressClassName = kong.String(consts.IngressClass)
 	require.NoError(t, clusters.DeployIngress(ctx, env.Cluster(), namespace, ingress))
 	return deployment, service, ingress, pluginKeyAuth

--- a/test/integration/kic/isolated/skip.go
+++ b/test/integration/kic/isolated/skip.go
@@ -21,7 +21,7 @@ func SkipIfRouterNotExpressions(ctx context.Context, t *testing.T, _ *envconf.Co
 
 // SkipIfEnterpriseNotEnabled skips the test when Kong Enterprise is not enabled.
 func SkipIfEnterpriseNotEnabled(ctx context.Context, t *testing.T, _ *envconf.Config) context.Context {
-	if !testenv.KongEnterpriseEnabled() {
+	if !testenv.KongEnterpriseImageUsed() {
 		t.Skip("skipping, Kong enterprise is required")
 	}
 	return ctx

--- a/test/integration/kic/isolated/suite_test.go
+++ b/test/integration/kic/isolated/suite_test.go
@@ -197,7 +197,7 @@ func featureSetup(opts ...featureSetupOpt) func(ctx context.Context, t *testing.
 		}
 		// Add admin token and workspace args to controller args when running against Kong Enterprise with DB backed.
 		var extraControllerArgs []string
-		if testenv.KongEnterpriseEnabled() && testenv.DBMode() != testenv.DBModeOff {
+		if testenv.KongEnterpriseImageUsed() && testenv.DBMode() != testenv.DBModeOff {
 			extraControllerArgs = []string{
 				fmt.Sprintf("--kong-admin-token=%s", consts.KongTestPassword),
 				fmt.Sprintf("--kong-workspace=%s", consts.KongTestWorkspace),

--- a/test/integration/kic/plugin_test.go
+++ b/test/integration/kic/plugin_test.go
@@ -350,6 +350,7 @@ func TestPluginOrdering(t *testing.T) {
 
 	t.Logf("exposing deployment %s via service", deployment.Name)
 	service := generators.NewServiceForDeployment(deployment, corev1.ServiceTypeLoadBalancer)
+	service.Namespace = ns.Name
 	_, err = env.Cluster().Client().CoreV1().Services(ns.Name).Create(ctx, service, metav1.CreateOptions{})
 	require.NoError(t, err)
 	cleaner.Add(service)
@@ -358,6 +359,7 @@ func TestPluginOrdering(t *testing.T) {
 	ingress := generators.NewIngressForService("/test_plugin_ordering", map[string]string{
 		"konghq.com/strip-path": "true",
 	}, service)
+	ingress.Namespace = ns.Name
 	ingress.Spec.IngressClassName = kong.String(consts.IngressClass)
 	require.NoError(t, clusters.DeployIngress(ctx, env.Cluster(), ns.Name, ingress))
 	cleaner.Add(ingress)

--- a/test/integration/kic/suite_test.go
+++ b/test/integration/kic/suite_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/kong/kubernetes-testing-framework/pkg/clusters/types/kind"
 	"github.com/kong/kubernetes-testing-framework/pkg/environments"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 
 	managercfg "github.com/kong/kong-operator/v2/ingress-controller/pkg/manager/config"
@@ -219,6 +220,17 @@ func TestMain(m *testing.M) {
 		})
 		defer cancel()
 		helpers.ExitOnErr(ctx, err)
+
+		fmt.Println("INFO: applying KongLicense")
+		mgrClient, err := client.New(env.Cluster().Config(), client.Options{Scheme: scheme.Get()})
+		helpers.ExitOnErr(ctx, err)
+		cleanupKongLicense, err := helpers.CreateKongLicense(ctx, mgrClient, "kic-integration-license-")
+		helpers.ExitOnErr(ctx, err)
+		defer func() {
+			if err := cleanupKongLicense(); err != nil {
+				fmt.Printf("WARN: %s\n", err)
+			}
+		}()
 	}
 
 	gatewayClient, err := gatewayclient.NewForConfig(env.Cluster().Config())

--- a/test/integration/kic/vault_test.go
+++ b/test/integration/kic/vault_test.go
@@ -45,6 +45,7 @@ func TestCustomVault(t *testing.T) {
 
 	t.Logf("exposing deployment %s via service", deployment.Name)
 	service := generators.NewServiceForDeployment(deployment, corev1.ServiceTypeLoadBalancer)
+	service.Namespace = ns.Name
 	_, err = env.Cluster().Client().CoreV1().Services(ns.Name).Create(ctx, service, metav1.CreateOptions{})
 	require.NoError(t, err)
 	cleaner.Add(service)
@@ -53,6 +54,7 @@ func TestCustomVault(t *testing.T) {
 	ingress := generators.NewIngressForService("/test_custom_vault", map[string]string{
 		"konghq.com/strip-path": "true",
 	}, service)
+	ingress.Namespace = ns.Name
 	ingress.Spec.IngressClassName = kong.String(consts.IngressClass)
 	require.NoError(t, clusters.DeployIngress(ctx, env.Cluster(), ns.Name, ingress))
 	cleaner.Add(ingress)

--- a/test/integration/kic/version_test.go
+++ b/test/integration/kic/version_test.go
@@ -54,14 +54,8 @@ func RunWhenKongDBMode(t *testing.T, dbmode dpconf.DBMode, msg ...any) {
 func RunWhenKongEnterprise(t *testing.T) {
 	t.Helper()
 
-	if !testenv.KongEnterpriseEnabled() {
+	if !testenv.KongEnterpriseImageUsed() {
 		t.Skipf("skipping because Kong enterprise is not enabled")
-	}
-
-	version := eventuallyGetKongVersion(t, proxyAdminURL)
-
-	if !version.IsKongGatewayEnterprise() {
-		t.Skipf("skipping because Kong is not running as Enterprise, detected version %q", version)
 	}
 }
 

--- a/test/integration/ko/suite_test.go
+++ b/test/integration/ko/suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	integration.Suite(m)
+	integration.Suite(m, integration.WithKongLicense())
 }

--- a/test/integration/suite.go
+++ b/test/integration/suite.go
@@ -65,9 +65,30 @@ func GetClients() testutils.K8sClients {
 	return clients
 }
 
+// SuiteOption configures optional behavior of Suite.
+type SuiteOption func(*suiteOptions)
+
+type suiteOptions struct {
+	createKongLicense bool
+}
+
+// WithKongLicense loads license data from the KONG_LICENSE_DATA
+// environment variable into the test cluster by creating a KongLicense
+// resource. If not set, the test suite will exit with an error.
+func WithKongLicense() SuiteOption {
+	return func(o *suiteOptions) {
+		o.createKongLicense = true
+	}
+}
+
 // Suite sets up the testing environment for the integration test suite.
 // It is intended to be called from TestMain in the respective test package.
-func Suite(m *testing.M) {
+func Suite(m *testing.M, opts ...SuiteOption) {
+	var so suiteOptions
+	for _, opt := range opts {
+		opt(&so)
+	}
+
 	var code int
 	defer func() {
 		if r := recover(); r != nil {
@@ -120,6 +141,16 @@ func Suite(m *testing.M) {
 
 	fmt.Println("INFO: Deploying all required Kubernetes Configuration (RBAC, CRDs, etc.) for the operator")
 	exitOnErr(kcfg.DeployKubernetesConfiguration(GetCtx(), env.Cluster()))
+
+	if so.createKongLicense {
+		cleanupKongLicense, err := helpers.CreateKongLicense(GetCtx(), clients.MgrClient, "ko-integration-license-")
+		exitOnErr(err)
+		defer func() {
+			if err := cleanupKongLicense(); err != nil {
+				fmt.Printf("WARN: %s\n", err)
+			}
+		}()
+	}
 
 	cleanupTelepresence, err := helpers.SetupTelepresence(ctx)
 	exitOnErr(err)

--- a/test/integration/validatingwebhook/suite_test.go
+++ b/test/integration/validatingwebhook/suite_test.go
@@ -7,5 +7,5 @@ import (
 )
 
 func TestMain(m *testing.M) {
-	integration.Suite(m)
+	integration.Suite(m, integration.WithKongLicense())
 }

--- a/test/test_dependencies.yaml
+++ b/test/test_dependencies.yaml
@@ -10,23 +10,23 @@ integration:
   # renovate: datasource=docker depName=kong versioning=docker
   kong-oss: '3.9.3'
   # renovate: datasource=docker depName=kong/kong-gateway versioning=docker
-  kong-ee: '3.14.0.9'
+  kong-ee: '3.15.0.2'
 
 kongintegration:
   # renovate: datasource=docker depName=kong versioning=docker
   kong-oss: '3.9.3'
   # renovate: datasource=docker depName=kong/kong-gateway versioning=docker
-  kong-ee: '3.14.0.9'
+  kong-ee: '3.15.0.2'
 
 envtests:
   # renovate: datasource=docker depName=kong/kong-gateway versioning=docker
-  kong-ee: '3.14.0.9'
+  kong-ee: '3.15.0.2'
   # This is a version of Kong Gateway that does not support sticky sessions,
   # all versions >= 3.11.0 support sticky sessions.
   kong-without-sticky-sessions: '3.9.1'
 
 chainsaw:
   # renovate: datasource=docker depName=kong/kong-gateway versioning=docker
-  kong-ee: '3.14.0.9'
+  kong-ee: '3.15.0.2'
   # renovate: datasource=docker depName=kong/kong-ai-gateway-dev versioning=docker
   aigw-dp: '2.0.1-rc.5'


### PR DESCRIPTION
**What this PR does / why we need it**:

For Kong Gateway 3.15, a license is required not only for particular features, but also to access the admin API. Thus, it has to be injected basically for all test suites. License helpers are now consolidated 

**Which issue this PR fixes**

Replaces #5098, #5083 and #4765

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
