### PR TITLE
test(chainsaw): re-enable chainsaw tests for AIGateway requiring model routing

### DIFF
--- a/test/e2e/chainsaw/aigateway/ai-proxy-mirror/02-aigateway-provider-model.yaml
+++ b/test/e2e/chainsaw/aigateway/ai-proxy-mirror/02-aigateway-provider-model.yaml
@@ -61,8 +61,9 @@ spec:
           model:
             type: headers
             headers:
-              X-Kong-LLM-Model:
-                - qwen2.5:0.5b
+              headers:
+                X-Kong-LLM-Model:
+                  - qwen2.5:0.5b
           paths:
             - /aigw11/chat
       targets:

--- a/test/e2e/chainsaw/aigateway/ai-proxy-mirror/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/aigateway/ai-proxy-mirror/chainsaw-test.yaml
@@ -3,9 +3,6 @@ kind: Test
 metadata:
   name: aigateway-ai-proxy-mirror
 spec:
-  # Skipping this test until related AI model routing issue is resolved.
-  # TODO: https://github.com/Kong/kong-operator/issues/5046
-  skip: true
   description: |
     AI GW 1.1 — AI Proxy Advanced against a MIRROR KonnectAIGateway. Creates an Origin
     KonnectAIGateway (which provisions the Konnect AI Gateway control plane), grabs its

--- a/test/e2e/chainsaw/aigateway/ai-proxy/02-aigateway-provider-model.yaml
+++ b/test/e2e/chainsaw/aigateway/ai-proxy/02-aigateway-provider-model.yaml
@@ -61,8 +61,9 @@ spec:
           model:
             type: headers
             headers:
-              X-Kong-LLM-Model:
-                - qwen2.5:0.5b
+              headers:
+                X-Kong-LLM-Model:
+                  - qwen2.5:0.5b
           paths:
             - /aigw11/chat
       targets:

--- a/test/e2e/chainsaw/aigateway/ai-proxy/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/aigateway/ai-proxy/chainsaw-test.yaml
@@ -3,9 +3,6 @@ kind: Test
 metadata:
   name: aigateway-ai-proxy
 spec:
-  # Skipping this test until related AI model routing issue is resolved.
-  # TODO: https://github.com/Kong/kong-operator/issues/5046
-  skip: true
   description: |
     AI GW 1.1 — AI Proxy Advanced. Stands up the Konnect AIGateway control plane, an
     OpenAI-compatible provider + model exposing /aigw11/chat pointed at the shared mock

--- a/test/e2e/chainsaw/aigateway/aigateway-policy/03-aigateway-model-referencing-the-policy.yaml
+++ b/test/e2e/chainsaw/aigateway/aigateway-policy/03-aigateway-model-referencing-the-policy.yaml
@@ -61,8 +61,9 @@ spec:
           model:
             type: headers
             headers:
-              X-Kong-LLM-Model:
-                - qwen2.5:0.5b
+              headers:
+                X-Kong-LLM-Model:
+                  - qwen2.5:0.5b
           paths:
             - /aigw11/chat
       policies:

--- a/test/e2e/chainsaw/aigateway/aigateway-policy/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/aigateway/aigateway-policy/chainsaw-test.yaml
@@ -3,9 +3,6 @@ kind: Test
 metadata:
   name: aigateway-policy
 spec:
-  # Skipping this test until related AI model routing issue is resolved.
-  # TODO: https://github.com/Kong/kong-operator/issues/5046
-  skip: true
   description: |
     Konnect AIGateway - Policy. Stands up the Konnect AIGateway control plane
     and creates policies to test the AIGatewayPolicy CRD. Then check for the policies


### PR DESCRIPTION
**What this PR does / why we need it**:

Re-enable chainsaw tests for AIGateway requiring model routing.

**Which issue this PR fixes**

Fixes #5046

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
