### PR TITLE
feat(hybridgateway): GRPCRoute translator

### DIFF
--- a/controller/hybridgateway/builder/kongplugin.go
+++ b/controller/hybridgateway/builder/kongplugin.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"maps"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	configurationv1 "github.com/kong/kong-operator/v2/api/configuration/v1"
@@ -41,7 +42,7 @@ func (b *KongPluginBuilder) WithNamespace(namespace string) *KongPluginBuilder {
 }
 
 // WithLabels sets the labels for the KongPlugin resource based on the given HTTPRoute.
-func (b *KongPluginBuilder) WithLabels(route *gwtypes.HTTPRoute, parentRef *gwtypes.ParentReference) *KongPluginBuilder {
+func (b *KongPluginBuilder) WithLabels(route client.Object, parentRef *gwtypes.ParentReference) *KongPluginBuilder {
 	labels := metadata.BuildLabels(route, parentRef)
 	if b.plugin.Labels == nil {
 		b.plugin.Labels = make(map[string]string)
@@ -51,7 +52,7 @@ func (b *KongPluginBuilder) WithLabels(route *gwtypes.HTTPRoute, parentRef *gwty
 }
 
 // WithAnnotations sets the annotations for the KongPlugin resource based on the given HTTPRoute and parent reference.
-func (b *KongPluginBuilder) WithAnnotations(route *gwtypes.HTTPRoute, parentRef *gwtypes.ParentReference) *KongPluginBuilder {
+func (b *KongPluginBuilder) WithAnnotations(route client.Object, parentRef *gwtypes.ParentReference) *KongPluginBuilder {
 	if route == nil {
 		b.errors = append(b.errors, errors.New("route cannot be nil"))
 		return b

--- a/controller/hybridgateway/builder/kongpluginbinding.go
+++ b/controller/hybridgateway/builder/kongpluginbinding.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"maps"
 
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	commonv1alpha1 "github.com/kong/kong-operator/v2/api/common/v1alpha1"
@@ -41,7 +42,7 @@ func (b *KongPluginBindingBuilder) WithNamespace(namespace string) *KongPluginBi
 }
 
 // WithLabels sets the labels for the KongPluginBinding resource based on the given HTTPRoute.
-func (b *KongPluginBindingBuilder) WithLabels(route *gwtypes.HTTPRoute, parentRef *gwtypes.ParentReference) *KongPluginBindingBuilder {
+func (b *KongPluginBindingBuilder) WithLabels(route client.Object, parentRef *gwtypes.ParentReference) *KongPluginBindingBuilder {
 	labels := metadata.BuildLabels(route, parentRef)
 	if b.binding.Labels == nil {
 		b.binding.Labels = make(map[string]string)
@@ -51,7 +52,7 @@ func (b *KongPluginBindingBuilder) WithLabels(route *gwtypes.HTTPRoute, parentRe
 }
 
 // WithAnnotations sets the annotations for the KongPluginBinding resource based on the given HTTPRoute and parent reference.
-func (b *KongPluginBindingBuilder) WithAnnotations(route *gwtypes.HTTPRoute, parentRef *gwtypes.ParentReference) *KongPluginBindingBuilder {
+func (b *KongPluginBindingBuilder) WithAnnotations(route client.Object, parentRef *gwtypes.ParentReference) *KongPluginBindingBuilder {
 	annotations := metadata.BuildAnnotations(route, parentRef)
 	if b.binding.Annotations == nil {
 		b.binding.Annotations = make(map[string]string)

--- a/controller/hybridgateway/builder/kongroute.go
+++ b/controller/hybridgateway/builder/kongroute.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"regexp"
 	"strings"
 
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
@@ -30,6 +31,12 @@ const (
 	// KongHTTPRoutePathRegexPriorityOffset reserves lower regex_priority values for synthetic
 	// catch-all regex routes used by default path header-only matches.
 	KongHTTPRoutePathRegexPriorityOffset int64 = 1 << 20
+
+	// KongGRPCRouteCatchAllPath is the synthetic regex path used for GRPCRoute matches that
+	// specify no method matcher at all (Method == nil), which per Gateway API must match every
+	// service and method. GRPCRouteMatch has no path field, so regex_priority (not path
+	// specificity) is what Kong uses to order these against more specific matches.
+	KongGRPCRouteCatchAllPath = KongPathRegexPrefix + "/(.*)"
 )
 
 // KongRouteBuilder is a builder for configurationv1alpha1.KongRoute resources.
@@ -86,6 +93,29 @@ func (b *KongRouteBuilder) WithHTTPRouteMatch(match gwtypes.HTTPRouteMatch, setC
 		}
 	}
 	// Note: QueryParams are not natively supported by KongRoute
+
+	return b
+}
+
+// WithGRPCRouteMatch sets the match criteria (method/service path, headers) for the KongRoute.
+// Unlike HTTPRoute, GRPCRouteMatch has no path field: the gRPC path is derived from the method
+// matcher, and precedence (service/method character length, header count) is expressed
+// entirely through regex_priority by the caller rather than through path specificity.
+func (b *KongRouteBuilder) WithGRPCRouteMatch(match gatewayv1.GRPCRouteMatch) *KongRouteBuilder {
+	b.route.Spec.Paths = append(b.route.Spec.Paths, GenerateKongRoutePathFromGRPCMethodMatch(match.Method)...)
+
+	if len(match.Headers) > 0 {
+		if b.route.Spec.Headers == nil {
+			b.route.Spec.Headers = make(map[string][]string)
+		}
+		for _, hdr := range match.Headers {
+			value := hdr.Value
+			if hdr.Type != nil && *hdr.Type == gatewayv1.GRPCHeaderMatchRegularExpression {
+				value = KongHeaderRegexPrefix + value
+			}
+			b.route.Spec.Headers[string(hdr.Name)] = append(b.route.Spec.Headers[string(hdr.Name)], value)
+		}
+	}
 
 	return b
 }
@@ -312,4 +342,48 @@ func regexPriorityForHTTPPathMatch(matchType gatewayv1.PathMatchType, value stri
 		priority++
 	}
 	return &priority
+}
+
+// GenerateKongRoutePathFromGRPCMethodMatch translates a GRPCRouteMatch's method matcher into the
+// path used by KongRoute. A gRPC request's wire path is always "/service/method", so the method
+// matcher is folded into an equivalent Kong regex path:
+//   - No matcher at all: match every service and method (KongGRPCRouteCatchAllPath).
+//   - Service only: match any method of that service.
+//   - Method only: match that method on any service.
+//   - Both: match that exact service/method pair.
+//
+// For Type: RegularExpression, Service/Method are regex fragments themselves (validated only for
+// Exact), so they're spliced in as-is without additional anchoring, mirroring how HTTPRoute
+// RegularExpression path matches are passed through untouched. For Type: Exact (the default),
+// Service/Method are literal strings that happen to contain "." (gRPC service names are always
+// "package.path.Service"), so they're [regexp.QuoteMeta]-escaped before being spliced into the
+// regex path — otherwise an unescaped "." matches any character, letting an Exact match for
+// "foo.bar.Service" also match an unrelated "fooXbarXService".
+func GenerateKongRoutePathFromGRPCMethodMatch(method *gatewayv1.GRPCMethodMatch) []string {
+	if method == nil {
+		return []string{KongGRPCRouteCatchAllPath}
+	}
+
+	isRegex := method.Type != nil && *method.Type == gatewayv1.GRPCMethodMatchRegularExpression
+
+	service := "[^/]+"
+	if method.Service != nil && *method.Service != "" {
+		service = *method.Service
+		if !isRegex {
+			service = regexp.QuoteMeta(service)
+		}
+	}
+	grpcMethod := "[^/]+"
+	if method.Method != nil && *method.Method != "" {
+		grpcMethod = *method.Method
+		if !isRegex {
+			grpcMethod = regexp.QuoteMeta(grpcMethod)
+		}
+	}
+
+	path := fmt.Sprintf("%s/%s/%s", KongPathRegexPrefix, service, grpcMethod)
+	if !isRegex {
+		path += "$"
+	}
+	return []string{path}
 }

--- a/controller/hybridgateway/builder/kongroute_test.go
+++ b/controller/hybridgateway/builder/kongroute_test.go
@@ -1,6 +1,7 @@
 package builder
 
 import (
+	"regexp"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -628,4 +629,127 @@ func TestKongRouteBuilder_WithSpecTags(t *testing.T) {
 		route := NewKongRoute().WithSpecTags([]string{"foo", "bar"}).MustBuild()
 		assert.Equal(t, commonv1alpha1.Tags{"foo", "bar"}, route.Spec.Tags)
 	})
+}
+
+func TestGenerateKongRoutePathFromGRPCMethodMatch(t *testing.T) {
+	exact := gatewayv1.GRPCMethodMatchExact
+	regex := gatewayv1.GRPCMethodMatchRegularExpression
+
+	tests := []struct {
+		name     string
+		method   *gatewayv1.GRPCMethodMatch
+		expected []string
+	}{
+		{
+			name:     "nil method matches every service and method",
+			method:   nil,
+			expected: []string{KongGRPCRouteCatchAllPath},
+		},
+		{
+			name: "exact service and method",
+			method: &gatewayv1.GRPCMethodMatch{
+				Type:    &exact,
+				Service: new("foo.bar.v1.Service"),
+				Method:  new("DoThing"),
+			},
+			// "." in the service name is regexp.QuoteMeta-escaped so it matches a literal dot,
+			// not "any character" — see GenerateKongRoutePathFromGRPCMethodMatch's doc comment.
+			expected: []string{`~/foo\.bar\.v1\.Service/DoThing$`},
+		},
+		{
+			name: "service only matches any method of that service",
+			method: &gatewayv1.GRPCMethodMatch{
+				Type:    &exact,
+				Service: new("foo.bar.v1.Service"),
+			},
+			expected: []string{`~/foo\.bar\.v1\.Service/[^/]+$`},
+		},
+		{
+			name: "method only matches that method on any service",
+			method: &gatewayv1.GRPCMethodMatch{
+				Type:   &exact,
+				Method: new("DoThing"),
+			},
+			expected: []string{"~/[^/]+/DoThing$"},
+		},
+		{
+			name: "regular expression is not anchored",
+			method: &gatewayv1.GRPCMethodMatch{
+				Type:    &regex,
+				Service: new("foo.*"),
+				Method:  new("Do.*"),
+			},
+			expected: []string{"~/foo.*/Do.*"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			assert.Equal(t, tt.expected, GenerateKongRoutePathFromGRPCMethodMatch(tt.method))
+		})
+	}
+}
+
+// TestGenerateKongRoutePathFromGRPCMethodMatch_ExactDotsAreLiteral is a regression test for an
+// unescaped-regex-metacharacter bug: an Exact GRPCMethodMatch's Service/Method are literal
+// strings, but gRPC service names always contain "." (e.g. "foo.bar.Service"). Without
+// [regexp.QuoteMeta] escaping, "." compiles as "any character" in the generated Kong regex path,
+// so an Exact match for "foo.bar.Service" would incorrectly also match an unrelated
+// "fooXbarXService". This proves the compiled path matches only the literal service/method.
+func TestGenerateKongRoutePathFromGRPCMethodMatch_ExactDotsAreLiteral(t *testing.T) {
+	exact := gatewayv1.GRPCMethodMatchExact
+	paths := GenerateKongRoutePathFromGRPCMethodMatch(&gatewayv1.GRPCMethodMatch{
+		Type:    &exact,
+		Service: new("foo.bar.v1.Service"),
+		Method:  new("DoThing"),
+	})
+	require.Len(t, paths, 1)
+
+	// Strip the Kong regex-path prefix ("~") before compiling as a Go regexp.
+	re, err := regexp.Compile(paths[0][1:])
+	require.NoError(t, err)
+
+	assert.True(t, re.MatchString("/foo.bar.v1.Service/DoThing"), "must match the literal service/method")
+	assert.False(t, re.MatchString("/fooXbarXv1XService/DoThing"), "dots must not act as regex wildcards")
+}
+
+func TestKongRouteBuilder_WithGRPCRouteMatch(t *testing.T) {
+	exact := gatewayv1.GRPCMethodMatchExact
+	regexHeader := gatewayv1.GRPCHeaderMatchRegularExpression
+
+	route := NewKongRoute().WithGRPCRouteMatch(gatewayv1.GRPCRouteMatch{
+		Method: &gatewayv1.GRPCMethodMatch{
+			Type:    &exact,
+			Service: new("foo.bar.v1.Service"),
+			Method:  new("DoThing"),
+		},
+		Headers: []gatewayv1.GRPCHeaderMatch{
+			{Name: "version", Value: "v1"},
+			{Name: "color", Type: &regexHeader, Value: "^blue$"},
+		},
+	}).MustBuild()
+
+	assert.Equal(t, []string{`~/foo\.bar\.v1\.Service/DoThing$`}, route.Spec.Paths)
+	assert.Equal(t, map[string][]string{
+		"version": {"v1"},
+		"color":   {KongHeaderRegexPrefix + "^blue$"},
+	}, route.Spec.Headers)
+}
+
+// TestKongRouteBuilder_WithGRPCRouteMatch_NoMethod covers a GRPCRouteMatch with no Method matcher
+// at all (headers-only), which per Gateway API must match every service/method: WithGRPCRouteMatch
+// falls back to KongGRPCRouteCatchAllPath in that case (see GenerateKongRoutePathFromGRPCMethodMatch's
+// nil-method behavior, exercised at this builder layer rather than only indirectly via
+// kongroute.RoutesForGRPCRouteRule's tests).
+func TestKongRouteBuilder_WithGRPCRouteMatch_NoMethod(t *testing.T) {
+	route := NewKongRoute().WithGRPCRouteMatch(gatewayv1.GRPCRouteMatch{
+		Headers: []gatewayv1.GRPCHeaderMatch{
+			{Name: "version", Value: "v1"},
+		},
+	}).MustBuild()
+
+	assert.Equal(t, []string{KongGRPCRouteCatchAllPath}, route.Spec.Paths)
+	assert.Equal(t, map[string][]string{
+		"version": {"v1"},
+	}, route.Spec.Headers)
 }

--- a/controller/hybridgateway/converter/converter.go
+++ b/controller/hybridgateway/converter/converter.go
@@ -56,7 +56,7 @@ type DesiredStateReadinessChecker interface {
 // RootObject is an interface that represents all resource types that can be loaded
 // as root by the APIConverter.
 type RootObject interface {
-	gwtypes.HTTPRoute | gwtypes.TLSRoute | gwtypes.TCPRoute | gwtypes.Gateway
+	gwtypes.HTTPRoute | gwtypes.TLSRoute | gwtypes.GRPCRoute | gwtypes.TCPRoute | gwtypes.Gateway
 }
 
 // RootObjectPtr is a generic interface that represents a pointer to a type T,
@@ -75,6 +75,8 @@ func NewConverter[t RootObject](obj t, cl client.Client, fqdnMode bool, clusterD
 	// TODO: add other types here
 	case gwtypes.HTTPRoute:
 		return newHTTPRouteConverter(&o, cl, fqdnMode, clusterDomain).(APIConverter[t]), nil
+	case gwtypes.GRPCRoute:
+		return newGRPCRouteConverter(&o, cl, fqdnMode, clusterDomain).(APIConverter[t]), nil
 	case gwtypes.TLSRoute:
 		return newTLSRouteConverter(&o, cl, fqdnMode, clusterDomain).(APIConverter[t]), nil
 	case gwtypes.TCPRoute:

--- a/controller/hybridgateway/converter/grpc_route.go
+++ b/controller/hybridgateway/converter/grpc_route.go
@@ -1,0 +1,469 @@
+package converter
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	configurationv1 "github.com/kong/kong-operator/v2/api/configuration/v1"
+	configurationv1alpha1 "github.com/kong/kong-operator/v2/api/configuration/v1alpha1"
+	konnectv1alpha1 "github.com/kong/kong-operator/v2/api/konnect/v1alpha1"
+	"github.com/kong/kong-operator/v2/controller/hybridgateway/kongroute"
+	"github.com/kong/kong-operator/v2/controller/hybridgateway/metadata"
+	"github.com/kong/kong-operator/v2/controller/hybridgateway/namegen"
+	"github.com/kong/kong-operator/v2/controller/hybridgateway/plugin"
+	"github.com/kong/kong-operator/v2/controller/hybridgateway/pluginbinding"
+	"github.com/kong/kong-operator/v2/controller/hybridgateway/route"
+	"github.com/kong/kong-operator/v2/controller/hybridgateway/service"
+	"github.com/kong/kong-operator/v2/controller/hybridgateway/target"
+	"github.com/kong/kong-operator/v2/controller/hybridgateway/upstream"
+	"github.com/kong/kong-operator/v2/controller/hybridgateway/utils"
+	"github.com/kong/kong-operator/v2/controller/pkg/log"
+	gwtypes "github.com/kong/kong-operator/v2/internal/types"
+)
+
+var _ APIConverter[gwtypes.GRPCRoute] = &grpcRouteConverter{}
+var _ DesiredStateReadinessChecker = &grpcRouteConverter{}
+var _ OrphanedResourceHandler = &grpcRouteConverter{}
+
+type grpcRouteConverter struct {
+	client.Client
+
+	route         *gwtypes.GRPCRoute
+	outputStore   []client.Object
+	expectedGVKs  []schema.GroupVersionKind
+	fqdnMode      bool
+	clusterDomain string
+}
+
+// HandleOrphanedResource removes this GRPCRoute from an orphaned resource's hybrid-routes annotation.
+func (c *grpcRouteConverter) HandleOrphanedResource(ctx context.Context, logger logr.Logger, resource *unstructured.Unstructured) (skipDelete bool, err error) {
+	am := metadata.NewAnnotationManager(logger)
+	key := client.ObjectKeyFromObject(resource)
+	gvk := resource.GroupVersionKind()
+
+	fresh := &unstructured.Unstructured{}
+	fresh.SetGroupVersionKind(gvk)
+	if err := c.Get(ctx, key, fresh); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Already gone; nothing to delete.
+			return true, nil
+		}
+		return true, fmt.Errorf("failed to get resource: %w", err)
+	}
+
+	// If the route is not present in the hybrid-routes annotation of the Kong resource, don't touch it.
+	if !am.ContainsRoute(fresh, c.route) {
+		log.Trace(logger, "Route annotation not found, skipping resource", "kind", fresh.GetKind(), "obj", key)
+		return true, nil
+	}
+
+	base := fresh.DeepCopy()
+	am.RemoveRouteFromAnnotation(fresh, c.route)
+
+	// If other Routes are still present in the annotation, we just need to update the resource.
+	if len(am.GetRoutesWithKind(fresh, "GRPCRoute")) > 0 {
+		log.Debug(logger, "Updating hybrid-routes annotation", "kind", fresh.GetKind(), "obj", key)
+		if err := c.Patch(ctx, fresh, client.MergeFromWithOptions(base, client.MergeFromWithOptimisticLock{})); err != nil {
+			if apierrors.IsNotFound(err) {
+				return true, nil
+			}
+			return true, fmt.Errorf("failed to update resource: %w", err)
+		}
+		// Reflect the persisted state back onto the caller's resource.
+		resource.SetAnnotations(fresh.GetAnnotations())
+		resource.SetResourceVersion(fresh.GetResourceVersion())
+		return true, nil
+	}
+
+	// No other routes remain. Surface the validated resourceVersion (and the annotation
+	// removal) on the caller's resource so the orphan deletion uses it as an optimistic-lock
+	// precondition, and don't skip deletion.
+	resource.SetAnnotations(fresh.GetAnnotations())
+	resource.SetResourceVersion(fresh.GetResourceVersion())
+	return false, nil
+}
+
+// DesiredResourcesReady implements DesiredStateReadinessChecker. It decides whether orphan cleanup
+// may proceed for this GRPCRoute. Mirrors httpRouteConverter.DesiredResourcesReady's gate: see that
+// method's doc comment for the full rationale (serviceID-based, not Programmed-based, gating).
+func (c *grpcRouteConverter) DesiredResourcesReady(ctx context.Context, logger logr.Logger) (bool, error) {
+	desired, err := c.GetOutputStore(ctx, logger)
+	if err != nil {
+		return false, fmt.Errorf("failed to get desired objects for readiness check: %w", err)
+	}
+
+	for i := range desired {
+		d := &desired[i]
+		if d.GetKind() != "KongRoute" {
+			continue
+		}
+
+		r := &unstructured.Unstructured{}
+		r.SetGroupVersionKind(d.GroupVersionKind())
+		if err := c.Get(ctx, client.ObjectKeyFromObject(d), r); err != nil {
+			if apierrors.IsNotFound(err) {
+				log.Debug(logger, "Desired KongRoute not found yet, deferring orphan cleanup", "obj", client.ObjectKeyFromObject(d))
+				return false, nil
+			}
+			return false, fmt.Errorf("failed to get KongRoute %s: %w", client.ObjectKeyFromObject(d), err)
+		}
+
+		serviceRefName, _, _ := unstructured.NestedString(r.Object, "spec", "serviceRef", "namespacedRef", "name")
+		if serviceRefName == "" {
+			log.Debug(logger, "KongRoute has no serviceRef, skipping readiness check", "obj", client.ObjectKeyFromObject(r))
+			continue
+		}
+		boundServiceID, _, _ := unstructured.NestedString(r.Object, "status", "konnect", "serviceID")
+
+		var svc configurationv1alpha1.KongService
+		if err := c.Get(ctx, client.ObjectKey{Namespace: d.GetNamespace(), Name: serviceRefName}, &svc); err != nil {
+			if apierrors.IsNotFound(err) {
+				log.Debug(logger, "Referenced KongService not found yet, deferring orphan cleanup", "route", client.ObjectKeyFromObject(r), "service", serviceRefName)
+				return false, nil
+			}
+			return false, fmt.Errorf("failed to get KongService %s for route %s: %w", serviceRefName, client.ObjectKeyFromObject(r), err)
+		}
+		if !meta.IsStatusConditionTrue(svc.Status.Conditions, konnectv1alpha1.KonnectEntityProgrammedConditionType) {
+			log.Debug(logger, "Referenced KongService not Programmed yet, deferring orphan cleanup", "route", client.ObjectKeyFromObject(r), "service", serviceRefName)
+			return false, nil
+		}
+
+		var desiredServiceID string
+		if svc.Status.Konnect != nil {
+			desiredServiceID = svc.Status.Konnect.ID
+		}
+		if desiredServiceID == "" || boundServiceID != desiredServiceID {
+			log.Debug(logger, "KongRoute not yet bound to its referenced KongService in Konnect, deferring orphan cleanup",
+				"route", client.ObjectKeyFromObject(r),
+				"service", serviceRefName,
+				"boundServiceID", boundServiceID,
+				"desiredServiceID", desiredServiceID)
+			return false, nil
+		}
+	}
+
+	log.Debug(logger, "All routes are bound to their referenced KongService in Konnect, orphan cleanup may proceed")
+	return true, nil
+}
+
+// GetExpectedGVKs returns the ordered list of Kong resource GVKs managed for a GRPCRoute.
+func (c *grpcRouteConverter) GetExpectedGVKs() []schema.GroupVersionKind {
+	return c.expectedGVKs
+}
+
+// Translate converts the GRPCRoute into desired Kong resources and stores them in the output store.
+func (c *grpcRouteConverter) Translate(ctx context.Context, logger logr.Logger) (int, error) {
+	if err := c.translate(ctx, logger); err != nil {
+		return 0, err
+	}
+	return len(c.outputStore), nil
+}
+
+// GetRootObject returns a copy of the GRPCRoute managed by this converter.
+func (c *grpcRouteConverter) GetRootObject() gwtypes.GRPCRoute {
+	return *c.route
+}
+
+// GetOutputStore converts the translated Kong resources into unstructured objects.
+func (c *grpcRouteConverter) GetOutputStore(ctx context.Context, logger logr.Logger) ([]unstructured.Unstructured, error) {
+	logger = logger.WithValues("phase", "output-store-conversion")
+	log.Debug(logger, "Starting output store conversion")
+
+	var conversionErrors []error
+
+	objects := make([]unstructured.Unstructured, 0, len(c.outputStore))
+	for _, obj := range c.outputStore {
+		unstr, err := utils.ToUnstructured(obj, c.Scheme())
+		if err != nil {
+			conversionErr := fmt.Errorf("failed to convert %T %s to unstructured: %w", obj, obj.GetName(), err)
+			conversionErrors = append(conversionErrors, conversionErr)
+			log.Error(logger, err, "Failed to convert object to unstructured",
+				"objectName", obj.GetName())
+			continue
+		}
+		objects = append(objects, unstr)
+	}
+
+	// Check if any conversion errors occurred and return aggregated error.
+	if len(conversionErrors) > 0 {
+		log.Error(logger, nil, "Output store conversion completed with errors",
+			"totalObjectsAttempted", len(c.outputStore),
+			"successfulConversions", len(objects),
+			"conversionErrors", len(conversionErrors))
+
+		// Join all errors using errors.Join for better error handling.
+		return objects, fmt.Errorf("output store conversion failed with %d errors: %w", len(conversionErrors), errors.Join(conversionErrors...))
+	}
+
+	log.Debug(logger, "Successfully converted all objects in output store",
+		"totalObjectsConverted", len(objects))
+
+	log.Debug(logger, "Finished output store conversion", "totalObjectsConverted", len(objects))
+	return objects, nil
+}
+
+// UpdateRootObjectStatus reconciles the GRPCRoute status conditions for its parent references.
+func (c *grpcRouteConverter) UpdateRootObjectStatus(ctx context.Context, logger logr.Logger) (updated bool, stop bool, err error) {
+	return route.UpdateRouteStatus(ctx, logger, c.Client, c.route, c.expectedGVKs, route.BuildResolvedRefsConditionForGRPCRoute)
+}
+
+func newGRPCRouteConverter(grpcRoute *gwtypes.GRPCRoute, cl client.Client, fqdnMode bool, clusterDomain string) APIConverter[gwtypes.GRPCRoute] {
+	return &grpcRouteConverter{
+		Client:        cl,
+		route:         grpcRoute,
+		outputStore:   []client.Object{},
+		fqdnMode:      fqdnMode,
+		clusterDomain: clusterDomain,
+		expectedGVKs: []schema.GroupVersionKind{
+			{Group: configurationv1alpha1.GroupVersion.Group, Version: configurationv1alpha1.GroupVersion.Version, Kind: "KongRoute"},
+			{Group: configurationv1alpha1.GroupVersion.Group, Version: configurationv1alpha1.GroupVersion.Version, Kind: "KongTarget"},
+			{Group: configurationv1alpha1.GroupVersion.Group, Version: configurationv1alpha1.GroupVersion.Version, Kind: "KongPluginBinding"},
+			{Group: configurationv1alpha1.GroupVersion.Group, Version: configurationv1alpha1.GroupVersion.Version, Kind: "KongService"},
+			{Group: configurationv1alpha1.GroupVersion.Group, Version: configurationv1alpha1.GroupVersion.Version, Kind: "KongCertificate"},
+			{Group: configurationv1alpha1.GroupVersion.Group, Version: configurationv1alpha1.GroupVersion.Version, Kind: "KongReferenceGrant"},
+			{Group: configurationv1alpha1.GroupVersion.Group, Version: configurationv1alpha1.GroupVersion.Version, Kind: "KongUpstream"},
+			{Group: configurationv1alpha1.GroupVersion.Group, Version: configurationv1.GroupVersion.Version, Kind: "KongPlugin"},
+		},
+	}
+}
+
+func (c *grpcRouteConverter) translate(ctx context.Context, logger logr.Logger) error {
+	logger = logger.WithValues("phase", "grpcroute-translate")
+	log.Debug(logger, "Starting GRPCRoute translation")
+
+	var translationErrors []error
+
+	supportedParentRefs, err := getHybridGatewayParents(ctx, logger, c.Client, c.route)
+	if err != nil {
+		log.Error(logger, err, "Failed to get supported parent references")
+		return err
+	}
+	if len(supportedParentRefs) == 0 {
+		log.Info(logger, "No supported parent references found, skipping translation")
+		return nil
+	}
+
+	log.Debug(logger, "Found supported parent references",
+		"parentRefCount", len(supportedParentRefs))
+
+	for _, pRefData := range supportedParentRefs {
+		pRef := pRefData.parentRef
+		cp := pRefData.cpRef
+		hostnames := pRefData.hostnames
+		var namingParentRef *gwtypes.ParentReference
+		if len(supportedParentRefs) > 1 {
+			namingParentRef = &pRef
+		}
+
+		log.Debug(logger, "Processing parent reference",
+			"parentRef", pRef,
+			"hostnames", hostnames,
+			"ruleCount", len(c.route.Spec.Rules))
+
+		for ruleIndex, rule := range c.route.Spec.Rules {
+			log.Debug(logger, "Processing rule",
+				"ruleIndex", ruleIndex,
+				"backendRefCount", len(rule.BackendRefs),
+				"matchCount", len(rule.Matches),
+				"filterCount", len(rule.Filters))
+
+			upstreamName := namegen.NewKongUpstreamNameForGRPCRouteRule(c.route, cp, rule)
+
+			targets, err := target.TargetsForBackendRefs(
+				ctx,
+				logger.WithValues("upstream", upstreamName),
+				c.Client,
+				c.route,
+				rule.BackendRefs,
+				&pRef,
+				upstreamName,
+				c.fqdnMode,
+				c.clusterDomain,
+			)
+			if err != nil {
+				log.Error(logger, err, "Failed to translate KongTarget resources for rule, skipping rule",
+					"upstream", upstreamName,
+					"backendRefs", rule.BackendRefs,
+					"parentRef", pRef)
+				translationErrors = append(translationErrors, fmt.Errorf("failed to translate KongTarget resources for upstream %s: %w", upstreamName, err))
+				continue
+			}
+			log.Debug(logger, "Successfully translated KongTarget resources", "upstream", upstreamName, "targetCount", len(targets))
+
+			serviceNameOverride := ""
+			if len(rule.BackendRefs) > 0 && len(targets) == 0 {
+				serviceNameOverride = namegen.NewKongServiceNameForGRPCRouteRuleBackendNotFound(c.route, cp, rule)
+			}
+
+			servicePtr, certPtr, grantPtr, err := service.ServiceForRuleWithName(ctx, logger, c.Client, c.route, rule, &pRef, cp, upstreamName, serviceNameOverride)
+			if err != nil {
+				log.Error(logger, err, "Failed to translate KongService resource, skipping rule",
+					"controlPlane", cp.KonnectNamespacedRef,
+					"upstream", upstreamName)
+				translationErrors = append(translationErrors, fmt.Errorf("failed to translate KongService for rule: %w", err))
+				continue
+			}
+			serviceName := servicePtr.Name
+
+			routes, err := kongroute.RoutesForRule(ctx, logger, c.Client, c.route, rule, ruleIndex, &pRef, cp, namingParentRef, serviceName, hostnames)
+			if err != nil {
+				log.Error(logger, err, "Failed to translate KongRoute resources for rule, skipping rule",
+					"ruleIndex", ruleIndex,
+					"service", serviceName,
+					"hostnames", hostnames)
+				translationErrors = append(translationErrors, fmt.Errorf("failed to translate KongRoutes for rule %d: %w", ruleIndex, err))
+				continue
+			}
+
+			// Build the KongPlugin and KongPluginBinding resources.
+			log.Debug(logger, "Processing filters for rule",
+				"filterCount", len(rule.Filters))
+			filterOutputs := make([]client.Object, 0)
+
+			// Translate the rule's filters into KongPlugins. RequestMirror is not yet supported
+			// (see translateGRPCFromFilter); filters that map to the same Kong plugin type are
+			// merged into a single KongPlugin so a route never gets two plugins of the same type
+			// bound to it (Kong's unique-plugin-per-entity constraint).
+			plugins, err := plugin.GRPCPluginsForRule(ctx, logger, c.Client, c.route, rule, &pRef)
+			if err != nil {
+				log.Error(logger, err, "Failed to translate KongPlugin resources for rule, skipping plugins",
+					"ruleIndex", ruleIndex)
+				translationErrors = append(translationErrors, fmt.Errorf("failed to translate KongPlugins for rule %d: %w", ruleIndex, err))
+				plugins = nil
+			}
+
+			for i := range plugins {
+				pluginObj := &plugins[i]
+				pluginName := pluginObj.Name
+				filterOutputs = append(filterOutputs, pluginObj)
+				// Create a KongPluginBinding to bind the KongPlugin to each KongRoute generated for the rule.
+				for _, r := range routes {
+					bindingPtr, err := pluginbinding.BindingForGRPCPluginAndRoute(
+						ctx,
+						logger,
+						c.Client,
+						c.route,
+						&pRef,
+						cp,
+						pluginName,
+						r.Name,
+					)
+					if err != nil {
+						log.Error(logger, err, "Failed to build KongPluginBinding resource, skipping binding",
+							"plugin", pluginName,
+							"kongRoute", r.Name)
+						translationErrors = append(translationErrors, fmt.Errorf("failed to build KongPluginBinding for plugin %s: %w", pluginName, err))
+						continue
+					}
+					bindingName := bindingPtr.Name
+					filterOutputs = append(filterOutputs, bindingPtr)
+
+					log.Debug(logger, "Successfully translated KongPlugin and KongPluginBinding resources",
+						"plugin", pluginName,
+						"binding", bindingName,
+						"route", r.Name)
+				}
+			}
+
+			upstreamPtr, err := upstream.UpstreamForRule(ctx, logger, c.Client, c.route, rule, &pRef, cp)
+			if err != nil {
+				log.Error(logger, err, "Failed to translate KongUpstream resource for rule, skipping rule",
+					"controlPlane", cp.KonnectNamespacedRef)
+				translationErrors = append(translationErrors, fmt.Errorf("failed to translate KongUpstream resource: %w", err))
+				continue
+			}
+
+			ruleOutputs := []client.Object{upstreamPtr}
+			log.Debug(logger, "Successfully translated KongUpstream resource", "upstream", upstreamName)
+
+			// Append KongReferenceGrant before KongCertificate so the grant exists when the cert is applied.
+			if grantPtr != nil {
+				ruleOutputs = append(ruleOutputs, grantPtr)
+				log.Debug(logger, "Successfully translated KongReferenceGrant resource", "grant", grantPtr.Name)
+			}
+			if certPtr != nil {
+				ruleOutputs = append(ruleOutputs, certPtr)
+				log.Debug(logger, "Successfully translated KongCertificate resource", "cert", certPtr.Name)
+			}
+			ruleOutputs = append(ruleOutputs, servicePtr)
+			log.Debug(logger, "Successfully translated KongService resource", "service", serviceName)
+			for _, r := range routes {
+				routeName := r.Name
+				ruleOutputs = append(ruleOutputs, r)
+				log.Debug(logger, "Successfully translated KongRoute resource", "route", routeName)
+			}
+			ruleOutputs = append(ruleOutputs, filterOutputs...)
+
+			// Per Gateway API semantics, a rule that resolves to no valid backend must not
+			// silently succeed. GRPCRoute has no filter analogous to HTTPRoute's RequestRedirect
+			// that produces a response without a backend, so unlike HTTPRoute's translate() this
+			// safety net applies unconditionally whenever a rule with backendRefs resolves to no
+			// targets.
+			if len(targets) == 0 {
+				terminationPlugin, err := plugin.GRPCRequestTerminationForBackendNotFound(
+					ctx,
+					logger,
+					c.Client,
+					c.route,
+					&pRef,
+					serviceName,
+				)
+				if err != nil {
+					log.Error(logger, err, "Failed to translate request-termination plugin for backend-less rule",
+						"service", serviceName,
+						"backendRefs", rule.BackendRefs)
+					translationErrors = append(translationErrors, fmt.Errorf("failed to translate request-termination plugin for service %s: %w", serviceName, err))
+					continue
+				}
+
+				bindingPtr, err := pluginbinding.BindingForGRPCPluginAndService(
+					ctx,
+					logger,
+					c.Client,
+					c.route,
+					&pRef,
+					cp,
+					terminationPlugin.Name,
+					serviceName,
+				)
+				if err != nil {
+					log.Error(logger, err, "Failed to bind request-termination plugin to service",
+						"service", serviceName,
+						"plugin", terminationPlugin.Name)
+					translationErrors = append(translationErrors, fmt.Errorf("failed to bind request-termination plugin %s to service %s: %w", terminationPlugin.Name, serviceName, err))
+					continue
+				}
+				ruleOutputs = append(ruleOutputs, terminationPlugin, bindingPtr)
+			}
+
+			for i := range targets {
+				ruleOutputs = append(ruleOutputs, &targets[i])
+			}
+
+			c.outputStore = append(c.outputStore, ruleOutputs...)
+		}
+	}
+
+	c.outputStore = deduplicateOutputStore(c.outputStore)
+
+	if len(translationErrors) > 0 {
+		log.Error(logger, nil, "GRPCRoute translation completed with errors",
+			"totalResourcesCreated", len(c.outputStore),
+			"errorCount", len(translationErrors))
+
+		return fmt.Errorf("translation failed with %d errors: %w", len(translationErrors), errors.Join(translationErrors...))
+	}
+
+	log.Debug(logger, "Successfully completed GRPCRoute translation",
+		"totalResourcesCreated", len(c.outputStore))
+
+	return nil
+}

--- a/controller/hybridgateway/converter/grpc_route_converter_test.go
+++ b/controller/hybridgateway/converter/grpc_route_converter_test.go
@@ -1,0 +1,210 @@
+package converter
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	configurationv1alpha1 "github.com/kong/kong-operator/v2/api/configuration/v1alpha1"
+	konnectv1alpha2 "github.com/kong/kong-operator/v2/api/konnect/v1alpha2"
+	gwtypes "github.com/kong/kong-operator/v2/internal/types"
+	"github.com/kong/kong-operator/v2/modules/manager/scheme"
+)
+
+func TestGRPCRouteConverter_GetOutputStore(t *testing.T) {
+	ctx := t.Context()
+	logger := logr.Discard()
+
+	validUpstream := &configurationv1alpha1.KongUpstream{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "upstream-1",
+			Namespace: "default",
+		},
+	}
+	validService := &configurationv1alpha1.KongService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "service-1",
+			Namespace: "default",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme.Get()).Build()
+	converter := newGRPCRouteConverter(&gwtypes.GRPCRoute{}, fakeClient, false, "").(*grpcRouteConverter)
+	converter.outputStore = []client.Object{validUpstream, validService}
+
+	objects, err := converter.GetOutputStore(ctx, logger)
+	require.NoError(t, err)
+	require.Len(t, objects, 2, "GetOutputStore must return exactly len(outputStore) objects, no leading zero-value entries")
+	assert.Equal(t, "upstream-1", objects[0].GetName())
+	assert.Equal(t, "service-1", objects[1].GetName())
+	for _, obj := range objects {
+		assert.NotEmpty(t, obj.GetName(), "no zero-value/empty entries expected")
+	}
+}
+
+func TestGRPCRouteConverter_DesiredResourcesReady(t *testing.T) {
+	ctx := t.Context()
+	const (
+		ns           = "default"
+		routeName    = "route-1"
+		svcName      = "svc-1"
+		konnectSvcID = "konnect-svc-id-abc"
+	)
+
+	routeGVK := configurationv1alpha1.GroupVersion.WithKind("KongRoute")
+
+	desiredRoute := func(name string) *configurationv1alpha1.KongRoute {
+		r := &configurationv1alpha1.KongRoute{}
+		r.Name = name
+		r.Namespace = ns
+		r.SetGroupVersionKind(routeGVK)
+		return r
+	}
+
+	clusterRoute := func(name, serviceRefName, boundServiceID string) *unstructured.Unstructured {
+		u := &unstructured.Unstructured{}
+		u.SetGroupVersionKind(routeGVK)
+		u.SetName(name)
+		u.SetNamespace(ns)
+		if serviceRefName != "" {
+			_ = unstructured.SetNestedField(u.Object, serviceRefName, "spec", "serviceRef", "namespacedRef", "name")
+		}
+		if boundServiceID != "" {
+			_ = unstructured.SetNestedField(u.Object, boundServiceID, "status", "konnect", "serviceID")
+		}
+		return u
+	}
+
+	kongService := func(name string, programmed bool, konnectID string) *configurationv1alpha1.KongService {
+		svc := &configurationv1alpha1.KongService{}
+		svc.Name = name
+		svc.Namespace = ns
+		if programmed {
+			svc.Status.Conditions = []metav1.Condition{{
+				Type:               "Programmed",
+				Status:             metav1.ConditionTrue,
+				Reason:             "Programmed",
+				LastTransitionTime: metav1.Now(),
+			}}
+		}
+		if konnectID != "" {
+			svc.Status.Konnect = &konnectv1alpha2.KonnectEntityStatusWithControlPlaneAndCertificateAndCACertificatesRefs{
+				KonnectEntityStatus: konnectv1alpha2.KonnectEntityStatus{ID: konnectID},
+			}
+		}
+		return svc
+	}
+
+	baseRoute := &gwtypes.GRPCRoute{ObjectMeta: metav1.ObjectMeta{Name: "test-route", Namespace: ns}}
+
+	tests := []struct {
+		name            string
+		outputStore     []client.Object
+		existingObjs    []client.Object
+		interceptorFn   *interceptor.Funcs
+		wantReady       bool
+		wantErrContains string
+	}{
+		{
+			name:            "GetOutputStore error is propagated",
+			outputStore:     []client.Object{&badObject{Name: "bad"}},
+			wantReady:       false,
+			wantErrContains: "failed to get desired objects for readiness check",
+		},
+		{
+			name:        "empty output store → ready",
+			outputStore: nil,
+			wantReady:   true,
+		},
+		{
+			name:        "desired KongRoute not yet in cluster → defer (NotFound)",
+			outputStore: []client.Object{desiredRoute(routeName)},
+			wantReady:   false,
+		},
+		{
+			name:        "Get KongRoute returns non-NotFound error → propagate",
+			outputStore: []client.Object{desiredRoute(routeName)},
+			interceptorFn: &interceptor.Funcs{
+				Get: func(ctx context.Context, c client.WithWatch, key client.ObjectKey, obj client.Object, opts ...client.GetOption) error {
+					if _, ok := obj.(*unstructured.Unstructured); ok && key.Name == routeName {
+						return fmt.Errorf("simulated get error")
+					}
+					return c.Get(ctx, key, obj, opts...)
+				},
+			},
+			wantReady:       false,
+			wantErrContains: "failed to get KongRoute",
+		},
+		{
+			name:         "KongRoute found, no serviceRef (serviceless route) → ready",
+			outputStore:  []client.Object{desiredRoute(routeName)},
+			existingObjs: []client.Object{clusterRoute(routeName, "", "")},
+			wantReady:    true,
+		},
+		{
+			name:         "KongRoute found with serviceRef, KongService not found → defer",
+			outputStore:  []client.Object{desiredRoute(routeName)},
+			existingObjs: []client.Object{clusterRoute(routeName, svcName, "")},
+			wantReady:    false,
+		},
+		{
+			name:         "KongService found but not Programmed → defer",
+			outputStore:  []client.Object{desiredRoute(routeName)},
+			existingObjs: []client.Object{clusterRoute(routeName, svcName, ""), kongService(svcName, false, "")},
+			wantReady:    false,
+		},
+		{
+			name:        "KongService Programmed, Konnect ID set, but route bound to old service ID → defer",
+			outputStore: []client.Object{desiredRoute(routeName)},
+			existingObjs: []client.Object{
+				clusterRoute(routeName, svcName, "old-service-id"),
+				kongService(svcName, true, konnectSvcID),
+			},
+			wantReady: false,
+		},
+		{
+			name:        "KongRoute bound to correct service ID → ready",
+			outputStore: []client.Object{desiredRoute(routeName)},
+			existingObjs: []client.Object{
+				clusterRoute(routeName, svcName, konnectSvcID),
+				kongService(svcName, true, konnectSvcID),
+			},
+			wantReady: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			builder := fake.NewClientBuilder().WithScheme(scheme.Get())
+			if len(tt.existingObjs) > 0 {
+				builder = builder.WithObjects(tt.existingObjs...)
+			}
+			if tt.interceptorFn != nil {
+				builder = builder.WithInterceptorFuncs(*tt.interceptorFn)
+			}
+			cl := builder.Build()
+
+			conv := newGRPCRouteConverter(baseRoute, cl, false, "").(*grpcRouteConverter)
+			conv.outputStore = tt.outputStore
+
+			ready, err := conv.DesiredResourcesReady(ctx, logr.Discard())
+
+			if tt.wantErrContains != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.wantErrContains)
+				return
+			}
+			require.NoError(t, err)
+			assert.Equal(t, tt.wantReady, ready)
+		})
+	}
+}

