### PR TITLE
test(hybridgateway): UDPRoute e2e and conformance tests

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,13 @@
 
 ## Unreleased
 
+### Added
+
+- HybridGateway: Support UDPRoute for hybrid
+  [5160](https://github.com/Kong/kong-operator/pull/5160)
+  [5163](https://github.com/Kong/kong-operator/pull/5163)
+  [5164](https://github.com/Kong/kong-operator/pull/5164)
+
 ## [v2.3.0-rc.3]
 
 > Release date: 2026-08-06

--- a/controller/hybridgateway/route/status.go
+++ b/controller/hybridgateway/route/status.go
@@ -912,20 +912,6 @@ func backendRefResolvedCondition[T gwtypes.SupportedRoute, TPtr gwtypes.Supporte
 		return cond, nil
 	}
 
-	// Check if the referenced object exists.
-	service := &corev1.Service{}
-	err := cl.Get(ctx, client.ObjectKey{Namespace: bRefNamespace, Name: string(bRef.Name)}, service)
-	if err != nil {
-		if apierrors.IsNotFound(err) {
-			log.Debug(logger, "BackendRef not found", "namespace", bRefNamespace, "name", bRef.Name)
-			cond.Reason = string(gwtypes.RouteReasonBackendNotFound)
-			cond.Status = metav1.ConditionFalse
-			cond.Message = fmt.Sprintf("BackendRef %s/%s not found", bRefNamespace, bRef.Name)
-			return cond, nil
-		}
-		return nil, fmt.Errorf("failed to get BackendRef %s/%s: %w", bRefNamespace, bRef.Name, err)
-	}
-
 	// Check if the referenced object is permitted by the reference grant if in a different namespace.
 	if bRefNamespace != route.GetNamespace() {
 		// Use CheckReferenceGrant helper to check if the reference is permitted.
@@ -950,6 +936,21 @@ func backendRefResolvedCondition[T gwtypes.SupportedRoute, TPtr gwtypes.Supporte
 			return cond, nil
 		}
 	}
+
+	// Check if the referenced object exists.
+	service := &corev1.Service{}
+	err := cl.Get(ctx, client.ObjectKey{Namespace: bRefNamespace, Name: string(bRef.Name)}, service)
+	if err != nil {
+		if apierrors.IsNotFound(err) {
+			log.Debug(logger, "BackendRef not found", "namespace", bRefNamespace, "name", bRef.Name)
+			cond.Reason = string(gwtypes.RouteReasonBackendNotFound)
+			cond.Status = metav1.ConditionFalse
+			cond.Message = fmt.Sprintf("BackendRef %s/%s not found", bRefNamespace, bRef.Name)
+			return cond, nil
+		}
+		return nil, fmt.Errorf("failed to get BackendRef %s/%s: %w", bRefNamespace, bRef.Name, err)
+	}
+
 	return cond, nil
 }
 

--- a/test/conformance/conformance_test.go
+++ b/test/conformance/conformance_test.go
@@ -190,8 +190,8 @@ func conformanceProfiles(_ gatewayType) []suite.ConformanceProfileName {
 const conformanceCleanupTimeout = 90 * time.Second
 
 // waitForConformanceResourcesCleanup blocks until no HTTPRoute, TLSRoute,
-// TCPRoute or ReferenceGrant in any conformance namespace still has a deletion
-// timestamp,
+// TCPRoute, UDPRoute or ReferenceGrant in any conformance namespace still has
+// a deletion timestamp,
 // i.e. the previous test's resources have been fully finalized and removed.
 // These are per-test resources (the base manifests only contribute
 // Gateways/Services), and several tests reuse the same names (for example the
@@ -241,6 +241,17 @@ func waitForConformanceResourcesCleanup(ctx context.Context, cl client.Client, l
 		for i := range tcpRoutes.Items {
 			if r := &tcpRoutes.Items[i]; isConformanceNS(r.Namespace) && r.DeletionTimestamp != nil {
 				logf("waiting for TCPRoute %s/%s to finish terminating before next test", r.Namespace, r.Name)
+				return false, nil
+			}
+		}
+
+		var udpRoutes gatewayv1.UDPRouteList
+		if err := cl.List(ctx, &udpRoutes); err != nil {
+			return false, nil //nolint:nilerr
+		}
+		for i := range udpRoutes.Items {
+			if r := &udpRoutes.Items[i]; isConformanceNS(r.Namespace) && r.DeletionTimestamp != nil {
+				logf("waiting for UDPRoute %s/%s to finish terminating before next test", r.Namespace, r.Name)
 				return false, nil
 			}
 		}

--- a/test/conformance/skipped_tests_test.go
+++ b/test/conformance/skipped_tests_test.go
@@ -31,17 +31,6 @@ var skippedTestsForHybrid = []string{
 	tests.HTTPRouteRewritePath.ShortName,
 
 	tests.GRPCRouteWeight.ShortName,
-
-	// UDPRoute
-	tests.UDPRouteInvalidBackendRefNonexistent.ShortName,
-	tests.UDPRouteInvalidCrossNamespaceBackendRef.ShortName,
-	tests.UDPRouteMultipleRoutesAttachment.ShortName,
-	tests.UDPRouteNotAllowedByListeners.ShortName,
-	tests.UDPRouteParentRefAttachAllListeners.ShortName,
-	tests.UDPRouteParentRefPortAndSectionName.ShortName,
-	tests.UDPRouteReferenceGrant.ShortName,
-	tests.UDPRouteTest.ShortName,
-	tests.UDPRouteWeightedRouting.ShortName,
 }
 
 // skippedTestsForConfig returns the list of skipped tests for the given gateway type.

--- a/test/e2e/chainsaw/common/_step_templates/apply-assert-echoService.yaml
+++ b/test/e2e/chainsaw/common/_step_templates/apply-assert-echoService.yaml
@@ -28,7 +28,7 @@ spec:
                 targetPort: 1025
               - port: 1026
                 name: udp
-                protocol: TCP
+                protocol: UDP
                 targetPort: 1026
               - port: 1027
                 name: http

--- a/test/e2e/chainsaw/hybridgateway/basic-udproute/01-udpRoute-echo.yaml
+++ b/test/e2e/chainsaw/hybridgateway/basic-udproute/01-udpRoute-echo.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: UDPRoute
+metadata:
+  name: ($udp_route_name)
+  namespace: ($udp_route_namespace)
+  labels:
+    chainsaw/test: ($test_name)
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ($gateway_name)
+  rules:
+    - backendRefs:
+        - name: ($echo_deployment_name)
+          port: 1026

--- a/test/e2e/chainsaw/hybridgateway/basic-udproute/02-udpRoute-echo-assert.yaml
+++ b/test/e2e/chainsaw/hybridgateway/basic-udproute/02-udpRoute-echo-assert.yaml
@@ -1,0 +1,33 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: UDPRoute
+metadata:
+  name: ($udp_route_name)
+  namespace: ($udp_route_namespace)
+  labels:
+    chainsaw/test: ($test_name)
+status:
+  parents:
+    - parentRef:
+        name: ($gateway_name)
+        group: gateway.networking.k8s.io
+        kind: Gateway
+      controllerName: konghq.com/gateway-operator
+      (conditions[?type == 'Accepted']):
+        - status: "True"
+          reason: Accepted
+      (conditions[?type == 'ResolvedRefs']):
+        - status: "True"
+          reason: ResolvedRefs
+      (conditions[?type == 'KongRouteProgrammed']):
+        - status: "True"
+          reason: KongRouteProgrammed
+      (conditions[?type == 'KongServiceProgrammed']):
+        - status: "True"
+          reason: KongServiceProgrammed
+      (conditions[?type == 'KongUpstreamProgrammed']):
+        - status: "True"
+          reason: KongUpstreamProgrammed
+      (conditions[?type == 'KongTargetProgrammed']):
+        - status: "True"
+          reason: KongTargetProgrammed

--- a/test/e2e/chainsaw/hybridgateway/basic-udproute/03-assert-kong-resources.yaml
+++ b/test/e2e/chainsaw/hybridgateway/basic-udproute/03-assert-kong-resources.yaml
@@ -1,0 +1,111 @@
+---
+apiVersion: configuration.konghq.com/v1alpha1
+kind: KongRoute
+metadata:
+  namespace: ($namespace)
+  (labels."gateway-operator.konghq.com/managed-by" == 'UDPRoute'): true
+  (annotations."gateway-operator.konghq.com/hybrid-routes-UDPRoute" | contains(@, join('/', [($udp_route_namespace), ($udp_route_name)]))): true
+  (annotations."gateway-operator.konghq.com/hybrid-gateways" == join('/', [($gateway_namespace), ($gateway_name)])): true
+spec:
+  protocols:
+    - udp
+  destinations:
+    - port: (to_number($listener_udp_port))
+  (serviceRef.namespacedRef.name != null): true
+status:
+  (conditions[?type == 'Programmed']):
+    - status: 'True'
+      reason: Programmed
+  (conditions[?type == 'KongServiceRefValid']):
+    - status: 'True'
+      reason: Valid
+  (conditions[?type == 'APIAuthResolvedRef']):
+    - status: 'True'
+      reason: ResolvedRef
+  (conditions[?type == 'APIAuthValid']):
+    - status: 'True'
+      reason: Valid
+  (konnect.controlPlaneID != null): true
+  (konnect.id != null): true
+  (konnect.serviceID != null): true
+---
+apiVersion: configuration.konghq.com/v1alpha1
+kind: KongService
+metadata:
+  namespace: ($namespace)
+  (labels."gateway-operator.konghq.com/managed-by" == 'UDPRoute'): true
+  (annotations."gateway-operator.konghq.com/hybrid-routes-UDPRoute" | contains(@, join('/', [($udp_route_namespace), ($udp_route_name)]))): true
+  (annotations."gateway-operator.konghq.com/hybrid-gateways" == join('/', [($gateway_namespace), ($gateway_name)])): true
+spec:
+  protocol: udp
+  (host != null): true
+  controlPlaneRef:
+    type: konnectNamespacedRef
+status:
+  (conditions[?type == 'Programmed']):
+    - status: 'True'
+      reason: Programmed
+  (conditions[?type == 'ControlPlaneRefValid']):
+    - status: 'True'
+      reason: Valid
+  (conditions[?type == 'APIAuthResolvedRef']):
+    - status: 'True'
+      reason: ResolvedRef
+  (conditions[?type == 'APIAuthValid']):
+    - status: 'True'
+      reason: Valid
+  (konnect.controlPlaneID != null): true
+  (konnect.id != null): true
+---
+apiVersion: configuration.konghq.com/v1alpha1
+kind: KongUpstream
+metadata:
+  namespace: ($namespace)
+  (labels."gateway-operator.konghq.com/managed-by" == 'UDPRoute'): true
+  (annotations."gateway-operator.konghq.com/hybrid-routes-UDPRoute" | contains(@, join('/', [($udp_route_namespace), ($udp_route_name)]))): true
+  (annotations."gateway-operator.konghq.com/hybrid-gateways" == join('/', [($gateway_namespace), ($gateway_name)])): true
+status:
+  (conditions[?type == 'Programmed']):
+    - status: 'True'
+      reason: Programmed
+  (conditions[?type == 'ControlPlaneRefValid']):
+    - status: 'True'
+      reason: Valid
+  (conditions[?type == 'APIAuthResolvedRef']):
+    - status: 'True'
+      reason: ResolvedRef
+  (conditions[?type == 'APIAuthValid']):
+    - status: 'True'
+      reason: Valid
+  (konnect.controlPlaneID != null): true
+  (konnect.id != null): true
+---
+apiVersion: configuration.konghq.com/v1alpha1
+kind: KongTarget
+metadata:
+  namespace: ($namespace)
+  (labels."gateway-operator.konghq.com/managed-by" == 'UDPRoute'): true
+  (annotations."gateway-operator.konghq.com/hybrid-routes-UDPRoute" | contains(@, join('/', [($udp_route_namespace), ($udp_route_name)]))): true
+  (annotations."gateway-operator.konghq.com/hybrid-gateways" == join('/', [($gateway_namespace), ($gateway_name)])): true
+spec:
+  (target != null): true
+  (upstreamRef.name != null): true
+status:
+  (conditions[?type == 'Programmed']):
+    - status: 'True'
+      reason: Programmed
+  (conditions[?type == 'KongUpstreamRefValid']):
+    - status: 'True'
+      reason: Valid
+  (conditions[?type == 'ControlPlaneRefValid']):
+    - status: 'True'
+      reason: Valid
+  (conditions[?type == 'APIAuthResolvedRef']):
+    - status: 'True'
+      reason: ResolvedRef
+  (conditions[?type == 'APIAuthValid']):
+    - status: 'True'
+      reason: Valid
+  (konnect.controlPlaneID != null): true
+  (konnect.id != null): true
+  (konnect.upstreamID != null): true

--- a/test/e2e/chainsaw/hybridgateway/basic-udproute/04-udpRoute-echo-second.yaml
+++ b/test/e2e/chainsaw/hybridgateway/basic-udproute/04-udpRoute-echo-second.yaml
@@ -1,0 +1,17 @@
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: UDPRoute
+metadata:
+  name: ($second_udp_route_name)
+  namespace: ($udp_route_namespace)
+  labels:
+    chainsaw/test: ($test_name)
+spec:
+  parentRefs:
+    - group: gateway.networking.k8s.io
+      kind: Gateway
+      name: ($gateway_name)
+  rules:
+    - backendRefs:
+        - name: ($second_echo_deployment_name)
+          port: 1026

--- a/test/e2e/chainsaw/hybridgateway/basic-udproute/05-assert-udproutes-conflict.yaml
+++ b/test/e2e/chainsaw/hybridgateway/basic-udproute/05-assert-udproutes-conflict.yaml
@@ -1,0 +1,70 @@
+---
+# GEP-2645: the listener counts both same-listener UDPRoutes regardless of
+# arbitration outcome.
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ($gateway_name)
+  namespace: ($gateway_namespace)
+status:
+  (listeners[?name == 'udp']):
+    - attachedRoutes: 2
+---
+# Winner UDPRoute (older creationTimestamp) keeps its Kong resources programmed.
+apiVersion: gateway.networking.k8s.io/v1
+kind: UDPRoute
+metadata:
+  name: ($udp_route_name)
+  namespace: ($udp_route_namespace)
+status:
+  parents:
+    - parentRef:
+        name: ($gateway_name)
+        group: gateway.networking.k8s.io
+        kind: Gateway
+      controllerName: konghq.com/gateway-operator
+      (conditions[?type == 'Accepted']):
+        - status: "True"
+          reason: Accepted
+      (conditions[?type == 'ResolvedRefs']):
+        - status: "True"
+          reason: ResolvedRefs
+      (conditions[?type == 'KongRouteProgrammed']):
+        - status: "True"
+          reason: KongRouteProgrammed
+      (conditions[?type == 'KongServiceProgrammed']):
+        - status: "True"
+          reason: KongServiceProgrammed
+      (conditions[?type == 'KongUpstreamProgrammed']):
+        - status: "True"
+          reason: KongUpstreamProgrammed
+      (conditions[?type == 'KongTargetProgrammed']):
+        - status: "True"
+          reason: KongTargetProgrammed
+---
+# Loser UDPRoute (newer creationTimestamp on the same listener) is still
+# Accepted/ResolvedRefs=True per Gateway API status semantics, but loses
+# GEP-2645 arbitration: no Kong resources are created for it, so it carries
+# no Kong*Programmed conditions at all.
+apiVersion: gateway.networking.k8s.io/v1
+kind: UDPRoute
+metadata:
+  name: ($second_udp_route_name)
+  namespace: ($udp_route_namespace)
+status:
+  parents:
+    - parentRef:
+        name: ($gateway_name)
+        group: gateway.networking.k8s.io
+        kind: Gateway
+      controllerName: konghq.com/gateway-operator
+      (conditions[?type == 'Accepted']):
+        - status: "True"
+          reason: Accepted
+      (conditions[?type == 'ResolvedRefs']):
+        - status: "True"
+          reason: ResolvedRefs
+      (length(conditions[?type == 'KongRouteProgrammed'])): 0
+      (length(conditions[?type == 'KongServiceProgrammed'])): 0
+      (length(conditions[?type == 'KongUpstreamProgrammed'])): 0
+      (length(conditions[?type == 'KongTargetProgrammed'])): 0

--- a/test/e2e/chainsaw/hybridgateway/basic-udproute/06-assert-udproute-promoted.yaml
+++ b/test/e2e/chainsaw/hybridgateway/basic-udproute/06-assert-udproute-promoted.yaml
@@ -1,0 +1,43 @@
+---
+# With the winner deleted, only the second UDPRoute remains attached.
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ($gateway_name)
+  namespace: ($gateway_namespace)
+status:
+  (listeners[?name == 'udp']):
+    - attachedRoutes: 1
+---
+# The former loser is promoted: it now wins GEP-2645 arbitration and gets its
+# own Kong resources created and programmed.
+apiVersion: gateway.networking.k8s.io/v1
+kind: UDPRoute
+metadata:
+  name: ($second_udp_route_name)
+  namespace: ($udp_route_namespace)
+status:
+  parents:
+    - parentRef:
+        name: ($gateway_name)
+        group: gateway.networking.k8s.io
+        kind: Gateway
+      controllerName: konghq.com/gateway-operator
+      (conditions[?type == 'Accepted']):
+        - status: "True"
+          reason: Accepted
+      (conditions[?type == 'ResolvedRefs']):
+        - status: "True"
+          reason: ResolvedRefs
+      (conditions[?type == 'KongRouteProgrammed']):
+        - status: "True"
+          reason: KongRouteProgrammed
+      (conditions[?type == 'KongServiceProgrammed']):
+        - status: "True"
+          reason: KongServiceProgrammed
+      (conditions[?type == 'KongUpstreamProgrammed']):
+        - status: "True"
+          reason: KongUpstreamProgrammed
+      (conditions[?type == 'KongTargetProgrammed']):
+        - status: "True"
+          reason: KongTargetProgrammed

--- a/test/e2e/chainsaw/hybridgateway/basic-udproute/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/basic-udproute/chainsaw-test.yaml
@@ -1,0 +1,267 @@
+# Basic UDPRoute test scenario.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: basic-udproute
+spec:
+  description: |
+    This test validates that the hybrid gateway controller translates a basic
+    UDPRoute with a single Service backend into Kong resources and routes UDP
+    traffic through the generated Gateway data plane.
+
+  bindings:
+    - name: test_name
+      value: ($namespace)
+    - name: konnect_token
+      value: (env('KONNECT_TOKEN'))
+    - name: konnect_api_auth_namespace
+      value: ($namespace)
+    - name: listener_udp_port
+      value: 8899
+    - name: konnect_url
+      value: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
+    - name: auth_secret_name
+      value: (join('-', [($test_name), 'konnect-auth-secret']))
+    - name: auth_secret_namespace
+      value: ($namespace)
+    - name: konnect_auth_name
+      value: (join('-', [($test_name), 'konnect-api-auth']))
+    - name: konnect_auth_namespace
+      value: ($namespace)
+    - name: gateway_image
+      value: (env('GATEWAY_IMAGE'))
+    - name: gateway_name
+      value: (join('-', [($test_name), 'gateway']))
+    - name: gateway_namespace
+      value: ($namespace)
+    - name: udp_route_name
+      value: (join('-', [($test_name), 'echo-udp-route']))
+    - name: udp_route_namespace
+      value: ($namespace)
+    - name: echo_deployment_name
+      value: (join('-', [($test_name), 'echo']))
+    - name: echo_deployment_namespace
+      value: ($namespace)
+    - name: echo_deployment_replicas
+      value: 1
+    - name: second_udp_route_name
+      value: (join('-', [($test_name), 'echo-udp-route-second']))
+    - name: second_echo_deployment_name
+      value: (join('-', [($test_name), 'newer-echo']))
+
+  steps:
+    - name: Create-auth-secret
+      description: Create Secret with Konnect token for KonnectAPIAuthConfiguration.
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAuthSecret.yaml
+
+    - name: Create-konnect-api-auth
+      description: Create KonnectAPIAuthConfiguration for the test.
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration-secretref.yaml
+
+    - name: Create-gateway-configuration
+      description: Create GatewayConfiguration for the test.
+      use:
+        template: ../../common/_step_templates/apply-assert-gatewayConfiguration.yaml
+
+    - name: Create-gateway-class
+      description: Create GatewayClass for the test.
+      use:
+        template: ../../common/_step_templates/apply-assert-gatewayClass.yaml
+
+    - name: Create-gateway
+      description: Create Gateway with a UDP listener.
+      try:
+        - apply:
+            resource:
+              apiVersion: gateway.networking.k8s.io/v1
+              kind: Gateway
+              metadata:
+                name: ($gateway_name)
+                namespace: ($namespace)
+              spec:
+                gatewayClassName: (join('-', [($test_name), 'gateway-class']))
+                listeners:
+                  - name: udp
+                    protocol: UDP
+                    port: (to_number($listener_udp_port))
+        - assert:
+            resource:
+              apiVersion: gateway.networking.k8s.io/v1
+              kind: Gateway
+              metadata:
+                name: ($gateway_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'Accepted']):
+                  - status: 'True'
+                    reason: Accepted
+                (conditions[?type == 'Programmed']):
+                  - status: 'True'
+                    reason: Programmed
+                (conditions[?type == 'DataPlaneReady']):
+                  - status: 'True'
+                    reason: Ready
+                (conditions[?type == 'KonnectGatewayControlPlaneProgrammed']):
+                  - status: 'True'
+                    reason: Programmed
+                (conditions[?type == 'KonnectExtensionReady']):
+                  - status: 'True'
+                    reason: Ready
+                (conditions[?type == 'GatewayService']):
+                  - status: 'True'
+                    reason: Ready
+
+    - name: Assert-konnect-gateway-control-plane
+      description: Assert that the KonnectGatewayControlPlane resource is created and synchronized.
+      use:
+        template: ../../common/_step_templates/assert-konnectGatewayControlPlane.yaml
+
+    - name: Create-echo-service
+      description: Create and assert an echo service to route UDP traffic to.
+      use:
+        template: ../../common/_step_templates/apply-assert-echoService.yaml
+
+    - name: Create-udproute-echo
+      description: Create UDPRoute to route traffic to the echo service.
+      try:
+        - apply:
+            file: 01-udpRoute-echo.yaml
+        - assert:
+            file: 02-udpRoute-echo-assert.yaml
+
+    - name: Assert-kong-resources
+      description: Assert that UDPRoute-generated Kong resources are programmed.
+      try:
+        - assert:
+            file: 03-assert-kong-resources.yaml
+
+    - name: Verify-UDP-traffic-from-host
+      description: Verify that UDP traffic can be routed through the gateway to the echo service from the host.
+      try:
+        - script:
+            env:
+              - name: GATEWAY_NAME
+                value: ($gateway_name)
+              - name: GATEWAY_NAMESPACE
+                value: ($gateway_namespace)
+            content: |
+              bash ../../common/scripts/proxy_ip_address.sh
+            outputs:
+              - name: proxy_ip
+                value: (json_parse($stdout).proxy_ip_address)
+        - script:
+            env:
+              - name: PROXY_IP
+                value: ($proxy_ip)
+              - name: PROXY_PORT
+                value: (to_string($listener_udp_port))
+              - name: EXPECTED_RESPONSE
+                value: ($echo_deployment_name)
+            content: |
+              bash ../../common/scripts/host_connectivity_test_udp.sh
+
+    - name: Create-echo-service-second
+      description: Create and assert a second echo service to back the losing UDPRoute.
+      use:
+        template: ../../common/_step_templates/apply-assert-echoService.yaml
+        with:
+          bindings:
+            - name: echo_deployment_name
+              value: ($second_echo_deployment_name)
+
+    - name: Create-udproute-echo-second
+      description: |
+        Attach a second UDPRoute to the same listener as the first. Per GEP-2645
+        the older route (created first) wins arbitration and is the only one
+        pushed to the dataplane; the newer route stays Accepted/ResolvedRefs=True
+        but gets no Kong resources or Programmed conditions.
+      try:
+        - apply:
+            file: 04-udpRoute-echo-second.yaml
+        - assert:
+            file: 05-assert-udproutes-conflict.yaml
+
+    - name: Verify-UDP-traffic-still-reaches-first
+      description: |
+        With both same-listener UDPRoutes attached, UDP traffic must still
+        reach the first (winning) echo backend, proving the second (losing)
+        route is not receiving traffic.
+      try:
+        - script:
+            env:
+              - name: GATEWAY_NAME
+                value: ($gateway_name)
+              - name: GATEWAY_NAMESPACE
+                value: ($gateway_namespace)
+            content: |
+              bash ../../common/scripts/proxy_ip_address.sh
+            outputs:
+              - name: proxy_ip
+                value: (json_parse($stdout).proxy_ip_address)
+        - script:
+            env:
+              - name: PROXY_IP
+                value: ($proxy_ip)
+              - name: PROXY_PORT
+                value: (to_string($listener_udp_port))
+              - name: EXPECTED_RESPONSE
+                value: ($echo_deployment_name)
+            content: |
+              bash ../../common/scripts/host_connectivity_test_udp.sh
+
+    - name: Delete-winning-udproute
+      description: |
+        Delete the first (winning) UDPRoute. The second (losing) UDPRoute
+        is now the sole route attached to the listener and gets promoted:
+        its Kong resources are created and its Programmed conditions turn True.
+      try:
+        - delete:
+            ref:
+              apiVersion: gateway.networking.k8s.io/v1
+              kind: UDPRoute
+              namespace: ($udp_route_namespace)
+              name: ($udp_route_name)
+        - assert:
+            file: 06-assert-udproute-promoted.yaml
+
+    - name: Verify-UDP-traffic-reaches-promoted
+      description: |
+        After the winner is deleted, UDP traffic must now reach the second
+        (promoted) echo backend.
+      try:
+        - script:
+            env:
+              - name: GATEWAY_NAME
+                value: ($gateway_name)
+              - name: GATEWAY_NAMESPACE
+                value: ($gateway_namespace)
+            content: |
+              bash ../../common/scripts/proxy_ip_address.sh
+            outputs:
+              - name: proxy_ip
+                value: (json_parse($stdout).proxy_ip_address)
+        - script:
+            env:
+              - name: PROXY_IP
+                value: ($proxy_ip)
+              - name: PROXY_PORT
+                value: (to_string($listener_udp_port))
+              - name: EXPECTED_RESPONSE
+                value: ($second_echo_deployment_name)
+            content: |
+              bash ../../common/scripts/host_connectivity_test_udp.sh
+
+  catch:
+    - description: Capture debug snapshot
+      script:
+        env:
+          - name: TEST_NAME
+            value: hybridgateway-basic-udproute
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: OPERATOR_NAMESPACE
+            value: kong-system
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh


### PR DESCRIPTION
**What this PR does / why we need it**:

The third part of UDPRoute hybrid implementation.
This PR added e2e chainsaw tests and enabled all conformance tests towards UDPRoutes.

Also changed `backendRefResolvedCondition` in `controller/hybridgateway/route/status.go` to pass conformance tests, which is checking reference permission before existence.

**Which issue this PR fixes**

Fixes #2064 #4337

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
