### PR TITLE
Fix(dataplane): Fix comparing of `DataPlane`'s deployment options to include `scaling` for updating HPAs when `scaling` changed (#5003)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,17 @@
 - [v0.1.1](#v011)
 - [v0.1.0](#v010)
 
+## Unreleased
+
+### Fixes
+
+- Dataplane: Fixed the method to compare whether dataplane options are deep
+  equal to ensure that `HorizontalPodAutoscaler` is updated when it is changed
+  in `GatewayConfiguration`. Also fixed the calculation of the spec hash in the
+  `Deployment` to skip reconciliation of deployments if only `deployment.scaling`
+  is changed in dataplane options.
+  [#5003](https://github.com/Kong/kong-operator/pull/5003)
+
 ## [v2.2.3]
 
 > Relaese date: 2026-07-14

--- a/controller/dataplane/owned_deployment.go
+++ b/controller/dataplane/owned_deployment.go
@@ -166,7 +166,7 @@ func (d *DeploymentBuilder) BuildAndDeploy(
 	// apply default envvars and restore the hacked-out ones
 	desiredDeployment = applyEnvForDataPlane(existingEnvVars, desiredDeployment, config.KongDefaults)
 
-	if err := k8sresources.AnnotateObjWithHash(desiredDeployment.Unwrap(), dataplane.Spec); err != nil {
+	if err := k8sresources.AnnotateObjWithHash(desiredDeployment.Unwrap(), deploymentRelevantDataPlaneSpec(dataplane)); err != nil {
 		return nil, op.Noop, err
 	}
 
@@ -356,6 +356,17 @@ func isRecentDeploymentRestart(template *corev1.PodTemplateSpec, logger logr.Log
 	return restartTimeStr, false
 }
 
+// deploymentRelevantDataPlaneSpec returns a copy of the DataPlane's spec with fields
+// that have no bearing on the generated Deployment zeroed out. It's used as the input
+// for the Deployment's spec-hash annotation, so that changes to fields the Deployment
+// doesn't care about (e.g. Scaling, which only affects the HPA) don't cause a spurious
+// Deployment update that would pre-empt reconciliation of those other resources.
+func deploymentRelevantDataPlaneSpec(dataplane *operatorv1beta1.DataPlane) operatorv1beta1.DataPlaneSpec {
+	spec := *dataplane.Spec.DeepCopy()
+	spec.Deployment.Scaling = nil
+	return spec
+}
+
 // reconcileDataPlaneDeployment takes any existing DataPlane Deployment and a desired DataPlane Deployment and
 // reconciles the existing state to the desired state by either updating an existing Deployment, creating a new one,
 // or doing nothing.
@@ -374,7 +385,7 @@ func reconcileDataPlaneDeployment(
 		// existing Deployment with the spec hash of the desired Deployment. If
 		// the hashes match, we skip the update.
 		if !enforceConfig {
-			match, err := k8sresources.SpecHashMatchesAnnotation(dataplane.Spec, existing)
+			match, err := k8sresources.SpecHashMatchesAnnotation(deploymentRelevantDataPlaneSpec(dataplane), existing)
 			if err != nil {
 				return op.Noop, nil, err
 			}

--- a/controller/dataplane/owned_deployment_test.go
+++ b/controller/dataplane/owned_deployment_test.go
@@ -17,6 +17,7 @@ import (
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	operatorv1beta1 "github.com/kong/kong-operator/v2/api/gateway-operator/v1beta1"
+	"github.com/kong/kong-operator/v2/controller/pkg/op"
 	"github.com/kong/kong-operator/v2/pkg/consts"
 	k8sresources "github.com/kong/kong-operator/v2/pkg/utils/kubernetes/resources"
 )
@@ -226,6 +227,87 @@ func TestDeploymentBuilder_BuildAndDeploy(t *testing.T) {
 			assert.Equal(t, deployment.Namespace, fetchedDeployment.Namespace)
 		})
 	}
+}
+
+// TestDeploymentBuilder_BuildAndDeploy_ScalingOnlyChangeIsNoop is a regression test
+// for the DataPlane's HPA not being updated when only spec.deployment.scaling
+// changes: reconcileDataPlaneDeployment used to hash the whole DataPlane spec
+// (including Scaling, which has no effect on the Deployment) to decide whether the
+// Deployment needed a patch, so a scaling-only change would falsely report
+// op.Updated and pre-empt the DataPlane controller's HPA reconciliation for a pass.
+func TestDeploymentBuilder_BuildAndDeploy_ScalingOnlyChangeIsNoop(t *testing.T) {
+	dataplane := &operatorv1beta1.DataPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-dataplane",
+			Namespace: "default",
+			UID:       "test-uid",
+		},
+		Spec: operatorv1beta1.DataPlaneSpec{
+			DataPlaneOptions: operatorv1beta1.DataPlaneOptions{
+				Deployment: operatorv1beta1.DataPlaneDeploymentOptions{
+					DeploymentOptions: operatorv1beta1.DeploymentOptions{
+						PodTemplateSpec: &corev1.PodTemplateSpec{
+							Spec: corev1.PodSpec{
+								Containers: []corev1.Container{
+									{
+										Name:  consts.DataPlaneProxyContainerName,
+										Image: "kong/kong-gateway:3.11",
+									},
+								},
+							},
+						},
+						Scaling: &operatorv1beta1.Scaling{
+							HorizontalScaling: &operatorv1beta1.HorizontalScaling{
+								MinReplicas: new(int32(2)),
+								MaxReplicas: 3,
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	logger := logr.Discard()
+	scheme := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(scheme))
+	require.NoError(t, appsv1.AddToScheme(scheme))
+	require.NoError(t, operatorv1beta1.AddToScheme(scheme))
+
+	fakeClient := fakectrlruntimeclient.
+		NewClientBuilder().
+		WithScheme(scheme).
+		WithObjects(dataplane).
+		Build()
+
+	builder := NewDeploymentBuilder(logger, fakeClient).
+		WithDefaultImage("kong:3.0").
+		WithClusterCertificate("test-cert").
+		WithOpts(
+			labelSelectorFromDataPlaneStatusSelectorDeploymentOpt(dataplane),
+		)
+
+	_, res, err := builder.BuildAndDeploy(t.Context(), dataplane, true, false)
+	require.NoError(t, err)
+	require.Equal(t, op.Created, res)
+
+	// A second call with no spec changes lets the Deployment's PodTemplateSpec
+	// settle to its fully-defaulted form (the fake client, unlike a real API
+	// server, doesn't apply defaulting on Create), so the next call's diff is
+	// solely attributable to the scaling change below.
+	_, _, err = builder.BuildAndDeploy(t.Context(), dataplane, true, false)
+	require.NoError(t, err)
+
+	// Only the DataPlane's scaling changes; nothing that affects the Deployment
+	// template, strategy, or replica count (existing replicas already satisfy the
+	// new minReplicas).
+	dataplane.Spec.Deployment.Scaling.HorizontalScaling.MinReplicas = new(int32(1))
+	dataplane.Spec.Deployment.Scaling.HorizontalScaling.MaxReplicas = 2
+
+	_, res, err = builder.BuildAndDeploy(t.Context(), dataplane, true, false)
+	require.NoError(t, err)
+	assert.Equal(t, op.Noop, res, "a scaling-only change must not report the Deployment as updated, "+
+		"or it pre-empts the DataPlane controller's HPA reconciliation for a reconcile pass")
 }
 
 func TestGenerateDataPlaneDeployment(t *testing.T) {

--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -1081,6 +1081,10 @@ func deploymentOptionsDeepEqual(o1, o2 *operatorv1beta1.DeploymentOptions, envVa
 		return false
 	}
 
+	if !reflect.DeepEqual(o1.Scaling, o2.Scaling) {
+		return false
+	}
+
 	opts := []cmp.Option{
 		cmp.Comparer(k8sresources.ResourceRequirementsEqual),
 		cmp.Comparer(func(a, b []corev1.EnvVar) bool {

--- a/controller/gateway/controller_test.go
+++ b/controller/gateway/controller_test.go
@@ -505,6 +505,31 @@ func TestProvisionControlPlane_UpdatesExtensionsWhenOnlyExtensionsDiffer(t *test
 	require.Equal(t, gatewayConfig.Spec.Extensions, updatedControlPlane.Spec.Extensions)
 }
 
+// Test_deploymentOptionsDeepEqual_Scaling is a regression test for the DataPlane's
+// spec.deployment.scaling never being updated by provisionDataPlane: the comparator
+// used to gate whether the owned DataPlane needs a patch only compared Replicas and
+// PodTemplateSpec, silently ignoring Scaling, so a scaling-only change from the
+// GatewayConfiguration was never detected and the patch was skipped forever.
+func Test_deploymentOptionsDeepEqual_Scaling(t *testing.T) {
+	original := &operatorv1beta1.DeploymentOptions{
+		Scaling: &operatorv1beta1.Scaling{
+			HorizontalScaling: &operatorv1beta1.HorizontalScaling{
+				MinReplicas: new(int32(2)),
+				MaxReplicas: 3,
+			},
+		},
+	}
+	changed := original.DeepCopy()
+	changed.Scaling.HorizontalScaling.MinReplicas = new(int32(1))
+	changed.Scaling.HorizontalScaling.MaxReplicas = 2
+
+	assert.True(t, deploymentOptionsDeepEqual(original, original.DeepCopy()),
+		"identical DeploymentOptions must be reported as equal")
+	assert.False(t, deploymentOptionsDeepEqual(original, changed),
+		"a scaling-only change must not be reported as equal, or the DataPlane's "+
+			"scaling never gets patched by provisionDataPlane")
+}
+
 func Test_setDataPlaneOptionsDefaults(t *testing.T) {
 	testcases := []struct {
 		name     string


### PR DESCRIPTION

**What this PR does / why we need it**:

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