--- a/controller/hybridgateway/kongroute/route.go
+++ b/controller/hybridgateway/kongroute/route.go
@@ -64,6 +64,12 @@ func RoutesForRule[
 			return nil, fmt.Errorf("failed to build KongRoute: unmatched route type and rule type: %T and %T", route, rule)
 		}
 		return RoutesForHTTPRouteRule(ctx, logger, cl, r, httpRule, ruleIndex, pRef, cp, namingParentRef, serviceName, hostnames)
+	case *gwtypes.GRPCRoute:
+		grpcRule, ok := any(rule).(gwtypes.GRPCRouteRule)
+		if !ok {
+			return nil, fmt.Errorf("failed to build KongRoute: unmatched route type and rule type: %T and %T", route, rule)
+		}
+		return RoutesForGRPCRouteRule(ctx, logger, cl, r, grpcRule, ruleIndex, pRef, cp, namingParentRef, serviceName, hostnames)
 	case *gwtypes.TLSRoute:
 		tlsRule, ok := any(rule).(gwtypes.TLSRouteRule)
 		if !ok {
@@ -176,6 +182,185 @@ func RoutesForHTTPRouteRule(
 	}
 
 	return kongRoutes, nil
+}
+
+// RoutesForGRPCRouteRule creates or updates KongRoutes for the given GRPCRoute rule.
+// It generates one KongRoute per match in the rule, mirroring RoutesForHTTPRouteRule's
+// one-KongRoute-per-match approach for preserving Gateway API's OR-across-matches semantics.
+//
+// Unlike HTTPRoute, GRPCRouteMatch has no path field, so every match's regex_priority is set
+// explicitly from grpcRouteMatchPriorities rather than only for a header-only subset: Kong's own
+// path-based prioritization has no path-length/path-type signal to key off for gRPC, since the
+// path Kong sees is always synthesized from the method matcher (see
+// builder.GenerateKongRoutePathFromGRPCMethodMatch).
+func RoutesForGRPCRouteRule(
+	ctx context.Context,
+	logger logr.Logger,
+	cl client.Client,
+	grpcRoute *gwtypes.GRPCRoute,
+	rule gwtypes.GRPCRouteRule,
+	ruleIndex int,
+	pRef *gwtypes.ParentReference,
+	cp *commonv1alpha1.ControlPlaneRef,
+	namingParentRef *gwtypes.ParentReference,
+	serviceName string,
+	hostnames []string,
+) ([]*configurationv1alpha1.KongRoute, error) {
+	var kongRoutes []*configurationv1alpha1.KongRoute
+
+	// If the rule has no matches, create a single catch-all route.
+	// Kong requires at least one matcher; a matcher with no Method matches every
+	// service/method per Gateway API semantics.
+	if len(rule.Matches) == 0 {
+		rule.Matches = append(rule.Matches, gatewayv1.GRPCRouteMatch{})
+	}
+
+	protocols, err := grpcProtocolsFromGatewayListener(ctx, cl, grpcRoute, pRef)
+	if err != nil {
+		return nil, err
+	}
+
+	priorities := grpcRouteMatchPriorities(grpcRoute)
+	tags := pkgmetadata.ExtractTags(grpcRoute)
+
+	for i, match := range rule.Matches {
+		routeName := namegen.NewKongRouteNameForGRPCRouteMatch(grpcRoute, cp, namingParentRef, match, i)
+		mLog := logger.WithValues("kongroute", routeName, "matchIndex", i)
+		log.Debug(mLog, "Creating KongRoute for GRPCRoute match")
+
+		priority := priorityForGRPCRouteMatch(priorities, ruleIndex, i)
+
+		routeBuilder := builder.NewKongRoute().
+			WithName(routeName).
+			WithNamespace(metadata.NamespaceFromParentRef(grpcRoute, pRef)).
+			WithLabels(grpcRoute, pRef).
+			WithAnnotations(grpcRoute, pRef).
+			WithSpecName(routeName).
+			WithProtocols(protocols...).
+			WithHosts(hostnames).
+			WithSpecTags(tags).
+			WithKongService(serviceName).
+			WithGRPCRouteMatch(match).
+			WithRegexPriority(&priority)
+
+		newRoute, buildErr := routeBuilder.Build()
+		if buildErr != nil {
+			log.Error(mLog, buildErr, "Failed to build KongRoute resource")
+			return nil, fmt.Errorf("failed to build KongRoute %s: %w", routeName, buildErr)
+		}
+
+		if _, updErr := translator.VerifyAndUpdate(ctx, mLog, cl, &newRoute, grpcRoute, true); updErr != nil {
+			return nil, updErr
+		}
+
+		kongRoutes = append(kongRoutes, newRoute.DeepCopy())
+	}
+
+	return kongRoutes, nil
+}
+
+type grpcRouteMatchPriorityKey struct {
+	ruleIndex  int
+	matchIndex int
+}
+
+// grpcRoutePriorityClass mirrors httpRoutePriorityClass but keys on GRPCRoute's own precedence
+// criteria (Gateway API grpcroute_types.go): characters in a matching service, characters in a
+// matching method, then header count. GRPCRouteMatch has no path, so there's no path-type/length
+// dimension to carry over from the HTTP variant.
+type grpcRoutePriorityClass struct {
+	serviceLength int
+	methodLength  int
+	headerCount   int
+}
+
+// grpcRouteMatchPriorities computes a regex_priority for every match across the whole GRPCRoute,
+// ranking classes least-to-most specific and breaking ties within a class in favor of the
+// earlier-declared rule/match, per Gateway API's "first matching rule" tie-break rule.
+func grpcRouteMatchPriorities(grpcRoute *gwtypes.GRPCRoute) map[grpcRouteMatchPriorityKey]int64 {
+	classes := make([]grpcRoutePriorityClass, 0)
+	classSet := make(map[grpcRoutePriorityClass]struct{})
+	matchCountByClass := make(map[grpcRoutePriorityClass]int)
+	for _, rule := range grpcRoute.Spec.Rules {
+		for _, match := range rule.Matches {
+			class := calculateGRPCRoutePriorityClass(match)
+			if _, ok := classSet[class]; !ok {
+				classSet[class] = struct{}{}
+				classes = append(classes, class)
+			}
+			matchCountByClass[class]++
+		}
+	}
+
+	slices.SortFunc(classes, compareGRPCRoutePriorityClass)
+	rankByClass := make(map[grpcRoutePriorityClass]int64, len(classes))
+	for rank, class := range classes {
+		rankByClass[class] = int64(rank)
+	}
+
+	// See httpRouteMatchPriorities: bounds the number of matches sharing a class so their
+	// offsets don't overflow into the adjacent class' range.
+	const priorityClassSize = int64(1 << 10)
+	seenByClass := make(map[grpcRoutePriorityClass]int)
+	priorities := make(map[grpcRouteMatchPriorityKey]int64)
+	for ruleIndex, rule := range grpcRoute.Spec.Rules {
+		for matchIndex, match := range rule.Matches {
+			class := calculateGRPCRoutePriorityClass(match)
+			offset := matchCountByClass[class] - 1 - seenByClass[class]
+			seenByClass[class]++
+			priorities[grpcRouteMatchPriorityKey{
+				ruleIndex:  ruleIndex,
+				matchIndex: matchIndex,
+			}] = rankByClass[class]*priorityClassSize + int64(offset)
+		}
+	}
+	return priorities
+}
+
+func priorityForGRPCRouteMatch(priorities map[grpcRouteMatchPriorityKey]int64, ruleIndex, matchIndex int) int64 {
+	return priorities[grpcRouteMatchPriorityKey{
+		ruleIndex:  ruleIndex,
+		matchIndex: matchIndex,
+	}]
+}
+
+func calculateGRPCRoutePriorityClass(match gatewayv1.GRPCRouteMatch) grpcRoutePriorityClass {
+	class := grpcRoutePriorityClass{}
+	if match.Method != nil {
+		if match.Method.Service != nil {
+			class.serviceLength = len(*match.Method.Service)
+		}
+		if match.Method.Method != nil {
+			class.methodLength = len(*match.Method.Method)
+		}
+	}
+	class.headerCount = countEffectiveGRPCHeaderMatches(match.Headers)
+	return class
+}
+
+func compareGRPCRoutePriorityClass(a, b grpcRoutePriorityClass) int {
+	if c := a.serviceLength - b.serviceLength; c != 0 {
+		return c
+	}
+	if c := a.methodLength - b.methodLength; c != 0 {
+		return c
+	}
+	if c := a.headerCount - b.headerCount; c != 0 {
+		return c
+	}
+	return 0
+}
+
+func countEffectiveGRPCHeaderMatches(headers []gatewayv1.GRPCHeaderMatch) int {
+	seenHeaders := make(map[string]struct{}, len(headers))
+	for _, header := range headers {
+		name := strings.ToLower(string(header.Name))
+		if _, ok := seenHeaders[name]; ok {
+			continue
+		}
+		seenHeaders[name] = struct{}{}
+	}
+	return len(seenHeaders)
 }
 
 type httpRouteMatchPriorityKey struct {
@@ -511,23 +696,25 @@ func tcpDestinationPorts(
 }
 
 // protocolsFromGatewayListener derives Kong route protocols from the Gateway listener
-// referenced by the HTTPRoute's parentRef. It inspects the listener protocol and maps:
+// referenced by the route's parentRef. GRPCRoute attaches to the same HTTP/HTTPS listeners as
+// HTTPRoute (gRPC runs over HTTP/2), so both route kinds share this resolver. It inspects the
+// listener protocol and maps:
 //   - HTTP  → "http"
 //   - HTTPS → "https"
 //
 // Returns nil when no matching listeners are found (relies on Kong Gateway defaults).
 func protocolsFromGatewayListener(
-	ctx context.Context, cl client.Client, httpRoute *gwtypes.HTTPRoute, parentRef *gwtypes.ParentReference,
+	ctx context.Context, cl client.Client, route client.Object, parentRef *gwtypes.ParentReference,
 ) ([]sdkkonnectcomp.Protocols, error) {
-	ns := httpRoute.Namespace
+	ns := route.GetNamespace()
 	if parentRef.Namespace != nil && *parentRef.Namespace != "" {
 		ns = string(*parentRef.Namespace)
 	}
 
 	gw := &gwtypes.Gateway{}
 	if err := cl.Get(ctx, client.ObjectKey{Namespace: ns, Name: string(parentRef.Name)}, gw); err != nil {
-		return nil, fmt.Errorf("failed to get parent Gateway %s/%s for HTTPRoute %s/%s: %w",
-			ns, parentRef.Name, httpRoute.Namespace, httpRoute.Name, err)
+		return nil, fmt.Errorf("failed to get parent Gateway %s/%s for %s %s/%s: %w",
+			ns, parentRef.Name, route.GetObjectKind().GroupVersionKind().Kind, route.GetNamespace(), route.GetName(), err)
 	}
 
 	protos := gatewayutils.ProtocolsFromListeners(gw, parentRef.SectionName)
@@ -540,6 +727,28 @@ func protocolsFromGatewayListener(
 		protocols = append(protocols, sdkkonnectcomp.Protocols(p))
 	}
 	return protocols, nil
+}
+
+func grpcProtocolsFromGatewayListener(
+	ctx context.Context, cl client.Client, route client.Object, parentRef *gwtypes.ParentReference,
+) ([]sdkkonnectcomp.Protocols, error) {
+	protocols, err := protocolsFromGatewayListener(ctx, cl, route, parentRef)
+	if err != nil {
+		return nil, err
+	}
+
+	grpcProtocols := make([]sdkkonnectcomp.Protocols, 0, len(protocols))
+	for _, p := range protocols {
+		switch p {
+		case sdkkonnectcomp.ProtocolsHTTP:
+			grpcProtocols = append(grpcProtocols, sdkkonnectcomp.ProtocolsGrpc)
+		case sdkkonnectcomp.ProtocolsHTTPS:
+			grpcProtocols = append(grpcProtocols, sdkkonnectcomp.ProtocolsGrpcs)
+		default:
+			grpcProtocols = append(grpcProtocols, p)
+		}
+	}
+	return grpcProtocols, nil
 }
 
 // isTLSRoutePassthrough checks if the TLSRoute's parent Gateway listener uses TLS passthrough mode

--- a/controller/hybridgateway/kongroute/route.go
+++ b/controller/hybridgateway/kongroute/route.go
@@ -208,12 +208,7 @@ func RoutesForGRPCRouteRule(
 ) ([]*configurationv1alpha1.KongRoute, error) {
 	var kongRoutes []*configurationv1alpha1.KongRoute
 
-	// If the rule has no matches, create a single catch-all route.
-	// Kong requires at least one matcher; a matcher with no Method matches every
-	// service/method per Gateway API semantics.
-	if len(rule.Matches) == 0 {
-		rule.Matches = append(rule.Matches, gatewayv1.GRPCRouteMatch{})
-	}
+	matches := grpcRouteRuleMatches(rule)
 
 	protocols, err := grpcProtocolsFromGatewayListener(ctx, cl, grpcRoute, pRef)
 	if err != nil {
@@ -223,8 +218,8 @@ func RoutesForGRPCRouteRule(
 	priorities := grpcRouteMatchPriorities(grpcRoute)
 	tags := pkgmetadata.ExtractTags(grpcRoute)
 
-	for i, match := range rule.Matches {
-		routeName := namegen.NewKongRouteNameForGRPCRouteMatch(grpcRoute, cp, namingParentRef, match, i)
+	for i, match := range matches {
+		routeName := namegen.NewKongRouteNameForGRPCRouteMatch(grpcRoute, cp, namingParentRef, match, ruleIndex, i)
 		mLog := logger.WithValues("kongroute", routeName, "matchIndex", i)
 		log.Debug(mLog, "Creating KongRoute for GRPCRoute match")
 
@@ -282,7 +277,7 @@ func grpcRouteMatchPriorities(grpcRoute *gwtypes.GRPCRoute) map[grpcRouteMatchPr
 	classSet := make(map[grpcRoutePriorityClass]struct{})
 	matchCountByClass := make(map[grpcRoutePriorityClass]int)
 	for _, rule := range grpcRoute.Spec.Rules {
-		for _, match := range rule.Matches {
+		for _, match := range grpcRouteRuleMatches(rule) {
 			class := calculateGRPCRoutePriorityClass(match)
 			if _, ok := classSet[class]; !ok {
 				classSet[class] = struct{}{}
@@ -304,7 +299,7 @@ func grpcRouteMatchPriorities(grpcRoute *gwtypes.GRPCRoute) map[grpcRouteMatchPr
 	seenByClass := make(map[grpcRoutePriorityClass]int)
 	priorities := make(map[grpcRouteMatchPriorityKey]int64)
 	for ruleIndex, rule := range grpcRoute.Spec.Rules {
-		for matchIndex, match := range rule.Matches {
+		for matchIndex, match := range grpcRouteRuleMatches(rule) {
 			class := calculateGRPCRoutePriorityClass(match)
 			offset := matchCountByClass[class] - 1 - seenByClass[class]
 			seenByClass[class]++
@@ -315,6 +310,13 @@ func grpcRouteMatchPriorities(grpcRoute *gwtypes.GRPCRoute) map[grpcRouteMatchPr
 		}
 	}
 	return priorities
+}
+
+func grpcRouteRuleMatches(rule gwtypes.GRPCRouteRule) []gatewayv1.GRPCRouteMatch {
+	if len(rule.Matches) > 0 {
+		return rule.Matches
+	}
+	return []gatewayv1.GRPCRouteMatch{{}}
 }
 
 func priorityForGRPCRouteMatch(priorities map[grpcRouteMatchPriorityKey]int64, ruleIndex, matchIndex int) int64 {

--- a/controller/hybridgateway/kongroute/route_test.go
+++ b/controller/hybridgateway/kongroute/route_test.go
@@ -344,6 +344,106 @@ func TestRoutesForGRPCRouteRule_NoMatches(t *testing.T) {
 	assert.Equal(t, []string{routebuilder.KongGRPCRouteCatchAllPath}, results[0].Spec.Paths)
 }
 
+func TestRoutesForGRPCRouteRule_NoMatchesHasLowerPriorityThanSpecificMatch(t *testing.T) {
+	ctx := context.Background()
+	logger := logr.Discard()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, configurationv1alpha1.AddToScheme(scheme))
+	require.NoError(t, gatewayv1.Install(scheme))
+
+	grpcRoute := &gwtypes.GRPCRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-route", Namespace: "test-namespace"},
+		Spec: gatewayv1.GRPCRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{{Name: "test-gateway"}},
+			},
+			Rules: []gatewayv1.GRPCRouteRule{
+				{},
+				{
+					Matches: []gatewayv1.GRPCRouteMatch{{
+						Method: &gatewayv1.GRPCMethodMatch{Service: new("foo.bar.v1.Service")},
+					}},
+				},
+			},
+		},
+	}
+	pRef := &gwtypes.ParentReference{Name: "test-gateway", Namespace: (*gatewayv1.Namespace)(new("test-namespace"))}
+	cpRef := &commonv1alpha1.ControlPlaneRef{
+		Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+		KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+			Name: "test-cp",
+		},
+	}
+	gateway := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-gateway", Namespace: "test-namespace"},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "test-class",
+			Listeners: []gatewayv1.Listener{
+				{Name: "http", Protocol: gatewayv1.HTTPProtocolType, Port: 80},
+			},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gateway).Build()
+
+	catchAllRoutes, err := RoutesForGRPCRouteRule(ctx, logger, fakeClient, grpcRoute, grpcRoute.Spec.Rules[0], 0, pRef, cpRef, nil, "catch-all-service", nil)
+	require.NoError(t, err)
+	require.Len(t, catchAllRoutes, 1)
+	specificRoutes, err := RoutesForGRPCRouteRule(ctx, logger, fakeClient, grpcRoute, grpcRoute.Spec.Rules[1], 1, pRef, cpRef, nil, "specific-service", nil)
+	require.NoError(t, err)
+	require.Len(t, specificRoutes, 1)
+
+	require.NotNil(t, catchAllRoutes[0].Spec.RegexPriority)
+	require.NotNil(t, specificRoutes[0].Spec.RegexPriority)
+	assert.Equal(t, []string{routebuilder.KongGRPCRouteCatchAllPath}, catchAllRoutes[0].Spec.Paths)
+	assert.Greater(t, *specificRoutes[0].Spec.RegexPriority, *catchAllRoutes[0].Spec.RegexPriority)
+}
+
+func TestRoutesForGRPCRouteRule_NoMatchesRulesHaveDistinctNames(t *testing.T) {
+	ctx := context.Background()
+	logger := logr.Discard()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, configurationv1alpha1.AddToScheme(scheme))
+	require.NoError(t, gatewayv1.Install(scheme))
+
+	grpcRoute := &gwtypes.GRPCRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-route", Namespace: "test-namespace"},
+		Spec: gatewayv1.GRPCRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{{Name: "test-gateway"}},
+			},
+			Rules: []gatewayv1.GRPCRouteRule{{}, {}},
+		},
+	}
+	pRef := &gwtypes.ParentReference{Name: "test-gateway", Namespace: (*gatewayv1.Namespace)(new("test-namespace"))}
+	cpRef := &commonv1alpha1.ControlPlaneRef{
+		Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+		KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+			Name: "test-cp",
+		},
+	}
+	gateway := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-gateway", Namespace: "test-namespace"},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "test-class",
+			Listeners: []gatewayv1.Listener{
+				{Name: "http", Protocol: gatewayv1.HTTPProtocolType, Port: 80},
+			},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gateway).Build()
+
+	rule0Routes, err := RoutesForGRPCRouteRule(ctx, logger, fakeClient, grpcRoute, grpcRoute.Spec.Rules[0], 0, pRef, cpRef, nil, "backend-a-service", nil)
+	require.NoError(t, err)
+	require.Len(t, rule0Routes, 1)
+	rule1Routes, err := RoutesForGRPCRouteRule(ctx, logger, fakeClient, grpcRoute, grpcRoute.Spec.Rules[1], 1, pRef, cpRef, nil, "backend-b-service", nil)
+	require.NoError(t, err)
+	require.Len(t, rule1Routes, 1)
+
+	assert.NotEqual(t, rule0Routes[0].Name, rule1Routes[0].Name)
+}
+
 func TestGRPCRouteMatchPriorities(t *testing.T) {
 	grpcRoute := &gwtypes.GRPCRoute{
 		Spec: gatewayv1.GRPCRouteSpec{

--- a/controller/hybridgateway/kongroute/route_test.go
+++ b/controller/hybridgateway/kongroute/route_test.go
@@ -214,6 +214,195 @@ func TestRoutesForRule(t *testing.T) {
 	}
 }
 
+func TestRoutesForGRPCRouteRule(t *testing.T) {
+	ctx := context.Background()
+	logger := logr.Discard()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, configurationv1alpha1.AddToScheme(scheme))
+	require.NoError(t, gatewayv1.Install(scheme))
+
+	grpcRoute := &gwtypes.GRPCRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "test-namespace",
+		},
+		Spec: gatewayv1.GRPCRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{
+					{Name: "test-gateway"},
+				},
+			},
+		},
+	}
+
+	exact := gatewayv1.GRPCMethodMatchExact
+	rule := gwtypes.GRPCRouteRule{
+		Matches: []gatewayv1.GRPCRouteMatch{
+			{
+				Method: &gatewayv1.GRPCMethodMatch{
+					Type:    &exact,
+					Service: new("foo.bar.v1.Service"),
+					Method:  new("DoThing"),
+				},
+			},
+			{
+				Headers: []gatewayv1.GRPCHeaderMatch{{Name: "version", Value: "v1"}},
+			},
+		},
+	}
+	// grpcRouteMatchPriorities reads priorities from the route's own Spec.Rules, so it must
+	// match the rule passed to RoutesForRule below.
+	grpcRoute.Spec.Rules = []gatewayv1.GRPCRouteRule{rule}
+
+	pRef := &gwtypes.ParentReference{
+		Name:      "test-gateway",
+		Namespace: (*gatewayv1.Namespace)(new("test-namespace")),
+	}
+	cpRef := &commonv1alpha1.ControlPlaneRef{
+		Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+		KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+			Name: "test-cp",
+		},
+	}
+	gateway := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-gateway",
+			Namespace: "test-namespace",
+		},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "test-class",
+			Listeners: []gatewayv1.Listener{
+				{Name: "http", Protocol: gatewayv1.HTTPProtocolType, Port: 80},
+				{Name: "https", Protocol: gatewayv1.HTTPSProtocolType, Port: 443},
+			},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gateway).Build()
+
+	results, err := RoutesForRule(ctx, logger, fakeClient, grpcRoute, rule, 0, pRef, cpRef, nil, "test-service", []string{"example.com"})
+	require.NoError(t, err)
+	require.Len(t, results, 2)
+
+	methodRoute := results[0]
+	assert.Equal(t, "test-namespace", methodRoute.Namespace)
+	assert.Equal(t, []string{"example.com"}, methodRoute.Spec.Hosts)
+	assert.Equal(t, []string{`~/foo\.bar\.v1\.Service/DoThing$`}, methodRoute.Spec.Paths)
+	require.NotNil(t, methodRoute.Spec.ServiceRef)
+	require.NotNil(t, methodRoute.Spec.ServiceRef.NamespacedRef)
+	assert.Equal(t, "test-service", methodRoute.Spec.ServiceRef.NamespacedRef.Name)
+	assert.ElementsMatch(t, []sdkkonnectcomp.Protocols{sdkkonnectcomp.ProtocolsGrpc, sdkkonnectcomp.ProtocolsGrpcs}, methodRoute.Spec.Protocols)
+	require.NotNil(t, methodRoute.Spec.RegexPriority)
+
+	headerRoute := results[1]
+	assert.Equal(t, []string{routebuilder.KongGRPCRouteCatchAllPath}, headerRoute.Spec.Paths)
+	assert.Contains(t, headerRoute.Spec.Headers, "version")
+	require.NotNil(t, headerRoute.Spec.RegexPriority)
+
+	// The exact service+method match is strictly more specific (longer service/method
+	// character count) than the headers-only, method-less match, so it must win.
+	assert.Greater(t, *methodRoute.Spec.RegexPriority, *headerRoute.Spec.RegexPriority)
+}
+
+func TestRoutesForGRPCRouteRule_NoMatches(t *testing.T) {
+	ctx := context.Background()
+	logger := logr.Discard()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, configurationv1alpha1.AddToScheme(scheme))
+	require.NoError(t, gatewayv1.Install(scheme))
+
+	grpcRoute := &gwtypes.GRPCRoute{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-route", Namespace: "test-namespace"},
+		Spec: gatewayv1.GRPCRouteSpec{
+			CommonRouteSpec: gatewayv1.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{{Name: "test-gateway"}},
+			},
+		},
+	}
+	pRef := &gwtypes.ParentReference{Name: "test-gateway", Namespace: (*gatewayv1.Namespace)(new("test-namespace"))}
+	cpRef := &commonv1alpha1.ControlPlaneRef{
+		Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+		KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+			Name: "test-cp",
+		},
+	}
+	gateway := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Name: "test-gateway", Namespace: "test-namespace"},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "test-class",
+			Listeners: []gatewayv1.Listener{
+				{Name: "http", Protocol: gatewayv1.HTTPProtocolType, Port: 80},
+			},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gateway).Build()
+
+	results, err := RoutesForGRPCRouteRule(ctx, logger, fakeClient, grpcRoute, gwtypes.GRPCRouteRule{}, 0, pRef, cpRef, nil, "test-service", nil)
+	require.NoError(t, err)
+	require.Len(t, results, 1)
+	assert.Equal(t, []string{routebuilder.KongGRPCRouteCatchAllPath}, results[0].Spec.Paths)
+}
+
+func TestGRPCRouteMatchPriorities(t *testing.T) {
+	grpcRoute := &gwtypes.GRPCRoute{
+		Spec: gatewayv1.GRPCRouteSpec{
+			Rules: []gatewayv1.GRPCRouteRule{
+				{
+					// Rule 0: no method matcher, headers only -> least specific class.
+					Matches: []gatewayv1.GRPCRouteMatch{{
+						Headers: []gatewayv1.GRPCHeaderMatch{{Name: "version", Value: "v1"}},
+					}},
+				},
+				{
+					// Rule 1: service only.
+					Matches: []gatewayv1.GRPCRouteMatch{{
+						Method: &gatewayv1.GRPCMethodMatch{Service: new("foo.bar.v1.Service")},
+					}},
+				},
+				{
+					// Rule 2: service + method, most specific.
+					Matches: []gatewayv1.GRPCRouteMatch{{
+						Method: &gatewayv1.GRPCMethodMatch{
+							Service: new("foo.bar.v1.Service"),
+							Method:  new("DoThing"),
+						},
+					}},
+				},
+			},
+		},
+	}
+
+	priorities := grpcRouteMatchPriorities(grpcRoute)
+
+	headersOnly := priorityForGRPCRouteMatch(priorities, 0, 0)
+	serviceOnly := priorityForGRPCRouteMatch(priorities, 1, 0)
+	serviceAndMethod := priorityForGRPCRouteMatch(priorities, 2, 0)
+
+	assert.Less(t, headersOnly, serviceOnly)
+	assert.Less(t, serviceOnly, serviceAndMethod)
+}
+
+func TestGRPCRouteMatchPriorities_TieBreaksOnFirstDeclaredMatch(t *testing.T) {
+	// Two matches in the same specificity class (identical service, no method, no headers):
+	// the earlier-declared one must win per Gateway API's "first matching rule" tie-break.
+	grpcRoute := &gwtypes.GRPCRoute{
+		Spec: gatewayv1.GRPCRouteSpec{
+			Rules: []gatewayv1.GRPCRouteRule{
+				{Matches: []gatewayv1.GRPCRouteMatch{{
+					Method: &gatewayv1.GRPCMethodMatch{Service: new("foo.bar.v1.Service")},
+				}}},
+				{Matches: []gatewayv1.GRPCRouteMatch{{
+					Method: &gatewayv1.GRPCMethodMatch{Service: new("other.v1.Service")},
+				}}},
+			},
+		},
+	}
+
+	priorities := grpcRouteMatchPriorities(grpcRoute)
+	assert.Greater(t, priorityForGRPCRouteMatch(priorities, 0, 0), priorityForGRPCRouteMatch(priorities, 1, 0))
+}
+
 func TestRoutesForTCPRouteRule(t *testing.T) {
 	ctx := context.Background()
 	logger := logr.Discard()
@@ -724,6 +913,85 @@ func TestRoutesForTLSRouteRule_TagsAnnotation(t *testing.T) {
 			}
 
 			results, err := RoutesForRule(ctx, logger, fakeClient, tlsRoute, rule, 0, pRef, cpRef, nil, "test-service", []string{"example.com"})
+			require.NoError(t, err)
+			require.Len(t, results, 1)
+			assert.Equal(t, tt.expected, results[0].Spec.Tags)
+		})
+	}
+}
+
+func TestRoutesForGRPCRouteRule_TagsAnnotation(t *testing.T) {
+	ctx := context.Background()
+	logger := logr.Discard()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, configurationv1alpha1.AddToScheme(scheme))
+	require.NoError(t, gatewayv1.Install(scheme))
+
+	pRef := &gwtypes.ParentReference{
+		Name:      "test-gateway",
+		Namespace: (*gatewayv1.Namespace)(new("test-namespace")),
+	}
+	cpRef := &commonv1alpha1.ControlPlaneRef{
+		Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+		KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+			Name: "test-cp",
+		},
+	}
+	rule := gwtypes.GRPCRouteRule{
+		Matches: []gatewayv1.GRPCRouteMatch{
+			{Method: &gatewayv1.GRPCMethodMatch{Service: new("foo.bar.v1.Service")}},
+		},
+	}
+	gateway := &gatewayv1.Gateway{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-gateway",
+			Namespace: "test-namespace",
+		},
+		Spec: gatewayv1.GatewaySpec{
+			GatewayClassName: "test-class",
+			Listeners: []gatewayv1.Listener{
+				{Name: "http", Protocol: gatewayv1.HTTPProtocolType, Port: 80},
+			},
+		},
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(gateway).Build()
+
+	tests := []struct {
+		name        string
+		annotations map[string]string
+		expected    commonv1alpha1.Tags
+	}{
+		{
+			name:        "tags annotation present",
+			annotations: map[string]string{"konghq.com/tags": "r1,r2"},
+			expected:    commonv1alpha1.Tags{"r1", "r2"},
+		},
+		{
+			name:        "tags annotation absent",
+			annotations: nil,
+			expected:    nil,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			grpcRoute := &gwtypes.GRPCRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:        "test-route",
+					Namespace:   "test-namespace",
+					Annotations: tt.annotations,
+				},
+				Spec: gatewayv1.GRPCRouteSpec{
+					CommonRouteSpec: gatewayv1.CommonRouteSpec{
+						ParentRefs: []gatewayv1.ParentReference{
+							{Name: "test-gateway"},
+						},
+					},
+				},
+			}
+
+			results, err := RoutesForRule(ctx, logger, fakeClient, grpcRoute, rule, 0, pRef, cpRef, nil, "test-service", []string{"example.com"})
 			require.NoError(t, err)
 			require.Len(t, results, 1)
 			assert.Equal(t, tt.expected, results[0].Spec.Tags)

