### PR TITLE
ci: fix releases not being marked as latest correctly

### DIFF
--- a/.github/ISSUE_TEMPLATE/---release.md
+++ b/.github/ISSUE_TEMPLATE/---release.md
@@ -29,7 +29,7 @@ If the troubleshooting section does not contain the answer to the problem you en
 - [ ] Wait for the workflow to complete.
 - [ ] The CI should create a PR in the [Kong Operator][ko-prs] repo that bumps KO version in `VERSION` file and manifests. Merge it.
 - [ ] After the PR is merged, [release-bot][release-bot-workflow] workflow will be triggered. It will create a new GH release, as well as a release branch (if not patch or prerelease):
-  - [ ] Check the [releases][releases] page. The release has to be marked manually as `latest` if this is the case.
+  - [ ] Check the [releases][releases] page and confirm the `latest` badge is on the expected release (this now follows the `latest` workflow input automatically, no manual step needed).
   - [ ] If the release is not a patch or prerelease, check the `release/N.M.x` release branch exists.
 - [ ] Update the official documentation at [https://github.com/Kong/developer.konghq.com/][docs_repo]
   - [ ] **Changelog, CLI configuration options, and CRD reference**: Automatically synced by the release workflow (when `latest=true`). A docs PR will be created in the [docs repo][docs_repo] and a comment will be posted in this issue. Review and merge the PR when ready.

--- a/.github/workflows/release-bot.yaml
+++ b/.github/workflows/release-bot.yaml
@@ -121,6 +121,12 @@ jobs:
           tag: v${{ needs.semver.outputs.version }}
           commit: ${{ github.sha }}
           prerelease: ${{ needs.look_for_release.outputs.release_type == 'prerelease' }}
+          # Without this, ncipollo/release-action defaults to makeLatest: legacy, which
+          # makes GitHub mark whichever release was *created* most recently as "latest" -
+          # regardless of version order. This breaks patch releases from older release
+          # branches (e.g. 2.0.11 after 2.2.3). Only mark latest when the release commit
+          # was explicitly tagged with [latest].
+          makeLatest: ${{ needs.look_for_release.outputs.release_latest == 'true' && needs.look_for_release.outputs.release_type == 'release' }}
 
   create-release-branch:
     permissions:


### PR DESCRIPTION
**What this PR does / why we need it**:

slack thread: https://kongstrong.slack.com/archives/C011RQPHDC7/p1786003647898989?thread_ts=1786003189.994089&cid=C011RQPHDC7

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
