### PR TITLE
 chore(dependencies): bump default AIGateway image to 2.0.1-rc.5

### DIFF
--- a/pkg/consts/aigateway.go
+++ b/pkg/consts/aigateway.go
@@ -51,7 +51,7 @@ const (
 	// Once the GA version is released, we will switch back to kong/kong-ai-gateway.
 	DefaultAIGatewayDataPlaneBaseImage = "kong/kong-ai-gateway-dev"
 	// DefaultAIGatewayDataPlaneTag is the default image tag for the AI Gateway container.
-	DefaultAIGatewayDataPlaneTag = "2.0.1-rc.4" // renovate: datasource=docker depName=kong/kong-ai-gateway-dev
+	DefaultAIGatewayDataPlaneTag = "2.0.1-rc.5" // renovate: datasource=docker depName=kong/kong-ai-gateway-dev
 	// DefaultAIGatewayDataPlaneImage is the full default image reference for the AI Gateway container.
 	DefaultAIGatewayDataPlaneImage = DefaultAIGatewayDataPlaneBaseImage + ":" + DefaultAIGatewayDataPlaneTag
 )

--- a/test/test_dependencies.yaml
+++ b/test/test_dependencies.yaml
@@ -29,4 +29,4 @@ chainsaw:
   # renovate: datasource=docker depName=kong/kong-gateway versioning=docker
   kong-ee: '3.14.0.9'
   # renovate: datasource=docker depName=kong/kong-ai-gateway-dev versioning=docker
-  aigw-dp: '2.0.1-rc.4'
+  aigw-dp: '2.0.1-rc.5'


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
