### PR TITLE
fix: fix Konnect config sychronizer cancellation

### DIFF
--- a/ingress-controller/internal/konnect/config_synchronizer.go
+++ b/ingress-controller/internal/konnect/config_synchronizer.go
@@ -225,6 +225,13 @@ func (s *ConfigSynchronizer) handleConfigSynchronizationTick(ctx context.Context
 
 	logger.V(logging.DebugLevel).Info("Start uploading configuration to Konnect")
 
+	// The context may have been cancelled while this tick was being handled (or the tick may have been
+	// buffered before cancellation). Don't push configuration after shutdown has been requested.
+	if ctx.Err() != nil {
+		logger.V(logging.DebugLevel).Info("Context done, skipping Konnect configuration upload")
+		return
+	}
+
 	// Get the latest configuration copy to upload to Konnect. We don't want to hold the lock for a long time to prevent
 	// blocking the update of the configuration.
 	targetCfg, ok := s.currentContent(ctx)


### PR DESCRIPTION
**What this PR does / why we need it**:

Address failures like: https://github.com/Kong/kong-operator/actions/runs/30903522378/job/91973236308?pr=5131#step:13:20471

```
=== Failed
=== FAIL: ingress-controller/internal/konnect TestConfigSynchronizer_UpdatesKongConfigAccordingly (1.11s)
    config_synchronizer_test.go:357: Running Konnect config synchronizer
    config_synchronizer_test.go:56: Verifying that no URL are updated when no configuration received
    config_synchronizer_test.go:62: Verifying that the new config updated when received
    config_synchronizer_test.go:96: Verifying that update is not called when config not changed
    config_synchronizer_test.go:103: Verifying that new config are not sent after context cancelled
    config_synchronizer_test.go:115: 
        	Error Trace:	/home/runner/work/kong-operator/kong-operator/test/helpers/asserts/never.go:38
        	            				/home/runner/work/kong-operator/kong-operator/ingress-controller/internal/konnect/config_synchronizer_test.go:115
        	Error:      	Condition met unexpectedly: Should not send new updates after context cancelled
        	Test:       	TestConfigSynchronizer_UpdatesKongConfigAccordingly
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