--- a/controller/hybridgateway/metadata/annotation.go
+++ b/controller/hybridgateway/metadata/annotation.go
@@ -36,6 +36,7 @@ const (
 
 const (
 	kindHTTPRoute = "HTTPRoute"
+	kindGRPCRoute = "GRPCRoute"
 	kindTLSRoute  = "TLSRoute"
 	kindTCPRoute  = "TCPRoute"
 )
@@ -249,6 +250,8 @@ func BuildAnnotations(obj client.Object, parentRef *gwtypes.ParentReference) map
 	switch obj.(type) {
 	case *gwtypes.HTTPRoute:
 		annotations[consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation] = client.ObjectKeyFromObject(obj).String()
+	case *gwtypes.GRPCRoute:
+		annotations[consts.GatewayOperatorHybridRoutesGRPCRouteAnnotation] = client.ObjectKeyFromObject(obj).String()
 	case *gwtypes.TLSRoute:
 		annotations[consts.GatewayOperatorHybridRoutesTLSRouteAnnotation] = client.ObjectKeyFromObject(obj).String()
 	case *gwtypes.TCPRoute:
@@ -559,6 +562,8 @@ func (am *AnnotationManager) RouteAnnotationKeyForKind(routeKind string) string 
 	switch routeKind {
 	case kindHTTPRoute:
 		return consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation
+	case kindGRPCRoute:
+		return consts.GatewayOperatorHybridRoutesGRPCRouteAnnotation
 	case kindTLSRoute:
 		return consts.GatewayOperatorHybridRoutesTLSRouteAnnotation
 	case kindTCPRoute:

--- a/controller/hybridgateway/metadata/annotation_test.go
+++ b/controller/hybridgateway/metadata/annotation_test.go
@@ -22,6 +22,10 @@ var (
 		Kind:       kindHTTPRoute,
 		APIVersion: "gateway.networking.k8s.io/v1",
 	}
+	grpcRouteTypeMeta = metav1.TypeMeta{
+		Kind:       kindGRPCRoute,
+		APIVersion: "gateway.networking.k8s.io/v1",
+	}
 	tlsRouteTypeMeta = metav1.TypeMeta{
 		Kind:       "TLSRoute",
 		APIVersion: "gateway.networking.k8s.io/v1",
@@ -266,6 +270,30 @@ func TestBuildAnnotations(t *testing.T) {
 			assert.Equal(t, tt.expected, result, tt.description)
 		})
 	}
+}
+
+func TestBuildAnnotationsGRPCRoute(t *testing.T) {
+	grpcRoute := &gwtypes.GRPCRoute{
+		TypeMeta: grpcRouteTypeMeta,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "test-namespace",
+		},
+	}
+	parentRef := &gwtypes.ParentReference{
+		Name: "test-gateway",
+	}
+
+	result := BuildAnnotations(grpcRoute, parentRef)
+	assert.Equal(t, "test-namespace/test-route", result[consts.GatewayOperatorHybridRoutesGRPCRouteAnnotation])
+
+	am := NewAnnotationManager(logr.Discard())
+	assert.Equal(t, consts.GatewayOperatorHybridRoutesGRPCRouteAnnotation, am.RouteAnnotationKeyForKind(kindGRPCRoute))
+
+	obj := &configurationv1alpha1.KongRoute{}
+	assert.True(t, am.AppendRouteToAnnotation(obj, grpcRoute), "AppendRouteToAnnotation must not no-op for GRPCRoute")
+	assert.True(t, am.ContainsRoute(obj, grpcRoute))
+	assert.True(t, am.RemoveRouteFromAnnotation(obj, grpcRoute))
 }
 
 func TestBuildAnnotationsObjectKeyCreation(t *testing.T) {

--- a/controller/hybridgateway/namegen/name.go
+++ b/controller/hybridgateway/namegen/name.go
@@ -39,8 +39,11 @@ func BackendRequestTimeoutMilliseconds(rule gatewayv1.HTTPRouteRule) *int64 {
 }
 
 const (
-	// httpProcolPrefix is the prefix used for HTTP-related resources.
-	httpProcolPrefix = "http"
+	// httpProtocolPrefix is the prefix used for HTTP-related resources.
+	httpProtocolPrefix = "http"
+
+	// grpcProtocolPrefix is the prefix used for GRPC-related resources.
+	grpcProtocolPrefix = "grpc"
 
 	// tlsProtocolPrefix is the prefix for TLS-related resources.
 	tlsProtocolPrefix = "tls"
@@ -116,10 +119,20 @@ func newNameWithHashSuffix(readableElements []string, hashElements []string) str
 // NewKongUpstreamNameForHTTPRouteRule generates a KongUpstream name based on the ControlPlaneRef and HTTPRouteRule passed as arguments.
 func NewKongUpstreamNameForHTTPRouteRule(route *gwtypes.HTTPRoute, cp *commonv1alpha1.ControlPlaneRef, rule gatewayv1.HTTPRouteRule) string {
 	readableElements := append(
-		[]string{httpProcolPrefix},
+		[]string{httpProtocolPrefix},
 		backendRefDisplayNames(route.Namespace, rule.BackendRefs)...,
 	)
 	hashElements := hashElementsForServiceLikeName(route, cp, rule)
+	return newNameWithHashSuffix(readableElements, hashElements)
+}
+
+// NewKongUpstreamNameForGRPCRouteRule generates a KongUpstream name based on the ControlPlaneRef and GRPCRouteRule passed as arguments.
+func NewKongUpstreamNameForGRPCRouteRule(route *gwtypes.GRPCRoute, cp *commonv1alpha1.ControlPlaneRef, rule gatewayv1.GRPCRouteRule) string {
+	readableElements := append(
+		[]string{grpcProtocolPrefix},
+		backendRefDisplayNames(route.Namespace, rule.BackendRefs)...,
+	)
+	hashElements := hashElementsForServiceLikeNameGRPCRouteRule(route, cp, rule)
 	return newNameWithHashSuffix(readableElements, hashElements)
 }
 
@@ -146,7 +159,7 @@ func NewKongUpstreamNameForTCPRouteRule(route *gwtypes.TCPRoute, cp *commonv1alp
 // NewKongServiceNameForHTTPRouteRule generates a KongService name based on the ControlPlaneRef and HTTPRouteRule passed as arguments.
 func NewKongServiceNameForHTTPRouteRule(route *gwtypes.HTTPRoute, cp *commonv1alpha1.ControlPlaneRef, rule gatewayv1.HTTPRouteRule) string {
 	readableElements := append(
-		[]string{httpProcolPrefix},
+		[]string{httpProtocolPrefix},
 		backendRefDisplayNames(route.Namespace, rule.BackendRefs)...,
 	)
 	hashElements := hashElementsForServiceLikeName(route, cp, rule)
@@ -162,7 +175,7 @@ func NewKongServiceNameForHTTPRouteRuleBackendNotFound(
 	rule gatewayv1.HTTPRouteRule,
 ) string {
 	readableElements := append(
-		[]string{httpProcolPrefix},
+		[]string{httpProtocolPrefix},
 		backendRefDisplayNames(route.Namespace, rule.BackendRefs)...,
 	)
 	hashElements := []string{
@@ -175,6 +188,43 @@ func NewKongServiceNameForHTTPRouteRuleBackendNotFound(
 			Name:      route.Name,
 		}),
 		hashForHTTPRouteRuleServiceLikeName(route, rule),
+	}
+	return newNameWithHashSuffix(readableElements, hashElements)
+}
+
+// NewKongServiceNameForGRPCRouteRule generates a KongService name based on the ControlPlaneRef and GRPCRouteRule passed as arguments.
+func NewKongServiceNameForGRPCRouteRule(route *gwtypes.GRPCRoute, cp *commonv1alpha1.ControlPlaneRef, rule gatewayv1.GRPCRouteRule) string {
+	readableElements := append(
+		[]string{grpcProtocolPrefix},
+		backendRefDisplayNames(route.Namespace, rule.BackendRefs)...,
+	)
+	hashElements := hashElementsForServiceLikeNameGRPCRouteRule(route, cp, rule)
+	return newNameWithHashSuffix(readableElements, hashElements)
+}
+
+// NewKongServiceNameForGRPCRouteRuleBackendNotFound generates a route-scoped KongService name
+// for rules that have BackendRefs but no valid backend targets. These services get a
+// request-termination plugin, so they must not share the normal backend service name. Mirrors
+// NewKongServiceNameForHTTPRouteRuleBackendNotFound for GRPCRoute.
+func NewKongServiceNameForGRPCRouteRuleBackendNotFound(
+	route *gwtypes.GRPCRoute,
+	cp *commonv1alpha1.ControlPlaneRef,
+	rule gatewayv1.GRPCRouteRule,
+) string {
+	readableElements := append(
+		[]string{grpcProtocolPrefix},
+		backendRefDisplayNames(route.Namespace, rule.BackendRefs)...,
+	)
+	hashElements := []string{
+		defaultCPPrefix + utils.Hash32(cp),
+		backendNotFoundPrefix + utils.Hash32(struct {
+			Namespace string
+			Name      string
+		}{
+			Namespace: route.Namespace,
+			Name:      route.Name,
+		}),
+		hashForGRPCRouteRuleServiceLikeName(route, rule),
 	}
 	return newNameWithHashSuffix(readableElements, hashElements)
 }
@@ -247,6 +297,42 @@ func hashForHTTPRouteRuleServiceLikeName(route *gwtypes.HTTPRoute, rule gatewayv
 	return hash
 }
 
+// hashElementsForServiceLikeNameGRPCRouteRule mirrors hashElementsForServiceLikeName for GRPCRoute.
+func hashElementsForServiceLikeNameGRPCRouteRule(
+	route *gwtypes.GRPCRoute,
+	cp *commonv1alpha1.ControlPlaneRef,
+	rule gatewayv1.GRPCRouteRule,
+) []string {
+	hash := hashForGRPCRouteRuleServiceLikeName(route, rule)
+	return []string{
+		defaultCPPrefix + utils.Hash32(cp),
+		hash,
+	}
+}
+
+// hashForGRPCRouteRuleServiceLikeName mirrors hashForHTTPRouteRuleServiceLikeName for GRPCRoute.
+func hashForGRPCRouteRuleServiceLikeName(route *gwtypes.GRPCRoute, rule gatewayv1.GRPCRouteRule) string {
+	var hash string
+	if len(rule.BackendRefs) > 0 {
+		hash = utils.Hash32(rule.BackendRefs)
+	} else {
+		zeroBackendRuleIdentity := struct {
+			RouteNamespace string
+			RouteName      string
+			Matches        []gatewayv1.GRPCRouteMatch
+			Filters        []gatewayv1.GRPCRouteFilter
+		}{
+			RouteNamespace: route.Namespace,
+			RouteName:      route.Name,
+			Matches:        rule.Matches,
+			Filters:        rule.Filters,
+		}
+		hash = utils.Hash32(zeroBackendRuleIdentity)
+	}
+
+	return hash
+}
+
 func hashElementsForServiceLikeNameTLSRouteRule(
 	cp *commonv1alpha1.ControlPlaneRef,
 	rule gwtypes.TLSRouteRule,
@@ -282,7 +368,29 @@ func NewKongRouteNameForMatch(
 	index int,
 ) string {
 	readableElements := []string{
-		httpProcolPrefix,
+		httpProtocolPrefix,
+		route.Namespace + "-" + route.Name,
+	}
+	hashElements := []string{defaultCPPrefix + utils.Hash32(cp)}
+	if parentRef != nil {
+		hashElements = append(hashElements, parentRefHashElement(parentRef))
+	}
+	hashElements = append(hashElements, utils.Hash32(match), fmt.Sprintf("m%02d", index))
+	return newNameWithHashSuffix(readableElements, hashElements)
+}
+
+// NewKongRouteNameForGRPCRouteMatch generates a KongRoute name based on GRPCRoute, ControlPlaneRef,
+// ParentRef, and a single GRPCRouteMatch. The optional index is included to avoid collisions
+// when multiple matches are identical.
+func NewKongRouteNameForGRPCRouteMatch(
+	route *gwtypes.GRPCRoute,
+	cp *commonv1alpha1.ControlPlaneRef,
+	parentRef *gwtypes.ParentReference,
+	match gatewayv1.GRPCRouteMatch,
+	index int,
+) string {
+	readableElements := []string{
+		grpcProtocolPrefix,
 		route.Namespace + "-" + route.Name,
 	}
 	hashElements := []string{defaultCPPrefix + utils.Hash32(cp)}
@@ -354,6 +462,11 @@ func NewKongPluginNameForFilters(filters []gatewayv1.HTTPRouteFilter, namespace 
 	return newName(namespace, pluginName, utils.Hash32(filters))
 }
 
+// NewKongPluginNameForGRPCRouteFilter generates a KongPlugin name based on the GRPCRouteFilter.
+func NewKongPluginNameForGRPCRouteFilter(filter gatewayv1.GRPCRouteFilter, namespace string, pluginName string) string {
+	return newName(namespace, pluginName, utils.Hash32(filter))
+}
+
 // NewKongPluginNameForService generates a KongPlugin name tied to a KongService.
 func NewKongPluginNameForService(serviceName, pluginName string) string {
 	return newName(serviceName, pluginName)
@@ -369,9 +482,10 @@ func NewKongTargetName[T gwtypes.SupportedBackendRef](upstreamID, endpointID str
 	switch b := any(br).(type) {
 	case *gwtypes.HTTPBackendRef:
 		return newKongTargetNameForHTTPBackendRef(upstreamID, endpointID, port, b)
+	case *gwtypes.GRPCBackendRef:
+		return newKongTargetNameForGRPCBackendRef(upstreamID, endpointID, port, b)
 	case *gwtypes.BackendRef:
 		return newKongTargetNameForBackendRef(upstreamID, endpointID, port, b)
-		// TODO: add other types of BackendRefs (like GRPCBackendRef) when we support them.
 	}
 	// Should be unreachable.
 	return ""
@@ -384,6 +498,21 @@ func newKongTargetNameForHTTPBackendRef(upstreamID, endpointID string, port int,
 		endpointID string
 		port       int
 		backend    *gwtypes.HTTPBackendRef
+	}{
+		endpointID: endpointID,
+		port:       port,
+		backend:    br,
+	}
+	return newName(upstreamID, utils.Hash32(obj))
+}
+
+// newKongTargetNameForGRPCBackendRef generates a KongTarget name based on the KongUpstream name, the Service Endpoint ip,
+// the service port and the GRPCBackendRef.
+func newKongTargetNameForGRPCBackendRef(upstreamID, endpointID string, port int, br *gwtypes.GRPCBackendRef) string {
+	obj := struct {
+		endpointID string
+		port       int
+		backend    *gwtypes.GRPCBackendRef
 	}{
 		endpointID: endpointID,
 		port:       port,
@@ -429,6 +558,8 @@ func backendRefDisplayNames[T gwtypes.SupportedBackendRef](routeNamespace string
 		var backendRef gwtypes.BackendRef
 		switch r := any(ref).(type) {
 		case gwtypes.HTTPBackendRef:
+			backendRef = r.BackendRef
+		case gwtypes.GRPCBackendRef:
 			backendRef = r.BackendRef
 		case gwtypes.BackendRef:
 			backendRef = r

--- a/controller/hybridgateway/namegen/name.go
+++ b/controller/hybridgateway/namegen/name.go
@@ -380,14 +380,15 @@ func NewKongRouteNameForMatch(
 }
 
 // NewKongRouteNameForGRPCRouteMatch generates a KongRoute name based on GRPCRoute, ControlPlaneRef,
-// ParentRef, and a single GRPCRouteMatch. The optional index is included to avoid collisions
-// when multiple matches are identical.
+// ParentRef, and a single GRPCRouteMatch. Rule and match indexes are included to avoid collisions
+// when matches are identical across or within rules.
 func NewKongRouteNameForGRPCRouteMatch(
 	route *gwtypes.GRPCRoute,
 	cp *commonv1alpha1.ControlPlaneRef,
 	parentRef *gwtypes.ParentReference,
 	match gatewayv1.GRPCRouteMatch,
-	index int,
+	ruleIndex int,
+	matchIndex int,
 ) string {
 	readableElements := []string{
 		grpcProtocolPrefix,
@@ -397,7 +398,7 @@ func NewKongRouteNameForGRPCRouteMatch(
 	if parentRef != nil {
 		hashElements = append(hashElements, parentRefHashElement(parentRef))
 	}
-	hashElements = append(hashElements, utils.Hash32(match), fmt.Sprintf("m%02d", index))
+	hashElements = append(hashElements, utils.Hash32(match), fmt.Sprintf("r%02d", ruleIndex), fmt.Sprintf("m%02d", matchIndex))
 	return newNameWithHashSuffix(readableElements, hashElements)
 }
 

--- a/controller/hybridgateway/namegen/name_test.go
+++ b/controller/hybridgateway/namegen/name_test.go
@@ -23,6 +23,15 @@ func testRoute(namespace, name string) *gwtypes.HTTPRoute {
 	}
 }
 
+func testGRPCRoute(namespace, name string) *gwtypes.GRPCRoute {
+	return &gwtypes.GRPCRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+}
+
 func testControlPlaneRef(name string) *commonv1alpha1.ControlPlaneRef {
 	return &commonv1alpha1.ControlPlaneRef{
 		Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
@@ -56,6 +65,20 @@ func testBackendRef(
 	name string, namespace *gatewayv1.Namespace, port *gatewayv1.PortNumber,
 ) gatewayv1.HTTPBackendRef {
 	return gatewayv1.HTTPBackendRef{
+		BackendRef: gatewayv1.BackendRef{
+			BackendObjectReference: gatewayv1.BackendObjectReference{
+				Name:      gatewayv1.ObjectName(name),
+				Namespace: namespace,
+				Port:      port,
+			},
+		},
+	}
+}
+
+func testGRPCBackendRef(
+	name string, namespace *gatewayv1.Namespace, port *gatewayv1.PortNumber,
+) gatewayv1.GRPCBackendRef {
+	return gatewayv1.GRPCBackendRef{
 		BackendRef: gatewayv1.BackendRef{
 			BackendObjectReference: gatewayv1.BackendObjectReference{
 				Name:      gatewayv1.ObjectName(name),
@@ -256,6 +279,76 @@ func TestNewKongUpstreamName_Equality(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestNewKongUpstreamNameForGRPCRoute(t *testing.T) {
+	tests := []struct {
+		name             string
+		route            *gwtypes.GRPCRoute
+		cp               *commonv1alpha1.ControlPlaneRef
+		rule             gatewayv1.GRPCRouteRule
+		expectedReadable string
+	}{
+		{
+			name:  "basic upstream name generation",
+			route: testGRPCRoute("default", "test-route"),
+			cp:    testControlPlaneRef("test-cp"),
+			rule: gatewayv1.GRPCRouteRule{
+				BackendRefs: []gatewayv1.GRPCBackendRef{
+					testGRPCBackendRef("service1", nil, new(gatewayv1.PortNumber(8080))),
+				},
+			},
+			expectedReadable: "grpc.default-service1-8080.1",
+		},
+		{
+			name:  "cross namespace backend is reflected in readable prefix",
+			route: testGRPCRoute("default", "test-route"),
+			cp:    testControlPlaneRef("namespaced-cp"),
+			rule: gatewayv1.GRPCRouteRule{
+				BackendRefs: []gatewayv1.GRPCBackendRef{
+					testGRPCBackendRef("backend-service", new(gatewayv1.Namespace("backend-ns")), nil),
+				},
+			},
+			expectedReadable: "grpc.backend-ns-backend-service.1",
+		},
+		{
+			name:  "backendless rule produces readable prefix with just grpc and cp hash",
+			route: testGRPCRoute("default", "test-route"),
+			cp:    testControlPlaneRef("namespaced-cp"),
+			rule: gatewayv1.GRPCRouteRule{
+				BackendRefs: []gatewayv1.GRPCBackendRef{},
+				Matches: []gatewayv1.GRPCRouteMatch{
+					{Method: &gatewayv1.GRPCMethodMatch{Service: new("svc.Echo")}},
+				},
+			},
+			expectedReadable: "grpc",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := NewKongUpstreamNameForGRPCRouteRule(tt.route, tt.cp, tt.rule)
+			expected := tt.expectedReadable + ".cp" + utils.Hash32(tt.cp) + "." + hashForGRPCRouteRuleServiceLikeName(tt.route, tt.rule)
+			assert.Equal(t, expected, result)
+		})
+	}
+}
+
+func TestNewKongUpstreamNameForGRPCRoute_Equality(t *testing.T) {
+	route := testGRPCRoute("gateway-conformance-infra", "test-route")
+	cp := testControlPlaneRef("same-namespace")
+	ruleA := gatewayv1.GRPCRouteRule{
+		Matches: []gatewayv1.GRPCRouteMatch{{Method: &gatewayv1.GRPCMethodMatch{Service: new("svc.A")}}},
+	}
+	ruleB := gatewayv1.GRPCRouteRule{
+		Matches: []gatewayv1.GRPCRouteMatch{{Method: &gatewayv1.GRPCMethodMatch{Service: new("svc.B")}}},
+	}
+
+	nameA := NewKongUpstreamNameForGRPCRouteRule(route, cp, ruleA)
+	nameB := NewKongUpstreamNameForGRPCRouteRule(route, cp, ruleB)
+
+	assert.NotEqual(t, nameA, nameB)
+	assert.Equal(t, nameA, NewKongUpstreamNameForGRPCRouteRule(route, cp, ruleA), "identical inputs must be deterministic")
 }
 
 func TestNewKongServiceName(t *testing.T) {
@@ -519,6 +612,90 @@ func TestNewKongServiceName_BackendDisplayLimit(t *testing.T) {
 	}
 }
 
+func TestNewKongServiceNameForGRPCRoute(t *testing.T) {
+	tests := []struct {
+		name             string
+		route            *gwtypes.GRPCRoute
+		cp               *commonv1alpha1.ControlPlaneRef
+		rule             gatewayv1.GRPCRouteRule
+		expectedReadable string
+	}{
+		{
+			name:  "basic service name generation",
+			route: testGRPCRoute("default", "test-route"),
+			cp:    testControlPlaneRef("test-cp"),
+			rule: gatewayv1.GRPCRouteRule{
+				BackendRefs: []gatewayv1.GRPCBackendRef{
+					testGRPCBackendRef("service1", nil, new(gatewayv1.PortNumber(8080))),
+				},
+			},
+			expectedReadable: "grpc.default-service1-8080.1",
+		},
+		{
+			name:  "service with namespace",
+			route: testGRPCRoute("default", "test-route"),
+			cp: &commonv1alpha1.ControlPlaneRef{
+				Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+				KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+					Name:      "namespaced-cp",
+					Namespace: "konnect-system",
+				},
+			},
+			rule: gatewayv1.GRPCRouteRule{
+				BackendRefs: []gatewayv1.GRPCBackendRef{
+					testGRPCBackendRef("backend-service", new(gatewayv1.Namespace("backend-ns")), nil),
+				},
+			},
+			expectedReadable: "grpc.backend-ns-backend-service.1",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := NewKongServiceNameForGRPCRouteRule(tt.route, tt.cp, tt.rule)
+			expected := tt.expectedReadable + ".cp" + utils.Hash32(tt.cp) + "." + utils.Hash32(tt.rule.BackendRefs)
+			assert.Equal(t, expected, result)
+		})
+	}
+}
+
+func TestNewKongServiceNameForGRPCRoute_Equality(t *testing.T) {
+	route := testGRPCRoute("gateway-conformance-infra", "test-route")
+	cp := testControlPlaneRef("same-namespace")
+	ruleA := gatewayv1.GRPCRouteRule{
+		Matches: []gatewayv1.GRPCRouteMatch{{Method: &gatewayv1.GRPCMethodMatch{Service: new("svc.A")}}},
+	}
+	ruleB := gatewayv1.GRPCRouteRule{
+		Matches: []gatewayv1.GRPCRouteMatch{{Method: &gatewayv1.GRPCMethodMatch{Service: new("svc.B")}}},
+	}
+
+	nameA := NewKongServiceNameForGRPCRouteRule(route, cp, ruleA)
+	nameB := NewKongServiceNameForGRPCRouteRule(route, cp, ruleB)
+
+	assert.NotEqual(t, nameA, nameB)
+}
+
+func TestNewKongServiceNameForGRPCRouteRuleBackendNotFound(t *testing.T) {
+	backendNS := gatewayv1.Namespace("gateway-conformance-web-backend")
+	port := gatewayv1.PortNumber(8080)
+	rule := gatewayv1.GRPCRouteRule{
+		BackendRefs: []gatewayv1.GRPCBackendRef{
+			testGRPCBackendRef("web-backend", &backendNS, &port),
+		},
+	}
+	routeA := testGRPCRoute("gateway-conformance-infra", "invalid-cross-namespace-backend-ref")
+	routeB := testGRPCRoute("gateway-conformance-infra", "reference-grant")
+	cp := testControlPlaneRef("same-namespace")
+
+	normalName := NewKongServiceNameForGRPCRouteRule(routeA, cp, rule)
+	fallbackNameA := NewKongServiceNameForGRPCRouteRuleBackendNotFound(routeA, cp, rule)
+	fallbackNameB := NewKongServiceNameForGRPCRouteRuleBackendNotFound(routeB, cp, rule)
+
+	assert.NotEqual(t, normalName, fallbackNameA)
+	assert.NotEqual(t, fallbackNameA, fallbackNameB)
+	assert.Contains(t, fallbackNameA, backendNotFoundPrefix)
+}
+
 func TestNewKongRouteNameForMatch_DiffersByParentRef(t *testing.T) {
 	route := testRoute("default", "test-route")
 	cp := testControlPlaneRef("test-cp")
@@ -553,6 +730,47 @@ func TestNewKongRouteNameForMatch_WithoutParentRefKeepsLegacyFormat(t *testing.T
 	result := NewKongRouteNameForMatch(route, cp, nil, match, 0)
 	expected := "http.default-test-route.cp" + utils.Hash32(cp) + "." + utils.Hash32(match) + ".m00"
 	assert.Equal(t, expected, result)
+}
+
+func TestNewKongRouteNameForGRPCRouteMatch_DiffersByParentRef(t *testing.T) {
+	route := testGRPCRoute("default", "test-route")
+	cp := testControlPlaneRef("test-cp")
+	match := gatewayv1.GRPCRouteMatch{
+		Method: &gatewayv1.GRPCMethodMatch{Service: new("svc.Echo")},
+	}
+	listener1 := gatewayv1.SectionName("listener-1")
+	listener2 := gatewayv1.SectionName("listener-2")
+
+	name1 := NewKongRouteNameForGRPCRouteMatch(route, cp, testParentRef(&listener1), match, 0)
+	name2 := NewKongRouteNameForGRPCRouteMatch(route, cp, testParentRef(&listener2), match, 0)
+
+	assert.NotEqual(t, name1, name2)
+	assert.Equal(t, name1, NewKongRouteNameForGRPCRouteMatch(route, cp, testParentRef(&listener1), match, 0))
+}
+
+func TestNewKongRouteNameForGRPCRouteMatch_WithoutParentRefKeepsLegacyFormat(t *testing.T) {
+	route := testGRPCRoute("default", "test-route")
+	cp := testControlPlaneRef("test-cp")
+	match := gatewayv1.GRPCRouteMatch{
+		Method: &gatewayv1.GRPCMethodMatch{Service: new("svc.Echo")},
+	}
+
+	result := NewKongRouteNameForGRPCRouteMatch(route, cp, nil, match, 0)
+	expected := "grpc.default-test-route.cp" + utils.Hash32(cp) + "." + utils.Hash32(match) + ".m00"
+	assert.Equal(t, expected, result)
+}
+
+func TestNewKongRouteNameForGRPCRouteMatch_DiffersByIndex(t *testing.T) {
+	route := testGRPCRoute("default", "test-route")
+	cp := testControlPlaneRef("test-cp")
+	match := gatewayv1.GRPCRouteMatch{
+		Method: &gatewayv1.GRPCMethodMatch{Service: new("svc.Echo")},
+	}
+
+	name0 := NewKongRouteNameForGRPCRouteMatch(route, cp, nil, match, 0)
+	name1 := NewKongRouteNameForGRPCRouteMatch(route, cp, nil, match, 1)
+
+	assert.NotEqual(t, name0, name1)
 }
 
 func TestNewKongRouteNameForTLSRouteRule_DiffersByParentRef(t *testing.T) {
@@ -724,6 +942,51 @@ func TestNewKongPluginNameForFilters(t *testing.T) {
 	}
 }
 
+func TestNewKongPluginNameForGRPCRouteFilter(t *testing.T) {
+	tests := []struct {
+		name   string
+		filter gatewayv1.GRPCRouteFilter
+	}{
+		{
+			name: "request header modifier filter",
+			filter: gatewayv1.GRPCRouteFilter{
+				Type: gatewayv1.GRPCRouteFilterRequestHeaderModifier,
+				RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+					Set: []gatewayv1.HTTPHeader{
+						{Name: "X-Test", Value: "test-value"},
+					},
+				},
+			},
+		},
+		{
+			name: "response header modifier filter",
+			filter: gatewayv1.GRPCRouteFilter{
+				Type: gatewayv1.GRPCRouteFilterResponseHeaderModifier,
+				ResponseHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+					Add: []gatewayv1.HTTPHeader{
+						{Name: "X-Response", Value: "response-value"},
+					},
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result := NewKongPluginNameForGRPCRouteFilter(tt.filter, "default", "request-transformer")
+			assert.NotEmpty(t, result)
+			assert.True(t, strings.HasPrefix(result, "default.request-transformer."), "should start with plugin namespace.name prefix")
+			assert.Equal(t, result, NewKongPluginNameForGRPCRouteFilter(tt.filter, "default", "request-transformer"), "must be deterministic")
+		})
+	}
+
+	assert.NotEqual(t,
+		NewKongPluginNameForGRPCRouteFilter(tests[0].filter, "default", "request-transformer"),
+		NewKongPluginNameForGRPCRouteFilter(tests[1].filter, "default", "request-transformer"),
+		"different filter content must produce different names",
+	)
+}
+
 func TestNewKongPluginBindingName(t *testing.T) {
 	tests := []struct {
 		name     string
@@ -765,6 +1028,16 @@ func TestNewKongPluginBindingName(t *testing.T) {
 func TestNewKongTargetName(t *testing.T) {
 	httpBR := func(name string) *gwtypes.HTTPBackendRef {
 		return &gwtypes.HTTPBackendRef{
+			BackendRef: gatewayv1.BackendRef{
+				BackendObjectReference: gatewayv1.BackendObjectReference{
+					Name: gatewayv1.ObjectName(name),
+					Port: func() *gatewayv1.PortNumber { p := gatewayv1.PortNumber(8080); return &p }(),
+				},
+			},
+		}
+	}
+	grpcBR := func(name string) *gwtypes.GRPCBackendRef {
+		return &gwtypes.GRPCBackendRef{
 			BackendRef: gatewayv1.BackendRef{
 				BackendObjectReference: gatewayv1.BackendObjectReference{
 					Name: gatewayv1.ObjectName(name),
@@ -832,6 +1105,22 @@ func TestNewKongTargetName(t *testing.T) {
 		longUpstream := strings.Repeat("very-long-upstream-segment-", 10)
 		result := NewKongTargetName(longUpstream, "10.0.0.1", 8080, httpBR("svc"))
 		assert.LessOrEqual(t, len(result), maxLen)
+	})
+
+	t.Run("GRPCRoute BackendRef variant is idempotent and non-empty", func(t *testing.T) {
+		br := grpcBR("grpc-backend")
+		first := NewKongTargetName("upstream", "10.0.0.1", 8080, br)
+		second := NewKongTargetName("upstream", "10.0.0.1", 8080, br)
+		assert.NotEmpty(t, first)
+		assert.Equal(t, first, second)
+	})
+
+	t.Run("GRPCRoute BackendRef different service produces different name than HTTPBackendRef", func(t *testing.T) {
+		// The GRPC and HTTP variants hash different struct types, so names must not collide.
+		assert.NotEqual(t,
+			NewKongTargetName("upstream", "10.0.0.1", 8080, httpBR("svc-a")),
+			NewKongTargetName("upstream", "10.0.0.1", 8080, grpcBR("svc-a")),
+		)
 	})
 
 	t.Run("TLSRoute BackendRef variant is idempotent", func(t *testing.T) {

--- a/controller/hybridgateway/namegen/name_test.go
+++ b/controller/hybridgateway/namegen/name_test.go
@@ -741,11 +741,11 @@ func TestNewKongRouteNameForGRPCRouteMatch_DiffersByParentRef(t *testing.T) {
 	listener1 := gatewayv1.SectionName("listener-1")
 	listener2 := gatewayv1.SectionName("listener-2")
 
-	name1 := NewKongRouteNameForGRPCRouteMatch(route, cp, testParentRef(&listener1), match, 0)
-	name2 := NewKongRouteNameForGRPCRouteMatch(route, cp, testParentRef(&listener2), match, 0)
+	name1 := NewKongRouteNameForGRPCRouteMatch(route, cp, testParentRef(&listener1), match, 0, 0)
+	name2 := NewKongRouteNameForGRPCRouteMatch(route, cp, testParentRef(&listener2), match, 0, 0)
 
 	assert.NotEqual(t, name1, name2)
-	assert.Equal(t, name1, NewKongRouteNameForGRPCRouteMatch(route, cp, testParentRef(&listener1), match, 0))
+	assert.Equal(t, name1, NewKongRouteNameForGRPCRouteMatch(route, cp, testParentRef(&listener1), match, 0, 0))
 }
 
 func TestNewKongRouteNameForGRPCRouteMatch_WithoutParentRefKeepsLegacyFormat(t *testing.T) {
@@ -755,8 +755,8 @@ func TestNewKongRouteNameForGRPCRouteMatch_WithoutParentRefKeepsLegacyFormat(t *
 		Method: &gatewayv1.GRPCMethodMatch{Service: new("svc.Echo")},
 	}
 
-	result := NewKongRouteNameForGRPCRouteMatch(route, cp, nil, match, 0)
-	expected := "grpc.default-test-route.cp" + utils.Hash32(cp) + "." + utils.Hash32(match) + ".m00"
+	result := NewKongRouteNameForGRPCRouteMatch(route, cp, nil, match, 0, 0)
+	expected := "grpc.default-test-route.cp" + utils.Hash32(cp) + "." + utils.Hash32(match) + ".r00.m00"
 	assert.Equal(t, expected, result)
 }
 
@@ -767,8 +767,19 @@ func TestNewKongRouteNameForGRPCRouteMatch_DiffersByIndex(t *testing.T) {
 		Method: &gatewayv1.GRPCMethodMatch{Service: new("svc.Echo")},
 	}
 
-	name0 := NewKongRouteNameForGRPCRouteMatch(route, cp, nil, match, 0)
-	name1 := NewKongRouteNameForGRPCRouteMatch(route, cp, nil, match, 1)
+	name0 := NewKongRouteNameForGRPCRouteMatch(route, cp, nil, match, 0, 0)
+	name1 := NewKongRouteNameForGRPCRouteMatch(route, cp, nil, match, 0, 1)
+
+	assert.NotEqual(t, name0, name1)
+}
+
+func TestNewKongRouteNameForGRPCRouteMatch_DiffersByRuleIndex(t *testing.T) {
+	route := testGRPCRoute("default", "test-route")
+	cp := testControlPlaneRef("test-cp")
+	match := gatewayv1.GRPCRouteMatch{}
+
+	name0 := NewKongRouteNameForGRPCRouteMatch(route, cp, nil, match, 0, 0)
+	name1 := NewKongRouteNameForGRPCRouteMatch(route, cp, nil, match, 1, 0)
 
 	assert.NotEqual(t, name0, name1)
 }

--- a/controller/hybridgateway/plugin/grpc_converter.go
+++ b/controller/hybridgateway/plugin/grpc_converter.go
@@ -1,0 +1,118 @@
+package plugin
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+// translateGRPCFromFilter translates a GRPCRouteFilter into one or more KongPlugin
+// configurations. The generated KongPlugin(s) are filled with the pluginName and json config
+// only, leaving to the caller the responsibility to set metadata (name, namespace, labels,
+// annotations) as needed.
+//
+// Unlike HTTPRoute (translateRuleFilters), the caller does not need to merge configs produced by
+// multiple filters within a rule into a single KongPlugin: GRPCRouteRule's Filters are
+// CEL-validated to at most one RequestHeaderModifier and at most one ResponseHeaderModifier per
+// rule, and GRPCRouteFilter has no URLRewrite/RequestRedirect (those are HTTPRoute-only filter
+// types that additionally map to request-transformer there). So no two filters in a GRPCRoute
+// rule can ever target the same Kong plugin type, and each filter here maps 1:1 to its own
+// KongPlugin.
+//
+// Supported filter types and their corresponding Kong pluginConfs:
+//   - GRPCRouteFilterRequestHeaderModifier -> request-transformer
+//   - GRPCRouteFilterResponseHeaderModifier -> response-transformer
+func translateGRPCFromFilter(filter gatewayv1.GRPCRouteFilter) ([]kongPluginConfig, error) {
+	pluginConfs := []kongPluginConfig{}
+
+	switch filter.Type {
+	case gatewayv1.GRPCRouteFilterRequestHeaderModifier:
+		pConf := kongPluginConfig{name: pluginRequestTransformer}
+
+		config, err := translateGRPCRequestModifier(filter.RequestHeaderModifier)
+		if err != nil {
+			return nil, fmt.Errorf("translating RequestHeaderModifier filter: %w", err)
+		}
+		configJSON, err := json.Marshal(config)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal %q plugin config: %w", pConf.name, err)
+		}
+		pConf.config = configJSON
+		pluginConfs = append(pluginConfs, pConf)
+	case gatewayv1.GRPCRouteFilterResponseHeaderModifier:
+		pConf := kongPluginConfig{name: pluginResponseTransformer}
+
+		config, err := translateGRPCResponseModifier(filter.ResponseHeaderModifier)
+		if err != nil {
+			return nil, fmt.Errorf("translating ResponseHeaderModifier filter: %w", err)
+		}
+		configJSON, err := json.Marshal(config)
+		if err != nil {
+			return nil, fmt.Errorf("failed to marshal %q plugin config: %w", pConf.name, err)
+		}
+		pConf.config = configJSON
+		pluginConfs = append(pluginConfs, pConf)
+	default:
+		// TODO: translate GRPCRouteFilterRequestMirror into a Kong request-mirror-equivalent plugin.
+		return nil, fmt.Errorf("unsupported filter type: %s", filter.Type)
+	}
+	return pluginConfs, nil
+}
+
+// translateGRPCRequestModifier mirrors translateRequestModifier for GRPCRoute's
+// RequestHeaderModifier filter, which shares the same HTTPHeaderFilter config type as HTTPRoute's.
+func translateGRPCRequestModifier(hf *gatewayv1.HTTPHeaderFilter) (transformerData, error) {
+	plugin := transformerData{}
+
+	if hf == nil {
+		return plugin, errors.New("RequestHeaderModifier filter config is missing")
+	}
+
+	// In order to overwrite an header of add if not present (GWAPI Set) we should do a Kong Plugin
+	// Replace (so it will overwrite it if found) + Add (so if not found, will add it).
+	for _, v := range hf.Set {
+		plugin.Replace.Headers = append(plugin.Replace.Headers, string(v.Name)+":"+v.Value)
+		plugin.Add.Headers = append(plugin.Add.Headers, string(v.Name)+":"+v.Value)
+	}
+	// Add for GWAPI equals "append" for Kong Plugins (it will add another instance of the header).
+	for _, v := range hf.Add {
+		plugin.Append.Headers = append(plugin.Append.Headers, string(v.Name)+":"+v.Value)
+	}
+	if len(hf.Remove) > 0 {
+		plugin.Remove.Headers = append(plugin.Remove.Headers, hf.Remove...)
+	}
+
+	if len(plugin.Add.Headers)+len(plugin.Append.Headers)+
+		len(plugin.Remove.Headers)+len(plugin.Replace.Headers) == 0 {
+		return transformerData{}, errors.New("RequestHeaderModifier filter config is empty")
+	}
+	return plugin, nil
+}
+
+// translateGRPCResponseModifier mirrors translateResponseModifier for GRPCRoute's
+// ResponseHeaderModifier filter, which shares the same HTTPHeaderFilter config type as HTTPRoute's.
+func translateGRPCResponseModifier(hf *gatewayv1.HTTPHeaderFilter) (transformerData, error) {
+	plugin := transformerData{}
+
+	if hf == nil {
+		return plugin, errors.New("ResponseHeaderModifier filter config is missing")
+	}
+
+	for _, v := range hf.Set {
+		plugin.Replace.Headers = append(plugin.Replace.Headers, string(v.Name)+":"+v.Value)
+		plugin.Add.Headers = append(plugin.Add.Headers, string(v.Name)+":"+v.Value)
+	}
+	for _, v := range hf.Add {
+		plugin.Append.Headers = append(plugin.Append.Headers, string(v.Name)+":"+v.Value)
+	}
+	if len(hf.Remove) > 0 {
+		plugin.Remove.Headers = append(plugin.Remove.Headers, hf.Remove...)
+	}
+
+	if len(plugin.Add.Headers)+len(plugin.Append.Headers)+len(plugin.Remove.Headers)+len(plugin.Replace.Headers) == 0 {
+		return transformerData{}, errors.New("ResponseHeaderModifier filter config is empty")
+	}
+	return plugin, nil
+}

--- a/controller/hybridgateway/plugin/grpc_converter_test.go
+++ b/controller/hybridgateway/plugin/grpc_converter_test.go
@@ -1,0 +1,204 @@
+package plugin
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+)
+
+func TestTranslateGRPCRequestModifier(t *testing.T) {
+	tests := []struct {
+		name        string
+		hf          *gatewayv1.HTTPHeaderFilter
+		expected    transformerData
+		expectError bool
+	}{
+		{
+			name: "successful translation with all operations",
+			hf: &gatewayv1.HTTPHeaderFilter{
+				Add: []gatewayv1.HTTPHeader{
+					{Name: "X-Add", Value: "add-val"},
+				},
+				Set: []gatewayv1.HTTPHeader{
+					{Name: "X-Set", Value: "set-val"},
+				},
+				Remove: []string{"X-Remove"},
+			},
+			expected: transformerData{
+				Add: transformerTargetSlice{
+					Headers: []string{"X-Set:set-val"},
+				},
+				Append: transformerTargetSlice{
+					Headers: []string{"X-Add:add-val"},
+				},
+				Replace: transformerTargetSliceReplace{
+					transformerTargetSlice: transformerTargetSlice{
+						Headers: []string{"X-Set:set-val"},
+					},
+				},
+				Remove: transformerTargetSlice{
+					Headers: []string{"X-Remove"},
+				},
+			},
+		},
+		{
+			name:        "nil RequestHeaderModifier",
+			hf:          nil,
+			expectError: true,
+		},
+		{
+			name:        "empty RequestHeaderModifier",
+			hf:          &gatewayv1.HTTPHeaderFilter{},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := translateGRPCRequestModifier(tt.hf)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Equal(t, transformerData{}, result)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.ElementsMatch(t, tt.expected.Add.Headers, result.Add.Headers)
+			assert.ElementsMatch(t, tt.expected.Append.Headers, result.Append.Headers)
+			assert.ElementsMatch(t, tt.expected.Remove.Headers, result.Remove.Headers)
+			assert.ElementsMatch(t, tt.expected.Replace.Headers, result.Replace.Headers)
+		})
+	}
+}
+
+func TestTranslateGRPCResponseModifier(t *testing.T) {
+	tests := []struct {
+		name        string
+		hf          *gatewayv1.HTTPHeaderFilter
+		expected    transformerData
+		expectError bool
+	}{
+		{
+			name: "successful translation with all operations",
+			hf: &gatewayv1.HTTPHeaderFilter{
+				Add: []gatewayv1.HTTPHeader{
+					{Name: "X-Add", Value: "add-val"},
+				},
+				Set: []gatewayv1.HTTPHeader{
+					{Name: "X-Set", Value: "set-val"},
+				},
+				Remove: []string{"X-Remove"},
+			},
+			expected: transformerData{
+				Add:     transformerTargetSlice{Headers: []string{"X-Set:set-val"}},
+				Append:  transformerTargetSlice{Headers: []string{"X-Add:add-val"}},
+				Remove:  transformerTargetSlice{Headers: []string{"X-Remove"}},
+				Replace: transformerTargetSliceReplace{transformerTargetSlice: transformerTargetSlice{Headers: []string{"X-Set:set-val"}}},
+			},
+		},
+		{
+			name:        "nil ResponseHeaderModifier",
+			hf:          nil,
+			expectError: true,
+		},
+		{
+			name:        "empty ResponseHeaderModifier",
+			hf:          &gatewayv1.HTTPHeaderFilter{},
+			expectError: true,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			result, err := translateGRPCResponseModifier(tt.hf)
+
+			if tt.expectError {
+				assert.Error(t, err)
+				assert.Equal(t, transformerData{}, result)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.ElementsMatch(t, tt.expected.Add.Headers, result.Add.Headers)
+			assert.ElementsMatch(t, tt.expected.Append.Headers, result.Append.Headers)
+			assert.ElementsMatch(t, tt.expected.Remove.Headers, result.Remove.Headers)
+			assert.ElementsMatch(t, tt.expected.Replace.Headers, result.Replace.Headers)
+		})
+	}
+}
+
+func TestTranslateGRPCFromFilter(t *testing.T) {
+	tests := []struct {
+		name          string
+		filter        gatewayv1.GRPCRouteFilter
+		expectedName  string
+		expectedData  transformerData
+		expectedError string
+	}{
+		{
+			name: "RequestHeaderModifier maps to request-transformer",
+			filter: gatewayv1.GRPCRouteFilter{
+				Type: gatewayv1.GRPCRouteFilterRequestHeaderModifier,
+				RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+					Add: []gatewayv1.HTTPHeader{{Name: "X-Api-Version", Value: "v2"}},
+				},
+			},
+			expectedName: pluginRequestTransformer,
+			expectedData: transformerData{Append: transformerTargetSlice{Headers: []string{"X-Api-Version:v2"}}},
+		},
+		{
+			name: "ResponseHeaderModifier maps to response-transformer",
+			filter: gatewayv1.GRPCRouteFilter{
+				Type: gatewayv1.GRPCRouteFilterResponseHeaderModifier,
+				ResponseHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+					Add: []gatewayv1.HTTPHeader{{Name: "X-Backend", Value: "echo"}},
+				},
+			},
+			expectedName: pluginResponseTransformer,
+			expectedData: transformerData{Append: transformerTargetSlice{Headers: []string{"X-Backend:echo"}}},
+		},
+		{
+			name: "RequestMirror is not yet supported",
+			filter: gatewayv1.GRPCRouteFilter{
+				Type: gatewayv1.GRPCRouteFilterRequestMirror,
+				RequestMirror: &gatewayv1.HTTPRequestMirrorFilter{
+					BackendRef: gatewayv1.BackendObjectReference{
+						Name: "mirror-svc",
+					},
+				},
+			},
+			expectedError: "unsupported filter type: RequestMirror",
+		},
+		{
+			name: "unknown filter type falls into the same unsupported branch as RequestMirror",
+			filter: gatewayv1.GRPCRouteFilter{
+				Type: gatewayv1.GRPCRouteFilterType("Bogus"),
+			},
+			expectedError: "unsupported filter type: Bogus",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			confs, err := translateGRPCFromFilter(tt.filter)
+
+			if tt.expectedError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+				return
+			}
+
+			require.NoError(t, err)
+			require.Len(t, confs, 1)
+			assert.Equal(t, tt.expectedName, confs[0].name)
+
+			var data transformerData
+			require.NoError(t, json.Unmarshal(confs[0].config, &data))
+			assert.Equal(t, tt.expectedData, data)
+		})
+	}
+}

--- a/controller/hybridgateway/plugin/grpc_plugin.go
+++ b/controller/hybridgateway/plugin/grpc_plugin.go
@@ -1,0 +1,127 @@
+package plugin
+
+import (
+	"context"
+	"errors"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	configurationv1 "github.com/kong/kong-operator/v2/api/configuration/v1"
+	"github.com/kong/kong-operator/v2/controller/hybridgateway/builder"
+	"github.com/kong/kong-operator/v2/controller/hybridgateway/metadata"
+	"github.com/kong/kong-operator/v2/controller/hybridgateway/namegen"
+	"github.com/kong/kong-operator/v2/controller/hybridgateway/translator"
+	"github.com/kong/kong-operator/v2/controller/pkg/log"
+	gwtypes "github.com/kong/kong-operator/v2/internal/types"
+)
+
+// GRPCPluginsForRule creates or retrieves the KongPlugins for all filters of the given GRPCRoute
+// rule. Mirrors PluginsForRule for GRPCRoute's own filter type (GRPCRouteFilter), but unlike the
+// HTTPRoute path it doesn't need a merge step: GRPCRouteRule's Filters are CEL-validated to at
+// most one RequestHeaderModifier and at most one ResponseHeaderModifier per rule (see
+// translateGRPCFromFilter), so each translated filter maps 1:1 to its own KongPlugin.
+// RequestMirror is not yet translated (see translateGRPCFromFilter), and ExtensionRef filters are
+// retrieved as-is exactly like the HTTPRoute path.
+func GRPCPluginsForRule(
+	ctx context.Context,
+	logger logr.Logger,
+	cl client.Client,
+	grpcRoute *gwtypes.GRPCRoute,
+	rule gwtypes.GRPCRouteRule,
+	pRef *gwtypes.ParentReference,
+) ([]configurationv1.KongPlugin, error) {
+	plugins := []configurationv1.KongPlugin{}
+
+	for _, filter := range rule.Filters {
+		if filter.Type == gatewayv1.GRPCRouteFilterExtensionRef {
+			continue
+		}
+
+		confs, err := translateGRPCFromFilter(filter)
+		if err != nil {
+			return nil, fmt.Errorf("translating filters to KongPlugins: %w", err)
+		}
+
+		for _, conf := range confs {
+			pluginName := namegen.NewKongPluginNameForGRPCRouteFilter(filter, grpcRoute.Namespace, conf.name)
+			logger := logger.WithValues("kongplugin", pluginName)
+			log.Debug(logger, "Generating KongPlugin for GRPCRoute filter")
+
+			plugin, err := builder.NewKongPlugin().
+				WithName(pluginName).
+				WithNamespace(metadata.NamespaceFromParentRef(grpcRoute, pRef)).
+				WithLabels(grpcRoute, pRef).
+				WithPluginName(conf.name).
+				WithPluginConfig(conf.config).
+				WithAnnotations(grpcRoute, pRef).
+				Build()
+			if err != nil {
+				return nil, fmt.Errorf("failed to build KongPlugin %s: %w", pluginName, err)
+			}
+
+			if _, err = translator.VerifyAndUpdate(ctx, logger, cl, &plugin, grpcRoute, false); err != nil {
+				return nil, err
+			}
+			plugins = append(plugins, plugin)
+		}
+	}
+
+	// ExtensionRef filters reference user-managed KongPlugins; retrieve each one as-is.
+	for _, filter := range rule.Filters {
+		if filter.Type != gatewayv1.GRPCRouteFilterExtensionRef {
+			continue
+		}
+
+		logger := logger.WithValues("filter-type", filter.Type)
+		log.Debug(logger, "Filter is an ExtensionRef, retrieving referenced KongPlugin")
+		plugin, err := getReferencedKongPluginForGRPCFilter(ctx, cl, grpcRoute.Namespace, filter)
+		if err != nil {
+			if apierrors.IsNotFound(err) {
+				log.Debug(logger, "Referenced KongPlugin not found")
+				continue
+			}
+			return nil, fmt.Errorf("failed to retrieve referenced KongPlugin: %w", err)
+		}
+		pluginName := plugin.Name
+		log.Debug(logger, "Successfully retrieved referenced KongPlugin")
+		pluginCopy, err := builder.NewKongPlugin().
+			WithName(namegen.NewKongPluginNameForGRPCRouteFilter(filter, grpcRoute.Namespace, plugin.PluginName)).
+			WithNamespace(metadata.NamespaceFromParentRef(grpcRoute, pRef)).
+			WithLabels(grpcRoute, pRef).
+			WithPluginName(plugin.PluginName).
+			WithPluginConfig(plugin.Config.Raw).
+			WithAnnotations(grpcRoute, pRef).
+			Build()
+		if err != nil {
+			return nil, fmt.Errorf("failed to build KongPlugin %s: %w", pluginName, err)
+		}
+		plugins = append(plugins, pluginCopy)
+	}
+
+	return plugins, nil
+}
+
+func getReferencedKongPluginForGRPCFilter(ctx context.Context, cl client.Client, namespace string, filter gatewayv1.GRPCRouteFilter) (*configurationv1.KongPlugin, error) {
+	if filter.ExtensionRef == nil {
+		return nil, errors.New("ExtensionRef filter is missing")
+	}
+
+	if filter.ExtensionRef.Group != gatewayv1.Group(configurationv1.GroupVersion.Group) || filter.ExtensionRef.Kind != "KongPlugin" {
+		return nil, fmt.Errorf("unsupported ExtensionRef: %s/%s", filter.ExtensionRef.Group, filter.ExtensionRef.Kind)
+	}
+
+	plugin := &configurationv1.KongPlugin{}
+	if err := cl.Get(ctx, types.NamespacedName{
+		Name:      string(filter.ExtensionRef.Name),
+		Namespace: namespace,
+	}, plugin); err != nil {
+		return nil, err
+	}
+
+	return plugin, nil
+}

--- a/controller/hybridgateway/plugin/grpc_plugin_test.go
+++ b/controller/hybridgateway/plugin/grpc_plugin_test.go
@@ -1,0 +1,238 @@
+package plugin
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	configurationv1 "github.com/kong/kong-operator/v2/api/configuration/v1"
+	gwtypes "github.com/kong/kong-operator/v2/internal/types"
+	"github.com/kong/kong-operator/v2/modules/manager/scheme"
+	"github.com/kong/kong-operator/v2/pkg/consts"
+)
+
+var grpcRouteTypeMeta = metav1.TypeMeta{
+	Kind:       "GRPCRoute",
+	APIVersion: "gateway.networking.k8s.io/v1",
+}
+
+func TestGRPCPluginsForRule(t *testing.T) {
+	ctx := context.Background()
+	logger := logr.Discard()
+
+	grpcRoute := &gwtypes.GRPCRoute{
+		TypeMeta: grpcRouteTypeMeta,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "test-namespace",
+			UID:       "test-uid",
+		},
+	}
+	parentRef := &gwtypes.ParentReference{
+		Name: "test-gateway",
+	}
+
+	rule := gwtypes.GRPCRouteRule{
+		Filters: []gatewayv1.GRPCRouteFilter{
+			{
+				Type: gatewayv1.GRPCRouteFilterRequestHeaderModifier,
+				RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+					Set: []gatewayv1.HTTPHeader{
+						{Name: "X-Custom-Header", Value: "custom-value"},
+					},
+				},
+			},
+		},
+	}
+
+	fakeClient := fakectrlruntimeclient.NewClientBuilder().
+		WithScheme(scheme.Get()).
+		Build()
+
+	plugins, err := GRPCPluginsForRule(ctx, logger, fakeClient, grpcRoute, rule, parentRef)
+	require.NoError(t, err)
+	require.Len(t, plugins, 1)
+
+	plugin := plugins[0]
+	assert.Equal(t, "test-namespace", plugin.Namespace)
+	assert.Equal(t, "request-transformer", plugin.PluginName)
+	assert.Contains(t, plugin.Annotations, consts.GatewayOperatorHybridRoutesGRPCRouteAnnotation)
+	assert.Equal(t, "test-namespace/test-route", plugin.Annotations[consts.GatewayOperatorHybridRoutesGRPCRouteAnnotation])
+}
+
+func TestGRPCPluginsForRule_UnsupportedFilterErrors(t *testing.T) {
+	ctx := context.Background()
+	logger := logr.Discard()
+
+	grpcRoute := &gwtypes.GRPCRoute{
+		TypeMeta: grpcRouteTypeMeta,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "test-namespace",
+		},
+	}
+	rule := gwtypes.GRPCRouteRule{
+		Filters: []gatewayv1.GRPCRouteFilter{
+			{Type: gatewayv1.GRPCRouteFilterRequestMirror},
+		},
+	}
+
+	fakeClient := fakectrlruntimeclient.NewClientBuilder().WithScheme(scheme.Get()).Build()
+
+	_, err := GRPCPluginsForRule(ctx, logger, fakeClient, grpcRoute, rule, &gwtypes.ParentReference{Name: "gw"})
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported filter type")
+}
+
+func TestGetReferencedKongPluginForGRPCFilter(t *testing.T) {
+	tests := []struct {
+		name           string
+		filter         gatewayv1.GRPCRouteFilter
+		namespace      string
+		existingPlugin *configurationv1.KongPlugin
+		expectedPlugin *configurationv1.KongPlugin
+		expectedError  string
+	}{
+		{
+			name: "nil ExtensionRef",
+			filter: gatewayv1.GRPCRouteFilter{
+				Type:         gatewayv1.GRPCRouteFilterExtensionRef,
+				ExtensionRef: nil,
+			},
+			namespace:     "default",
+			expectedError: "ExtensionRef filter is missing",
+		},
+		{
+			name: "unsupported ExtensionRef group",
+			filter: gatewayv1.GRPCRouteFilter{
+				Type: gatewayv1.GRPCRouteFilterExtensionRef,
+				ExtensionRef: &gatewayv1.LocalObjectReference{
+					Group: gatewayv1.Group("unsupported.group"),
+					Kind:  "KongPlugin",
+					Name:  "test-plugin",
+				},
+			},
+			namespace:     "default",
+			expectedError: "unsupported ExtensionRef: unsupported.group/KongPlugin",
+		},
+		{
+			name: "unsupported ExtensionRef kind",
+			filter: gatewayv1.GRPCRouteFilter{
+				Type: gatewayv1.GRPCRouteFilterExtensionRef,
+				ExtensionRef: &gatewayv1.LocalObjectReference{
+					Group: gatewayv1.Group(configurationv1.GroupVersion.Group),
+					Kind:  "UnsupportedKind",
+					Name:  "test-plugin",
+				},
+			},
+			namespace:     "default",
+			expectedError: "unsupported ExtensionRef: configuration.konghq.com/UnsupportedKind",
+		},
+		{
+			name: "successful ExtensionRef fetch",
+			filter: gatewayv1.GRPCRouteFilter{
+				Type: gatewayv1.GRPCRouteFilterExtensionRef,
+				ExtensionRef: &gatewayv1.LocalObjectReference{
+					Group: gatewayv1.Group(configurationv1.GroupVersion.Group),
+					Kind:  "KongPlugin",
+					Name:  "test-plugin",
+				},
+			},
+			namespace: "default",
+			existingPlugin: &configurationv1.KongPlugin{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-plugin",
+					Namespace: "default",
+				},
+				PluginName: "rate-limiting",
+			},
+			expectedPlugin: &configurationv1.KongPlugin{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-plugin",
+					Namespace: "default",
+				},
+				PluginName: "rate-limiting",
+			},
+		},
+		{
+			name: "ExtensionRef not found",
+			filter: gatewayv1.GRPCRouteFilter{
+				Type: gatewayv1.GRPCRouteFilterExtensionRef,
+				ExtensionRef: &gatewayv1.LocalObjectReference{
+					Group: gatewayv1.Group(configurationv1.GroupVersion.Group),
+					Kind:  "KongPlugin",
+					Name:  "non-existent-plugin",
+				},
+			},
+			namespace:     "default",
+			expectedError: "kongplugins.configuration.konghq.com \"non-existent-plugin\" not found",
+		},
+		{
+			name: "ExtensionRef with complex plugin configuration",
+			filter: gatewayv1.GRPCRouteFilter{
+				Type: gatewayv1.GRPCRouteFilterExtensionRef,
+				ExtensionRef: &gatewayv1.LocalObjectReference{
+					Group: gatewayv1.Group(configurationv1.GroupVersion.Group),
+					Kind:  "KongPlugin",
+					Name:  "complex-plugin",
+				},
+			},
+			namespace: "test-namespace",
+			existingPlugin: &configurationv1.KongPlugin{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "complex-plugin",
+					Namespace: "test-namespace",
+				},
+				PluginName: "custom-plugin",
+				Config: apiextensionsv1.JSON{
+					Raw: []byte(`{"key":"value"}`),
+				},
+			},
+			expectedPlugin: &configurationv1.KongPlugin{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "complex-plugin",
+					Namespace: "test-namespace",
+				},
+				PluginName: "custom-plugin",
+				Config: apiextensionsv1.JSON{
+					Raw: []byte(`{"key":"value"}`),
+				},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			var objects []runtime.Object
+			if tt.existingPlugin != nil {
+				objects = append(objects, tt.existingPlugin)
+			}
+			fakeClient := fakectrlruntimeclient.NewClientBuilder().
+				WithScheme(scheme.Get()).
+				WithRuntimeObjects(objects...).
+				Build()
+
+			plugin, err := getReferencedKongPluginForGRPCFilter(context.Background(), fakeClient, tt.namespace, tt.filter)
+
+			if tt.expectedError != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), tt.expectedError)
+				return
+			}
+
+			require.NoError(t, err)
+			assert.Equal(t, tt.expectedPlugin.Name, plugin.Name)
+			assert.Equal(t, tt.expectedPlugin.Namespace, plugin.Namespace)
+			assert.Equal(t, tt.expectedPlugin.PluginName, plugin.PluginName)
+			assert.Equal(t, tt.expectedPlugin.Config.Raw, plugin.Config.Raw)
+		})
+	}
+}

--- a/controller/hybridgateway/plugin/grpc_request_termination.go
+++ b/controller/hybridgateway/plugin/grpc_request_termination.go
@@ -1,0 +1,63 @@
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	configurationv1 "github.com/kong/kong-operator/v2/api/configuration/v1"
+	"github.com/kong/kong-operator/v2/controller/hybridgateway/builder"
+	"github.com/kong/kong-operator/v2/controller/hybridgateway/metadata"
+	"github.com/kong/kong-operator/v2/controller/hybridgateway/namegen"
+	"github.com/kong/kong-operator/v2/controller/hybridgateway/translator"
+	gwtypes "github.com/kong/kong-operator/v2/internal/types"
+)
+
+// GRPCRequestTerminationForBackendNotFound creates a plugin that terminates requests to a
+// backend-less gRPC service, mirroring RequestTerminationForBackendNotFound's role for HTTPRoute.
+//
+// Kong's own default for a service with an empty upstream is a bare HTTP 503, which Kong (via its
+// HTTP_TO_GRPC_STATUS table) does not map to a specific gRPC status for gRPC content types, so a
+// gRPC client is left to fall back on its own HTTP-status conversion. We explicitly terminate with
+// status_code 500 and content_type application/grpc so Kong frames the response as gRPC: this
+// mirrors the "Internal" gRPC status (13) that HTTP 500 conventionally maps to (matching the
+// Google API HTTP-to-gRPC status mapping), analogous to HTTPRoute's 500-on-no-backend requirement.
+func GRPCRequestTerminationForBackendNotFound(
+	ctx context.Context,
+	logger logr.Logger,
+	cl client.Client,
+	grpcRoute *gwtypes.GRPCRoute,
+	pRef *gwtypes.ParentReference,
+	serviceName string,
+) (*configurationv1.KongPlugin, error) {
+	pluginName := namegen.NewKongPluginNameForService(serviceName, "request-termination")
+	config, err := json.Marshal(map[string]any{
+		"status_code":  500,
+		"message":      "no existing backendRef provided",
+		"content_type": "application/grpc",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal request-termination config: %w", err)
+	}
+
+	plugin, err := builder.NewKongPlugin().
+		WithName(pluginName).
+		WithNamespace(metadata.NamespaceFromParentRef(grpcRoute, pRef)).
+		WithLabels(grpcRoute, pRef).
+		WithAnnotations(grpcRoute, pRef).
+		WithPluginName("request-termination").
+		WithPluginConfig(config).
+		Build()
+	if err != nil {
+		return nil, fmt.Errorf("failed to build request-termination plugin %s: %w", pluginName, err)
+	}
+
+	if _, err := translator.VerifyAndUpdate(ctx, logger.WithValues("kongplugin", pluginName), cl, &plugin, grpcRoute, false); err != nil {
+		return nil, err
+	}
+
+	return &plugin, nil
+}

--- a/controller/hybridgateway/plugin/grpc_request_termination_test.go
+++ b/controller/hybridgateway/plugin/grpc_request_termination_test.go
@@ -1,0 +1,49 @@
+package plugin
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	gwtypes "github.com/kong/kong-operator/v2/internal/types"
+	"github.com/kong/kong-operator/v2/modules/manager/scheme"
+	"github.com/kong/kong-operator/v2/pkg/consts"
+)
+
+func TestGRPCRequestTerminationForBackendNotFound(t *testing.T) {
+	ctx := context.Background()
+	logger := logr.Discard()
+
+	grpcRoute := &gwtypes.GRPCRoute{
+		TypeMeta: grpcRouteTypeMeta,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "test-namespace",
+			UID:       "test-uid",
+		},
+	}
+	parentRef := &gwtypes.ParentReference{
+		Name: "test-gateway",
+	}
+
+	fakeClient := fakectrlruntimeclient.NewClientBuilder().WithScheme(scheme.Get()).Build()
+
+	plugin, err := GRPCRequestTerminationForBackendNotFound(ctx, logger, fakeClient, grpcRoute, parentRef, "test-service")
+	require.NoError(t, err)
+	require.NotNil(t, plugin)
+
+	assert.Equal(t, "request-termination", plugin.PluginName)
+	assert.Equal(t, "test-namespace", plugin.Namespace)
+	assert.Equal(t, "test-namespace/test-route", plugin.Annotations[consts.GatewayOperatorHybridRoutesGRPCRouteAnnotation])
+
+	var config map[string]any
+	require.NoError(t, json.Unmarshal(plugin.Config.Raw, &config))
+	assert.InEpsilon(t, 500.0, config["status_code"], 0.001)
+	assert.Equal(t, "application/grpc", config["content_type"])
+}

--- a/controller/hybridgateway/pluginbinding/grpc_pluginbinding.go
+++ b/controller/hybridgateway/pluginbinding/grpc_pluginbinding.go
@@ -1,0 +1,92 @@
+package pluginbinding
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+
+	commonv1alpha1 "github.com/kong/kong-operator/v2/api/common/v1alpha1"
+	configurationv1alpha1 "github.com/kong/kong-operator/v2/api/configuration/v1alpha1"
+	"github.com/kong/kong-operator/v2/controller/hybridgateway/builder"
+	"github.com/kong/kong-operator/v2/controller/hybridgateway/metadata"
+	"github.com/kong/kong-operator/v2/controller/hybridgateway/namegen"
+	"github.com/kong/kong-operator/v2/controller/hybridgateway/translator"
+	"github.com/kong/kong-operator/v2/controller/pkg/log"
+	gwtypes "github.com/kong/kong-operator/v2/internal/types"
+)
+
+// BindingForGRPCPluginAndRoute creates or updates a KongPluginBinding for the given plugin and
+// GRPCRoute-derived KongRoute. Mirrors BindingForPluginAndRoute for GRPCRoute.
+func BindingForGRPCPluginAndRoute(
+	ctx context.Context,
+	logger logr.Logger,
+	cl client.Client,
+	grpcRoute *gwtypes.GRPCRoute,
+	pRef *gwtypes.ParentReference,
+	cp *commonv1alpha1.ControlPlaneRef,
+	pluginName string,
+	routeName string,
+) (kongPluginBinding *configurationv1alpha1.KongPluginBinding, err error) {
+	bindingName := namegen.NewKongPluginBindingName(routeName, pluginName)
+	logger = logger.WithValues("kongpluginbinding", bindingName)
+	log.Debug(logger, "Generating KongPluginBinding for KongPlugin and KongRoute")
+
+	binding, err := builder.NewKongPluginBinding().
+		WithName(bindingName).
+		WithNamespace(metadata.NamespaceFromParentRef(grpcRoute, pRef)).
+		WithLabels(grpcRoute, pRef).
+		WithAnnotations(grpcRoute, pRef).
+		WithPluginRef(pluginName).
+		WithControlPlaneRef(*cp).
+		WithRouteRef(routeName).
+		Build()
+	if err != nil {
+		log.Error(logger, err, "Failed to build KongPluginBinding resource")
+		return nil, fmt.Errorf("failed to build KongPluginBinding %s: %w", bindingName, err)
+	}
+
+	if _, err = translator.VerifyAndUpdate(ctx, logger, cl, &binding, grpcRoute, true); err != nil {
+		return nil, err
+	}
+
+	return &binding, nil
+}
+
+// BindingForGRPCPluginAndService creates or updates a KongPluginBinding for the given plugin and
+// GRPCRoute-derived KongService. Mirrors BindingForPluginAndService for GRPCRoute.
+func BindingForGRPCPluginAndService(
+	ctx context.Context,
+	logger logr.Logger,
+	cl client.Client,
+	grpcRoute *gwtypes.GRPCRoute,
+	pRef *gwtypes.ParentReference,
+	cp *commonv1alpha1.ControlPlaneRef,
+	pluginName string,
+	serviceName string,
+) (kongPluginBinding *configurationv1alpha1.KongPluginBinding, err error) {
+	bindingName := namegen.NewKongPluginBindingName(serviceName, pluginName)
+	logger = logger.WithValues("kongpluginbinding", bindingName)
+	log.Debug(logger, "Generating KongPluginBinding for KongPlugin and KongService")
+
+	binding, err := builder.NewKongPluginBinding().
+		WithName(bindingName).
+		WithNamespace(metadata.NamespaceFromParentRef(grpcRoute, pRef)).
+		WithLabels(grpcRoute, pRef).
+		WithAnnotations(grpcRoute, pRef).
+		WithPluginRef(pluginName).
+		WithControlPlaneRef(*cp).
+		WithServiceRef(serviceName).
+		Build()
+	if err != nil {
+		log.Error(logger, err, "Failed to build KongPluginBinding resource")
+		return nil, fmt.Errorf("failed to build KongPluginBinding %s: %w", bindingName, err)
+	}
+
+	if _, err = translator.VerifyAndUpdate(ctx, logger, cl, &binding, grpcRoute, true); err != nil {
+		return nil, err
+	}
+
+	return &binding, nil
+}

--- a/controller/hybridgateway/pluginbinding/grpc_pluginbinding_test.go
+++ b/controller/hybridgateway/pluginbinding/grpc_pluginbinding_test.go
@@ -1,0 +1,102 @@
+package pluginbinding
+
+import (
+	"context"
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	commonv1alpha1 "github.com/kong/kong-operator/v2/api/common/v1alpha1"
+	gwtypes "github.com/kong/kong-operator/v2/internal/types"
+	"github.com/kong/kong-operator/v2/modules/manager/scheme"
+	"github.com/kong/kong-operator/v2/pkg/consts"
+)
+
+var grpcRouteTypeMeta = metav1.TypeMeta{
+	Kind:       "GRPCRoute",
+	APIVersion: "gateway.networking.k8s.io/v1",
+}
+
+func TestBindingForGRPCPluginAndRoute(t *testing.T) {
+	logger := logr.Discard()
+	ctx := context.Background()
+
+	grpcRoute := &gwtypes.GRPCRoute{
+		TypeMeta: grpcRouteTypeMeta,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-grpcroute",
+			Namespace: "test-namespace",
+			UID:       "test-uid",
+		},
+	}
+	parentRef := &gwtypes.ParentReference{
+		Name: "test-gateway",
+	}
+	cpRef := &commonv1alpha1.ControlPlaneRef{
+		Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+		KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+			Name: "test-cp",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme.Get()).Build()
+
+	binding, err := BindingForGRPCPluginAndRoute(ctx, logger, fakeClient, grpcRoute, parentRef, cpRef, "test-plugin", "test-route")
+	require.NoError(t, err)
+	require.NotNil(t, binding)
+
+	assert.Equal(t, "test-namespace", binding.Namespace)
+	assert.Equal(t, "test-plugin", binding.Spec.PluginReference.Name)
+	require.NotNil(t, binding.Spec.Targets)
+	require.NotNil(t, binding.Spec.Targets.RouteReference)
+	assert.Equal(t, "test-route", binding.Spec.Targets.RouteReference.Name)
+	assert.Equal(t, "configuration.konghq.com", binding.Spec.Targets.RouteReference.Group)
+	assert.Equal(t, "KongRoute", binding.Spec.Targets.RouteReference.Kind)
+	assert.Equal(t, commonv1alpha1.ControlPlaneRefKonnectNamespacedRef, binding.Spec.ControlPlaneRef.Type)
+	assert.Equal(t, "test-cp", binding.Spec.ControlPlaneRef.KonnectNamespacedRef.Name)
+	assert.Contains(t, binding.Annotations, consts.GatewayOperatorHybridRoutesGRPCRouteAnnotation)
+	assert.Equal(t, "test-namespace/test-grpcroute", binding.Annotations[consts.GatewayOperatorHybridRoutesGRPCRouteAnnotation])
+}
+
+func TestBindingForGRPCPluginAndService(t *testing.T) {
+	logger := logr.Discard()
+	ctx := context.Background()
+
+	grpcRoute := &gwtypes.GRPCRoute{
+		TypeMeta: grpcRouteTypeMeta,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-grpcroute",
+			Namespace: "test-namespace",
+			UID:       "test-uid",
+		},
+	}
+	parentRef := &gwtypes.ParentReference{
+		Name: "test-gateway",
+	}
+	cpRef := &commonv1alpha1.ControlPlaneRef{
+		Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+		KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+			Name: "test-cp",
+		},
+	}
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme.Get()).Build()
+
+	binding, err := BindingForGRPCPluginAndService(ctx, logger, fakeClient, grpcRoute, parentRef, cpRef, "test-plugin", "test-service")
+	require.NoError(t, err)
+	require.NotNil(t, binding)
+
+	assert.Equal(t, "test-namespace", binding.Namespace)
+	assert.Equal(t, "test-plugin", binding.Spec.PluginReference.Name)
+	require.NotNil(t, binding.Spec.Targets)
+	require.NotNil(t, binding.Spec.Targets.ServiceReference)
+	assert.Equal(t, "test-service", binding.Spec.Targets.ServiceReference.Name)
+	assert.Equal(t, "configuration.konghq.com", binding.Spec.Targets.ServiceReference.Group)
+	assert.Equal(t, "KongService", binding.Spec.Targets.ServiceReference.Kind)
+	assert.Contains(t, binding.Annotations, consts.GatewayOperatorHybridRoutesGRPCRouteAnnotation)
+	assert.Equal(t, "test-namespace/test-grpcroute", binding.Annotations[consts.GatewayOperatorHybridRoutesGRPCRouteAnnotation])
+}

--- a/controller/hybridgateway/refs/by.go
+++ b/controller/hybridgateway/refs/by.go
@@ -29,6 +29,8 @@ func GetNamespacedRefs(ctx context.Context, cl client.Client, obj runtime.Object
 	// TODO: add other types here
 	case *gwtypes.HTTPRoute:
 		return byRoute(ctx, cl, o)
+	case *gwtypes.GRPCRoute:
+		return byRoute(ctx, cl, o)
 	case *gwtypes.TLSRoute:
 		return byRoute(ctx, cl, o)
 	case *gwtypes.TCPRoute:

--- a/controller/hybridgateway/refs/by_test.go
+++ b/controller/hybridgateway/refs/by_test.go
@@ -50,6 +50,134 @@ func TestGetNamespacedRefs(t *testing.T) {
 			description: "should return empty map for HTTPRoute without references",
 		},
 		{
+			name: "GRPCRoute with no references",
+			setup: func() (client.Client, runtime.Object) {
+				cl := fake.NewClientBuilder().Build()
+				grpcRoute := &gwtypes.GRPCRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-route",
+						Namespace: "test-namespace",
+					},
+				}
+				return cl, grpcRoute
+			},
+			expected:    map[string]GatewaysByNamespacedRef{},
+			wantErr:     false,
+			description: "should return empty map for GRPCRoute without references",
+		},
+		{
+			name: "GRPCRoute with valid konnect control plane",
+			setup: func() (client.Client, runtime.Object) {
+				gatewayGroup := gwtypes.Group(gwtypes.GroupName)
+				gatewayKind := gwtypes.Kind("Gateway")
+
+				gateway := &gwtypes.Gateway{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-gateway",
+						Namespace: "test-namespace",
+						UID:       "gateway-uid-grpc",
+					},
+					Spec: gwtypes.GatewaySpec{
+						GatewayClassName: "test-gateway-class",
+					},
+				}
+
+				gatewayClass := &gwtypes.GatewayClass{
+					ObjectMeta: metav1.ObjectMeta{
+						Name: "test-gateway-class",
+					},
+					Spec: gwtypes.GatewayClassSpec{
+						ControllerName: "konghq.com/gateway-operator",
+					},
+				}
+
+				konnectExtension := &konnectv1alpha2.KonnectExtension{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-konnect-extension",
+						Namespace: "test-namespace",
+						Labels: map[string]string{
+							"gateway-operator.konghq.com/managed-by": "gateway",
+						},
+						OwnerReferences: []metav1.OwnerReference{
+							{
+								APIVersion: "gateway.networking.k8s.io/v1",
+								Kind:       "Gateway",
+								Name:       "test-gateway",
+								UID:        "gateway-uid-grpc",
+							},
+						},
+					},
+					Spec: konnectv1alpha2.KonnectExtensionSpec{
+						Konnect: konnectv1alpha2.KonnectExtensionKonnectSpec{
+							ControlPlane: konnectv1alpha2.KonnectExtensionControlPlane{
+								Ref: commonv1alpha1.KonnectExtensionControlPlaneRef{
+									Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+									KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+										Name: "test-cp",
+									},
+								},
+							},
+						},
+					},
+				}
+
+				controlPlane := &konnectv1alpha2.KonnectGatewayControlPlane{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-cp",
+						Namespace: "test-namespace",
+					},
+				}
+
+				cl := fake.NewClientBuilder().
+					WithScheme(newTestScheme()).
+					WithObjects(gateway, gatewayClass, konnectExtension, controlPlane).
+					Build()
+
+				grpcRoute := &gwtypes.GRPCRoute{
+					ObjectMeta: metav1.ObjectMeta{
+						Name:      "test-route",
+						Namespace: "test-namespace",
+					},
+					Spec: gwtypes.GRPCRouteSpec{
+						CommonRouteSpec: gatewayv1.CommonRouteSpec{
+							ParentRefs: []gwtypes.ParentReference{
+								{
+									Group: &gatewayGroup,
+									Kind:  &gatewayKind,
+									Name:  "test-gateway",
+								},
+							},
+						},
+					},
+				}
+				return cl, grpcRoute
+			},
+			expected: map[string]GatewaysByNamespacedRef{
+				"test-namespace/test-cp": {
+					Ref: commonv1alpha1.KonnectNamespacedRef{
+						Name:      "test-cp",
+						Namespace: "test-namespace",
+					},
+					Gateways: []gwtypes.Gateway{
+						{
+							ObjectMeta: metav1.ObjectMeta{
+								Name:      "test-gateway",
+								Namespace: "test-namespace",
+								UID:       "gateway-uid-grpc",
+								// ResourceVersion is set by the fake client when the Gateway is fetched.
+								ResourceVersion: "999",
+							},
+							Spec: gwtypes.GatewaySpec{
+								GatewayClassName: "test-gateway-class",
+							},
+						},
+					},
+				},
+			},
+			wantErr:     false,
+			description: "should return the KonnectNamespacedRef and Gateway for a GRPCRoute referencing a Konnect-backed Gateway (regression test: GetNamespacedRefs previously had no *gwtypes.GRPCRoute case and silently fell through to the default nil,nil branch)",
+		},
+		{
 			name: "TLSRoute with no references",
 			setup: func() (client.Client, runtime.Object) {
 				cl := fake.NewClientBuilder().Build()

--- a/controller/hybridgateway/route/status.go
+++ b/controller/hybridgateway/route/status.go
@@ -159,6 +159,8 @@ func routeKindForStatusPhase[T gwtypes.SupportedRoute](routeObject T) string {
 	switch any(routeObject).(type) {
 	case gwtypes.HTTPRoute:
 		return "HTTPRoute"
+	case gwtypes.GRPCRoute:
+		return "GRPCRoute"
 	case gwtypes.TLSRoute:
 		return "TLSRoute"
 	case gwtypes.TCPRoute:
@@ -373,6 +375,8 @@ func getParentStatus[T gwtypes.SupportedRoute](route T) []gwtypes.RouteParentSta
 	switch r := any(route).(type) {
 	case gwtypes.HTTPRoute:
 		return r.Status.Parents
+	case gwtypes.GRPCRoute:
+		return r.Status.Parents
 	case gwtypes.TLSRoute:
 		return r.Status.Parents
 	case gwtypes.TCPRoute:
@@ -384,6 +388,8 @@ func getParentStatus[T gwtypes.SupportedRoute](route T) []gwtypes.RouteParentSta
 func setParentRefStatus[T gwtypes.SupportedRoute, TPtr gwtypes.SupportedRoutePtr[T]](route TPtr, parentStatus []gwtypes.RouteParentStatus) {
 	switch r := any(route).(type) {
 	case *gwtypes.HTTPRoute:
+		r.Status.Parents = parentStatus
+	case *gwtypes.GRPCRoute:
 		r.Status.Parents = parentStatus
 	case *gwtypes.TLSRoute:
 		r.Status.Parents = parentStatus
@@ -655,6 +661,47 @@ func BuildResolvedRefsConditionForHTTPRoute(ctx context.Context, logger logr.Log
 	return buildResolvedRefsCondition(ctx, logger, cl, route, backendRefs, extensionRefs)
 }
 
+// BuildResolvedRefsConditionForGRPCRoute evaluates all BackendRefs and ExtensionRef filters in a
+// GRPCRoute to determine if their references are valid and permitted. Mirrors
+// BuildResolvedRefsConditionForHTTPRoute, keyed on GRPCRoute's own filter type
+// (gwtypes.GRPCRouteFilterExtensionRef) since GRPCRouteFilter is a distinct Go type from
+// HTTPRouteFilter despite sharing the same ExtensionRef shape.
+// It checks that each BackendRef:
+//   - Has a supported group/kind
+//   - Exists in the target namespace
+//   - Is permitted by ReferenceGrant if referencing a different namespace
+//
+// And that each ExtensionRef filter's referenced KongPlugin exists.
+//
+// Returns a condition indicating whether all references are resolved, or details about the first failure encountered.
+//
+// Parameters:
+//   - ctx: Context for API calls
+//   - logger: Logger for debugging information
+//   - cl: Kubernetes client for resource operations
+//   - route: The GRPCRoute whose BackendRefs and ExtensionRef filters are being checked
+//
+// Returns:
+//   - *metav1.Condition: Condition indicating resolved refs status
+//   - error: Any error encountered during evaluation
+func BuildResolvedRefsConditionForGRPCRoute(ctx context.Context, logger logr.Logger, cl client.Client, route *gwtypes.GRPCRoute) (*metav1.Condition, error) {
+	backendRefs := make([]gwtypes.BackendRef, 0)
+	extensionRefs := make([]*gwtypes.LocalObjectReference, 0)
+	for _, rule := range route.Spec.Rules {
+		for _, bRef := range rule.BackendRefs {
+			backendRefs = append(backendRefs, bRef.BackendRef)
+		}
+
+		for _, filter := range rule.Filters {
+			if filter.Type == gwtypes.GRPCRouteFilterExtensionRef {
+				extensionRefs = append(extensionRefs, filter.ExtensionRef)
+			}
+		}
+	}
+
+	return buildResolvedRefsCondition(ctx, logger, cl, route, backendRefs, extensionRefs)
+}
+
 // BuildResolvedRefsConditionForTLSRoute evaluates all BackendRefs in an TLSRoute to determine if their
 // references are valid and permitted.
 // It checks that each BackendRef:
@@ -766,6 +813,13 @@ func validateAnnotations[T gwtypes.SupportedRoute, TPtr gwtypes.SupportedRoutePt
 		}
 		for _, rule := range r.Spec.Rules {
 			backendRefs := utils.HTTPBackendRefsToBackendRefs(rule.BackendRefs)
+			if err := service.ValidateBackendRefAnnotations(ctx, cl, route.GetNamespace(), backendRefs, logger); err != nil {
+				return err
+			}
+		}
+	case *gwtypes.GRPCRoute:
+		for _, rule := range r.Spec.Rules {
+			backendRefs := utils.GRPCBackendRefsToBackendRefs(rule.BackendRefs)
 			if err := service.ValidateBackendRefAnnotations(ctx, cl, route.GetNamespace(), backendRefs, logger); err != nil {
 				return err
 			}
@@ -998,6 +1052,14 @@ func isListenerValidForKind(routeKind string, listener gwtypes.Listener) bool {
 		// HTTPRoutes support Terminate only
 		// Note: this is a guess we are doing as the upstream documentation is unclear at the moment.
 		// see https://github.com/kubernetes-sigs/gateway-api/issues/1474
+		if listener.Protocol != gwtypes.HTTPProtocolType && listener.Protocol != gwtypes.HTTPSProtocolType {
+			return false
+		}
+		if listener.TLS != nil && *listener.TLS.Mode != gwtypes.TLSModeTerminate {
+			return false
+		}
+		return true
+	case "GRPCRoute":
 		if listener.Protocol != gwtypes.HTTPProtocolType && listener.Protocol != gwtypes.HTTPSProtocolType {
 			return false
 		}

--- a/controller/hybridgateway/route/status.go
+++ b/controller/hybridgateway/route/status.go
@@ -1055,7 +1055,7 @@ func isListenerValidForKind(routeKind string, listener gwtypes.Listener) bool {
 		if listener.Protocol != gwtypes.HTTPProtocolType && listener.Protocol != gwtypes.HTTPSProtocolType {
 			return false
 		}
-		if listener.TLS != nil && *listener.TLS.Mode != gwtypes.TLSModeTerminate {
+		if listener.TLS != nil && listener.TLS.Mode != nil && *listener.TLS.Mode != gwtypes.TLSModeTerminate {
 			return false
 		}
 		return true
@@ -1063,7 +1063,7 @@ func isListenerValidForKind(routeKind string, listener gwtypes.Listener) bool {
 		if listener.Protocol != gwtypes.HTTPProtocolType && listener.Protocol != gwtypes.HTTPSProtocolType {
 			return false
 		}
-		if listener.TLS != nil && *listener.TLS.Mode != gwtypes.TLSModeTerminate {
+		if listener.TLS != nil && listener.TLS.Mode != nil && *listener.TLS.Mode != gwtypes.TLSModeTerminate {
 			return false
 		}
 		return true

--- a/controller/hybridgateway/route/status_test.go
+++ b/controller/hybridgateway/route/status_test.go
@@ -1521,6 +1521,7 @@ func Test_FilterMatchingListeners(t *testing.T) {
 	}
 	listenerAccepted := gwtypes.Listener{Name: "listener1", Port: 80, Protocol: gwtypes.HTTPProtocolType}
 	listenerRejected := gwtypes.Listener{Name: "listener2", Port: 80, Protocol: gwtypes.HTTPProtocolType}
+	listenerAcceptedHTTPS := gwtypes.Listener{Name: "listener1", Port: 443, Protocol: gwtypes.HTTPSProtocolType, TLS: &gatewayv1.ListenerTLSConfig{Mode: new(gwtypes.TLSModeTerminate)}}
 	tlsModePassthrough := gatewayv1.TLSModePassthrough
 	tlsModeTerminate := gatewayv1.TLSModeTerminate
 	listenerRejectedTLS := gwtypes.Listener{Name: "listener2", Port: 80, Protocol: gwtypes.TLSProtocolType, TLS: &gatewayv1.ListenerTLSConfig{Mode: &tlsModeTerminate}}
@@ -1589,6 +1590,22 @@ func Test_FilterMatchingListeners(t *testing.T) {
 			wantCond:  false,
 		},
 		{
+			name:      "GRPCRoute - HTTP listener matches",
+			pRef:      pRef,
+			routeKind: "GRPCRoute",
+			listeners: []gwtypes.Listener{listenerAccepted},
+			wantLen:   1,
+			wantCond:  false,
+		},
+		{
+			name:      "GRPCRoute - HTTPS listener with terminate TLS matches",
+			pRef:      pRef,
+			routeKind: "GRPCRoute",
+			listeners: []gwtypes.Listener{listenerAcceptedHTTPS},
+			wantLen:   1,
+			wantCond:  false,
+		},
+		{
 			name:      "TLSRoute - no accepted listeners",
 			pRef:      pRef,
 			routeKind: "TLSRoute",
@@ -1632,6 +1649,7 @@ func Test_FilterListenersByAllowedRoutes(t *testing.T) {
 	pRef := gwtypes.ParentReference{Name: "listener1"}
 	listener := gwtypes.Listener{Name: "listener1", Port: 80, Protocol: gwtypes.HTTPProtocolType}
 	kind := gwtypes.RouteGroupKind{Group: groupPtr(gwtypes.GroupName), Kind: "HTTPRoute"}
+	kindGRPCRoute := gwtypes.RouteGroupKind{Group: groupPtr(gwtypes.GroupName), Kind: "GRPCRoute"}
 	kindTLSRoute := gwtypes.RouteGroupKind{Group: groupPtr(gwtypes.GroupName), Kind: "TLSRoute"}
 	routeNS := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: "default"}}
 
@@ -1704,6 +1722,23 @@ func Test_FilterListenersByAllowedRoutes(t *testing.T) {
 			wantLen:   1,
 			wantCond:  false,
 			wantErr:   false,
+		},
+		{
+			name:      "GRPCRoute - AllowedRoutes nil (all allowed)",
+			listeners: []gwtypes.Listener{listener},
+			kind:      kindGRPCRoute,
+			routeNS:   routeNS,
+			wantLen:   1,
+			wantCond:  false,
+			wantErr:   false,
+		},
+		{
+			name:      "GRPCRoute - TLS mode mismatch",
+			listeners: []gwtypes.Listener{listenerTLSPassthrough},
+			kind:      kindGRPCRoute,
+			routeNS:   routeNS,
+			wantLen:   0,
+			wantCond:  true,
 		},
 		{
 			name:      "Kind mismatch",
@@ -2987,6 +3022,228 @@ func TestBuildResolvedRefsCondition(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestBuildResolvedRefsConditionForGRPCRoute covers the GRPCRoute-specific wiring in
+// BuildResolvedRefsConditionForGRPCRoute (extracting BackendRefs from GRPCRouteRule and
+// ExtensionRef filters keyed on gwtypes.GRPCRouteFilterExtensionRef, not HTTPRoute's constant).
+// The shared resolution logic itself (unsupported kind, cross-namespace ReferenceGrant, etc.) is
+// already exhaustively covered by TestBuildResolvedRefsCondition against buildResolvedRefsCondition,
+// so this only needs to prove the GRPCRoute wrapper feeds that logic correctly.
+func TestBuildResolvedRefsConditionForGRPCRoute(t *testing.T) {
+	ctx := context.Background()
+	logger := logr.Discard()
+
+	service := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "svc",
+		},
+	}
+	kongPlugin := &configurationv1.KongPlugin{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "test-plugin",
+		},
+		PluginName: "rate-limiting",
+	}
+
+	grpcRouteTypeMeta := metav1.TypeMeta{
+		Kind:       "GRPCRoute",
+		APIVersion: "gateway.networking.k8s.io/v1",
+	}
+
+	tests := []struct {
+		name        string
+		clientObjs  []client.Object
+		route       *gwtypes.GRPCRoute
+		wantStatus  metav1.ConditionStatus
+		wantReason  string
+		wantMsgPart string
+	}{
+		{
+			name:       "all references resolved - BackendRef and ExtensionRef filter",
+			clientObjs: []client.Object{service, kongPlugin},
+			route: &gwtypes.GRPCRoute{
+				TypeMeta:   grpcRouteTypeMeta,
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "route"},
+				Spec: gwtypes.GRPCRouteSpec{
+					Rules: []gwtypes.GRPCRouteRule{{
+						BackendRefs: []gwtypes.GRPCBackendRef{{
+							BackendRef: gwtypes.BackendRef{
+								BackendObjectReference: gwtypes.BackendObjectReference{
+									Name:  gwtypes.ObjectName("svc"),
+									Kind:  kindPtr("Service"),
+									Group: groupPtr("core"),
+								},
+							},
+						}},
+						Filters: []gatewayv1.GRPCRouteFilter{{
+							Type: gwtypes.GRPCRouteFilterExtensionRef,
+							ExtensionRef: &gwtypes.LocalObjectReference{
+								Group: "configuration.konghq.com",
+								Kind:  "KongPlugin",
+								Name:  "test-plugin",
+							},
+						}},
+					}},
+				},
+			},
+			wantStatus:  metav1.ConditionTrue,
+			wantReason:  string(gwtypes.RouteReasonResolvedRefs),
+			wantMsgPart: "All references resolved",
+		},
+		{
+			name:       "unsupported group/kind",
+			clientObjs: []client.Object{service},
+			route: &gwtypes.GRPCRoute{
+				TypeMeta:   grpcRouteTypeMeta,
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "route"},
+				Spec: gwtypes.GRPCRouteSpec{
+					Rules: []gwtypes.GRPCRouteRule{{
+						BackendRefs: []gwtypes.GRPCBackendRef{{
+							BackendRef: gwtypes.BackendRef{
+								BackendObjectReference: gwtypes.BackendObjectReference{
+									Name:  gwtypes.ObjectName("svc"),
+									Kind:  kindPtr("Unsupported"),
+									Group: groupPtr("core"),
+								},
+							},
+						}},
+					}},
+				},
+			},
+			wantStatus:  metav1.ConditionFalse,
+			wantReason:  string(gwtypes.RouteReasonInvalidKind),
+			wantMsgPart: "Unsupported BackendRef",
+		},
+		{
+			name:       "service not found",
+			clientObjs: []client.Object{},
+			route: &gwtypes.GRPCRoute{
+				TypeMeta:   grpcRouteTypeMeta,
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "route"},
+				Spec: gwtypes.GRPCRouteSpec{
+					Rules: []gwtypes.GRPCRouteRule{{
+						BackendRefs: []gwtypes.GRPCBackendRef{{
+							BackendRef: gwtypes.BackendRef{
+								BackendObjectReference: gwtypes.BackendObjectReference{
+									Name:  gwtypes.ObjectName("svc"),
+									Kind:  kindPtr("Service"),
+									Group: groupPtr("core"),
+								},
+							},
+						}},
+					}},
+				},
+			},
+			wantStatus:  metav1.ConditionFalse,
+			wantReason:  string(gwtypes.RouteReasonBackendNotFound),
+			wantMsgPart: "not found",
+		},
+		{
+			name:       "ExtensionRef KongPlugin not found",
+			clientObjs: []client.Object{service},
+			route: &gwtypes.GRPCRoute{
+				TypeMeta:   grpcRouteTypeMeta,
+				ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "route"},
+				Spec: gwtypes.GRPCRouteSpec{
+					Rules: []gwtypes.GRPCRouteRule{{
+						Filters: []gatewayv1.GRPCRouteFilter{{
+							Type: gwtypes.GRPCRouteFilterExtensionRef,
+							ExtensionRef: &gwtypes.LocalObjectReference{
+								Group: "configuration.konghq.com",
+								Kind:  "KongPlugin",
+								Name:  "missing-plugin",
+							},
+						}},
+					}},
+				},
+			},
+			wantStatus: metav1.ConditionFalse,
+			wantReason: string(gwtypes.RouteReasonBackendNotFound),
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			s := runtime.NewScheme()
+			require.NoError(t, corev1.AddToScheme(s))
+			require.NoError(t, configurationv1.AddToScheme(s))
+			require.NoError(t, gatewayv1.Install(s))
+
+			cl := fake.NewClientBuilder().WithScheme(s).WithObjects(tt.clientObjs...).Build()
+
+			cond, err := BuildResolvedRefsConditionForGRPCRoute(ctx, logger, cl, tt.route)
+			require.NoError(t, err)
+			require.NotNil(t, cond)
+			require.Equal(t, tt.wantStatus, cond.Status)
+			require.Equal(t, tt.wantReason, cond.Reason)
+			if tt.wantMsgPart != "" {
+				require.Contains(t, cond.Message, tt.wantMsgPart)
+			}
+		})
+	}
+}
+
+func TestValidateAnnotationsForGRPCRoute(t *testing.T) {
+	ctx := context.Background()
+	logger := logr.Discard()
+
+	s := runtime.NewScheme()
+	require.NoError(t, corev1.AddToScheme(s))
+	require.NoError(t, gatewayv1.Install(s))
+
+	port := gatewayv1.PortNumber(50051)
+	route := &gwtypes.GRPCRoute{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "route"},
+		Spec: gwtypes.GRPCRouteSpec{
+			Rules: []gwtypes.GRPCRouteRule{{
+				BackendRefs: []gwtypes.GRPCBackendRef{{
+					BackendRef: gwtypes.BackendRef{
+						BackendObjectReference: gwtypes.BackendObjectReference{
+							Name: "svc",
+							Port: &port,
+						},
+					},
+				}},
+			}},
+		},
+	}
+
+	t.Run("valid backend service annotations", func(t *testing.T) {
+		cl := fake.NewClientBuilder().
+			WithScheme(s).
+			WithObjects(&corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "svc",
+					Annotations: map[string]string{
+						"konghq.com/connect-timeout": "5000",
+					},
+				},
+			}).
+			Build()
+
+		require.NoError(t, validateAnnotations(ctx, logger, cl, route))
+	})
+
+	t.Run("malformed backend service annotations", func(t *testing.T) {
+		cl := fake.NewClientBuilder().
+			WithScheme(s).
+			WithObjects(&corev1.Service{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace: "default",
+					Name:      "svc",
+					Annotations: map[string]string{
+						"konghq.com/connect-timeout": "invalid",
+					},
+				},
+			}).
+			Build()
+
+		require.ErrorContains(t, validateAnnotations(ctx, logger, cl, route), "konghq.com/connect-timeout")
+	})
 }
 
 func TestBuildResolvedRefsConditionForTCPRoute(t *testing.T) {

--- a/controller/hybridgateway/service/service.go
+++ b/controller/hybridgateway/service/service.go
@@ -103,6 +103,16 @@ func ServiceForRuleWithName[
 		defaultProtocol = "http"
 		backendRequestTimeout = namegen.BackendRequestTimeoutMilliseconds(httpRule)
 
+	case *gwtypes.GRPCRoute:
+		grpcRule, ok := any(rule).(gwtypes.GRPCRouteRule)
+		if !ok {
+			return nil, nil, nil, fmt.Errorf("failed to build KongService : unmatched route type and rule type: %T and %T", parentRoute, rule)
+		}
+		serviceName = namegen.NewKongServiceNameForGRPCRouteRule(r, cp, grpcRule)
+		namespace = r.Namespace
+		backendRefs = utils.GRPCBackendRefsToBackendRefs(grpcRule.BackendRefs)
+		defaultProtocol = "grpc"
+
 	case *gwtypes.TLSRoute:
 		tlsRule, ok := any(rule).(gwtypes.TLSRouteRule)
 		if !ok {

--- a/controller/hybridgateway/service/service_test.go
+++ b/controller/hybridgateway/service/service_test.go
@@ -224,6 +224,57 @@ func TestServiceForTCPRouteRule(t *testing.T) {
 	assert.Equal(t, "test-namespace/test-route", service.Annotations[consts.GatewayOperatorHybridRoutesTCPRouteAnnotation])
 }
 
+// TestServiceForGRPCRouteRule covers ServiceForRuleWithName's *gwtypes.GRPCRoute branch: the
+// default protocol must resolve to "grpc" (unlike TCPRoute/TLSRoute, which default to "tcp"), and
+// backend refs must come through utils.GRPCBackendRefsToBackendRefs.
+func TestServiceForGRPCRouteRule(t *testing.T) {
+	ctx := context.Background()
+	logger := zap.New()
+
+	scheme := runtime.NewScheme()
+	require.NoError(t, configurationv1alpha1.AddToScheme(scheme))
+	require.NoError(t, corev1.AddToScheme(scheme))
+
+	cl := fake.NewClientBuilder().WithScheme(scheme).Build()
+	grpcRoute := &gwtypes.GRPCRoute{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "GRPCRoute",
+			APIVersion: "gateway.networking.k8s.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "test-namespace",
+		},
+	}
+	port := gwtypes.PortNumber(50051)
+	rule := gwtypes.GRPCRouteRule{
+		BackendRefs: []gwtypes.GRPCBackendRef{{
+			BackendRef: gwtypes.BackendRef{
+				BackendObjectReference: gwtypes.BackendObjectReference{
+					Name: "test-service",
+					Port: &port,
+				},
+			},
+		}},
+	}
+	pRef := &gwtypes.ParentReference{Name: "test-gateway"}
+	cp := &commonv1alpha1.ControlPlaneRef{
+		Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+		KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+			Name: "test-cp",
+		},
+	}
+
+	service, cert, grant, err := ServiceForRule(ctx, logger, cl, grpcRoute, rule, pRef, cp, "test-upstream")
+	require.NoError(t, err)
+	require.NotNil(t, service)
+	require.Nil(t, cert)
+	require.Nil(t, grant)
+	assert.Equal(t, sdkkonnectcomp.Protocol(sdkkonnectcomp.ProtocolsGrpc), service.Spec.Protocol)
+	assert.Equal(t, "test-upstream", service.Spec.Host)
+	assert.Equal(t, "test-namespace/test-route", service.Annotations[consts.GatewayOperatorHybridRoutesGRPCRouteAnnotation])
+}
+
 func TestServiceForRule_ProtocolAnnotation(t *testing.T) {
 	ctx := context.Background()
 	logger := zap.New()

--- a/controller/hybridgateway/target/target.go
+++ b/controller/hybridgateway/target/target.go
@@ -65,6 +65,10 @@ func TargetsForBackendRefs[
 		if _, ok := any(backendRefs).([]gwtypes.HTTPBackendRef); !ok {
 			return nil, fmt.Errorf("failed to build KongTarget: unmatched route and backendRefs type: %T and  %T", parentRoute, backendRefs)
 		}
+	case *gwtypes.GRPCRoute:
+		if _, ok := any(backendRefs).([]gwtypes.GRPCBackendRef); !ok {
+			return nil, fmt.Errorf("failed to build KongTarget: unmatched route and backendRefs type: %T and  %T", parentRoute, backendRefs)
+		}
 	case *gwtypes.TLSRoute:
 		if _, ok := any(backendRefs).([]gwtypes.BackendRef); !ok {
 			return nil, fmt.Errorf("failed to build KongTarget: unmatched route and backendRefs type: %T and  %T", parentRoute, backendRefs)

--- a/controller/hybridgateway/target/target_test.go
+++ b/controller/hybridgateway/target/target_test.go
@@ -3289,6 +3289,56 @@ func TestTargetsForTCPRouteBackendRefs(t *testing.T) {
 	assert.Equal(t, "test-namespace/test-route", targets[0].Annotations["gateway-operator.konghq.com/hybrid-routes-TCPRoute"])
 }
 
+// TestTargetsForGRPCRouteBackendRefs covers TargetsForBackendRefs' *gwtypes.GRPCRoute type-check
+// branch: a GRPCRoute paired with []gwtypes.GRPCBackendRef must pass the route/backendRefs type
+// match and produce targets normally.
+func TestTargetsForGRPCRouteBackendRefs(t *testing.T) {
+	ctx := context.Background()
+	logger := logr.Discard()
+	port := int32(80)
+	backendPort := gwtypes.PortNumber(80)
+
+	grpcRoute := &gwtypes.GRPCRoute{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "GRPCRoute",
+			APIVersion: "gateway.networking.k8s.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "test-namespace",
+		},
+	}
+	backendRefs := []gwtypes.GRPCBackendRef{{
+		BackendRef: gwtypes.BackendRef{
+			BackendObjectReference: gwtypes.BackendObjectReference{
+				Name: "test-service",
+				Port: &backendPort,
+			},
+		},
+	}}
+	service := createTestService("test-service", "test-namespace", corev1.ServiceTypeClusterIP, "10.0.0.1", "", []corev1.ServicePort{{
+		Name:       "grpc",
+		Port:       port,
+		Protocol:   corev1.ProtocolTCP,
+		TargetPort: intstr.FromInt(8080),
+	}})
+	endpointSlice := createTestEndpointSlice("test-service-slice", []discoveryv1.EndpointPort{
+		createTestEndpointPort("grpc", 8080, corev1.ProtocolTCP),
+	}, []discoveryv1.Endpoint{
+		createTestEndpoint([]string{"10.0.0.2"}, true),
+	})
+	endpointSlice.Namespace = "test-namespace"
+	endpointSlice.Labels = map[string]string{discoveryv1.LabelServiceName: "test-service"}
+
+	cl := createTestFakeClient(service, &endpointSlice)
+	targets, err := TargetsForBackendRefs(ctx, logger, cl, grpcRoute, backendRefs, &gwtypes.ParentReference{Name: "test-gateway"}, "test-upstream", false, "")
+	require.NoError(t, err)
+	require.Len(t, targets, 1)
+	assert.NotEmpty(t, targets[0].Name)
+	assert.Equal(t, "10.0.0.2:8080", targets[0].Spec.Target)
+	assert.Equal(t, "test-namespace/test-route", targets[0].Annotations["gateway-operator.konghq.com/hybrid-routes-GRPCRoute"])
+}
+
 func findTargetByAddress(targets []configurationv1alpha1.KongTarget, address string) *configurationv1alpha1.KongTarget {
 	for i := range targets {
 		if targets[i].Spec.Target == address {

--- a/controller/hybridgateway/upstream/upstream.go
+++ b/controller/hybridgateway/upstream/upstream.go
@@ -67,6 +67,14 @@ func UpstreamForRule[
 		upstreamName = namegen.NewKongUpstreamNameForHTTPRouteRule(r, cp, httpRule)
 		namespace = r.Namespace
 		backendRefs = utils.HTTPBackendRefsToBackendRefs(httpRule.BackendRefs)
+	case *gwtypes.GRPCRoute:
+		grpcRule, ok := any(rule).(gwtypes.GRPCRouteRule)
+		if !ok {
+			return nil, fmt.Errorf("failed to build KongUpstream: unmatched route type and rule type: %T and %T", parentRoute, rule)
+		}
+		upstreamName = namegen.NewKongUpstreamNameForGRPCRouteRule(r, cp, grpcRule)
+		namespace = r.Namespace
+		backendRefs = utils.GRPCBackendRefsToBackendRefs(grpcRule.BackendRefs)
 	case *gwtypes.TLSRoute:
 		tlsRule, ok := any(rule).(gwtypes.TLSRouteRule)
 		if !ok {

--- a/controller/hybridgateway/upstream/upstream_test.go
+++ b/controller/hybridgateway/upstream/upstream_test.go
@@ -327,6 +327,62 @@ func TestUpstreamForRule_NewUpstream(t *testing.T) {
 	assert.Equal(t, expectedAnnotation, actualAnnotation)
 }
 
+// TestUpstreamForGRPCRouteRule is a regression test: UpstreamForRule previously had no
+// *gwtypes.GRPCRoute case in its route-type switch, so it fell through to the "unsupported route
+// type" default error for every GRPCRoute rule.
+func TestUpstreamForGRPCRouteRule(t *testing.T) {
+	scheme := runtime.NewScheme()
+	require.NoError(t, configurationv1alpha1.AddToScheme(scheme))
+
+	client := fake.NewClientBuilder().WithScheme(scheme).Build()
+	logger := logr.Discard()
+	ctx := context.Background()
+
+	grpcRoute := &gwtypes.GRPCRoute{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "GRPCRoute",
+			APIVersion: "gateway.networking.k8s.io/v1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "test-namespace",
+		},
+	}
+
+	rule := gwtypes.GRPCRouteRule{
+		BackendRefs: []gwtypes.GRPCBackendRef{
+			{
+				BackendRef: gwtypes.BackendRef{
+					BackendObjectReference: gwtypes.BackendObjectReference{
+						Name: "test-service",
+						Port: func() *gwtypes.PortNumber { p := gwtypes.PortNumber(80); return &p }(),
+					},
+				},
+			},
+		},
+	}
+
+	pRef := &gwtypes.ParentReference{
+		Name: "test-gateway",
+	}
+
+	cp := &commonv1alpha1.ControlPlaneRef{
+		Type: commonv1alpha1.ControlPlaneRefKonnectNamespacedRef,
+		KonnectNamespacedRef: &commonv1alpha1.KonnectNamespacedRef{
+			Name:      "test-cp",
+			Namespace: "test-namespace",
+		},
+	}
+
+	upstream, err := UpstreamForRule(ctx, logger, client, grpcRoute, rule, pRef, cp)
+	require.NoError(t, err)
+	require.NotNil(t, upstream)
+
+	expectedAnnotation := "test-namespace/test-route"
+	actualAnnotation := upstream.Annotations[consts.GatewayOperatorHybridRoutesGRPCRouteAnnotation]
+	assert.Equal(t, expectedAnnotation, actualAnnotation)
+}
+
 func TestUpstreamForTCPRouteRule(t *testing.T) {
 	scheme := runtime.NewScheme()
 	require.NoError(t, configurationv1alpha1.AddToScheme(scheme))

--- a/controller/hybridgateway/utils/backendref.go
+++ b/controller/hybridgateway/utils/backendref.go
@@ -15,6 +15,15 @@ func HTTPBackendRefsToBackendRefs(refs []gwtypes.HTTPBackendRef) []gwtypes.Backe
 	return out
 }
 
+// GRPCBackendRefsToBackendRefs unwraps []GRPCBackendRef to []BackendRef.
+func GRPCBackendRefsToBackendRefs(refs []gwtypes.GRPCBackendRef) []gwtypes.BackendRef {
+	out := make([]gwtypes.BackendRef, len(refs))
+	for i, r := range refs {
+		out[i] = r.BackendRef
+	}
+	return out
+}
+
 // BackendRefGroupKind returns the effective group and kind for a BackendRef,
 // applying Gateway API defaults: kind defaults to "Service" and group defaults
 // to "" (core) when nil or empty.

--- a/controller/hybridgateway/utils/backendref_test.go
+++ b/controller/hybridgateway/utils/backendref_test.go
@@ -182,3 +182,103 @@ func TestHTTPBackendRefsToBackendRefs(t *testing.T) {
 		})
 	}
 }
+
+func TestGRPCBackendRefsToBackendRefs(t *testing.T) {
+	port80 := gatewayv1.PortNumber(80)
+	port443 := gatewayv1.PortNumber(443)
+	weight := int32(50)
+	otherNS := gatewayv1.Namespace("other-namespace")
+
+	tests := []struct {
+		name     string
+		input    []gatewayv1.GRPCBackendRef
+		expected []gwtypes.BackendRef
+	}{
+		{
+			name:     "nil input returns empty slice",
+			input:    nil,
+			expected: []gwtypes.BackendRef{},
+		},
+		{
+			name:     "empty input returns empty slice",
+			input:    []gatewayv1.GRPCBackendRef{},
+			expected: []gwtypes.BackendRef{},
+		},
+		{
+			name: "single ref extracted",
+			input: []gatewayv1.GRPCBackendRef{
+				{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "svc-a", Port: &port80}}},
+			},
+			expected: []gwtypes.BackendRef{
+				{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "svc-a", Port: &port80}},
+			},
+		},
+		{
+			name: "multiple refs extracted in order",
+			input: []gatewayv1.GRPCBackendRef{
+				{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "svc-a", Port: &port80}}},
+				{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "svc-b", Port: &port443}}},
+			},
+			expected: []gwtypes.BackendRef{
+				{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "svc-a", Port: &port80}},
+				{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "svc-b", Port: &port443}},
+			},
+		},
+		{
+			name: "GRPC filters are stripped, only BackendRef preserved",
+			input: []gatewayv1.GRPCBackendRef{
+				{
+					BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "svc-filtered", Port: &port80}},
+					Filters: []gatewayv1.GRPCRouteFilter{
+						{Type: gatewayv1.GRPCRouteFilterRequestHeaderModifier},
+					},
+				},
+			},
+			expected: []gwtypes.BackendRef{
+				{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "svc-filtered", Port: &port80}},
+			},
+		},
+		{
+			name: "cross-namespace ref preserved",
+			input: []gatewayv1.GRPCBackendRef{
+				{BackendRef: gatewayv1.BackendRef{BackendObjectReference: gatewayv1.BackendObjectReference{
+					Name:      "svc-other",
+					Port:      &port80,
+					Namespace: &otherNS,
+				}}},
+			},
+			expected: []gwtypes.BackendRef{
+				{BackendObjectReference: gatewayv1.BackendObjectReference{
+					Name:      "svc-other",
+					Port:      &port80,
+					Namespace: &otherNS,
+				}},
+			},
+		},
+		{
+			name: "weight preserved",
+			input: []gatewayv1.GRPCBackendRef{
+				{BackendRef: gatewayv1.BackendRef{
+					BackendObjectReference: gatewayv1.BackendObjectReference{Name: "svc-weighted", Port: &port80},
+					Weight:                 &weight,
+				}},
+			},
+			expected: []gwtypes.BackendRef{
+				{BackendObjectReference: gatewayv1.BackendObjectReference{Name: "svc-weighted", Port: &port80}, Weight: &weight},
+			},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GRPCBackendRefsToBackendRefs(tt.input)
+			require.Len(t, got, len(tt.expected))
+			for i := range tt.expected {
+				assert.Equal(t, tt.expected[i].Name, got[i].Name)
+				assert.Equal(t, tt.expected[i].Namespace, got[i].Namespace)
+				assert.Equal(t, tt.expected[i].Port, got[i].Port)
+				assert.Equal(t, tt.expected[i].Weight, got[i].Weight)
+			}
+		})
+	}
+}

--- a/internal/types/gatewaytypes.go
+++ b/internal/types/gatewaytypes.go
@@ -61,6 +61,8 @@ type (
 	GRPCRoute              = gatewayv1.GRPCRoute
 	GRPCRouteList          = gatewayv1.GRPCRouteList
 	GRPCRouteSpec          = gatewayv1.GRPCRouteSpec
+	GRPCRouteRule          = gatewayv1.GRPCRouteRule
+	GRPCBackendRef         = gatewayv1.GRPCBackendRef
 	UDPRoute               = gatewayv1.UDPRoute
 	UDPRouteList           = gatewayv1.UDPRouteList
 	UDPRouteSpec           = gatewayv1.UDPRouteSpec
@@ -78,6 +80,7 @@ const (
 	UDPProtocolType                       = gatewayv1.UDPProtocolType
 	TCPProtocolType                       = gatewayv1.TCPProtocolType
 	HTTPRouteFilterExtensionRef           = gatewayv1.HTTPRouteFilterExtensionRef
+	GRPCRouteFilterExtensionRef           = gatewayv1.GRPCRouteFilterExtensionRef
 	HTTPRouteFilterRequestHeaderModifier  = gatewayv1.HTTPRouteFilterRequestHeaderModifier
 	ListenerConditionProgrammed           = gatewayv1.ListenerConditionProgrammed
 	NamespacesFromAll                     = gatewayv1.NamespacesFromAll

--- a/internal/types/gatewaytypes_interfaces.go
+++ b/internal/types/gatewaytypes_interfaces.go
@@ -16,7 +16,7 @@ type SupportedRoutePtr[T SupportedRoute] interface {
 
 // SupportedRouteList defines a list of supported route.
 type SupportedRouteList interface {
-	HTTPRouteList | TLSRouteList | TCPRouteList | UDPRouteList
+	HTTPRouteList | TLSRouteList | GRPCRouteList | TCPRouteList | UDPRouteList
 }
 
 // SupportedRouteListPtr defines a pointer of a supported route list.
@@ -28,12 +28,12 @@ type SupportedRouteListPtr[T SupportedRouteList] interface {
 
 // SupportedRouteRule defines a rule in a supported route.
 type SupportedRouteRule interface {
-	HTTPRouteRule | TLSRouteRule | TCPRouteRule | UDPRouteRule
+	HTTPRouteRule | GRPCRouteRule | TLSRouteRule | TCPRouteRule | UDPRouteRule
 }
 
 // SupportedBackendRef defines a supported backendRef type.
 type SupportedBackendRef interface {
-	BackendRef | HTTPBackendRef
+	BackendRef | HTTPBackendRef | GRPCBackendRef
 }
 
 // GetSpecParentRefs returns the parent references of a supported route.
@@ -59,6 +59,8 @@ func GetSpecHostnames[T SupportedRoute](route T) []Hostname {
 	switch r := any(route).(type) {
 	case HTTPRoute:
 		return r.Spec.Hostnames
+	case GRPCRoute:
+		return r.Spec.Hostnames
 	case TLSRoute:
 		return r.Spec.Hostnames
 	case TCPRoute:
@@ -71,6 +73,8 @@ func GetSpecHostnames[T SupportedRoute](route T) []Hostname {
 func GetBackendRef[T SupportedBackendRef](bRef T) BackendRef {
 	switch b := any(bRef).(type) {
 	case HTTPBackendRef:
+		return b.BackendRef
+	case GRPCBackendRef:
 		return b.BackendRef
 	case BackendRef:
 		return b

--- a/pkg/consts/hybridgateway.go
+++ b/pkg/consts/hybridgateway.go
@@ -30,6 +30,10 @@ const (
 	// indicating which HTTPRoute is associated with the resource.
 	HybridRouteHTTPRouteAnnotation = "hybrid-routes"
 
+	// HybridRouteGRPCRouteAnnotation is used to annotate resources created for hybrid gateways,
+	// indicating which GRPCRoutes are associated with the resource.
+	HybridRouteGRPCRouteAnnotation = "hybrid-routes-GRPCRoute"
+
 	// HybridRouteTLSRouteAnnotation is used to annotate resources created for hybrid gateways,
 	// indicating which TLSRoutes are associated with the resource.
 	HybridRouteTLSRouteAnnotation = "hybrid-routes-TLSRoute"
@@ -42,6 +46,11 @@ const (
 	// used to annotate resources created for hybrid gateways, indicating which HTTPRoute
 	// is associated with the resource.
 	GatewayOperatorHybridRoutesHTTPRouteAnnotation = OperatorAnnotationPrefix + HybridRouteHTTPRouteAnnotation
+
+	// GatewayOperatorHybridRoutesGRPCRouteAnnotation is the fully qualified annotation key
+	// used to annotate resources created for hybrid gateways, indicating which GRPCRoute
+	// is associated with the resource.
+	GatewayOperatorHybridRoutesGRPCRouteAnnotation = OperatorAnnotationPrefix + HybridRouteGRPCRouteAnnotation
 
 	// GatewayOperatorHybridRoutesTLSRouteAnnotation is the fully qualified annotation key
 	// used to annotate resources created for hybrid gateways, indicating which TLSRoute


### PR DESCRIPTION
**What this PR does / why we need it**:

Part of #5120, this PR adds the GRPCRoute -> Kong object translation layer: builders, plugin/pluginbinding/kongroute construction, route status, service/target/upstream, and the grpcRouteConverter orchestrator.

**Which issue this PR fixes**

Part of #2265 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
