### PR TITLE
ci: add Kong license to release tests

### DIFF
--- a/.github/workflows/__release-workflow.yaml
+++ b/.github/workflows/__release-workflow.yaml
@@ -190,7 +190,7 @@ jobs:
       - name: integration tests
         run: make test.integration-ko
         env:
-          KONG_LICENSE_DATA: ${{ steps.get-license.outputs.license || '' }} # The license is optional for OSS tests.
+          KONG_LICENSE_DATA: ${{ steps.get-license.outputs.license || '' }}
           KONG_TEST_KONNECT_ACCESS_TOKEN: ${{ secrets.konnect-pat }}
           KONG_TEST_KONNECT_SERVER_URL: us.api.konghq.tech
 
@@ -214,6 +214,7 @@ jobs:
       test-image: ${{ needs.build-push-images.outputs.full_tag }}
     secrets:
       konnect-pat: ${{ secrets.konnect-pat }}
+      op-service-account-token: ${{ secrets.op-service-account-token }}
 
   create-release-pr:
     runs-on: ubuntu-latest

--- a/.github/workflows/falco-analyzed-e2e.yaml
+++ b/.github/workflows/falco-analyzed-e2e.yaml
@@ -7,7 +7,10 @@ on:
       konnect-pat:
         description: "Konnect PAT used by tests that hit Konnect"
         required: false
-    
+      op-service-account-token:
+        description: "1Password service account token used to fetch the Kong Enterprise License"
+        required: false
+
     inputs:
       test-image:
         description: "image used for e2e tests, if not set, the image built in the workflow will be used"
@@ -67,12 +70,19 @@ jobs:
       with:
         install: false
 
+    - name: Get Kong Enterprise License
+      id: license
+      uses: Kong/kong-license@ddccb487a0b319cef85f348b16a1ad2b6d9c1df7 # master @ 20260529
+      with:
+        op-token: ${{ secrets.op-service-account-token }}
+
     - name: run e2e tests
       run: make test.e2e
       env:
         KONG_TEST_KONG_OPERATOR_IMAGE_LOAD: ${{ env.TEST_IMAGE }}
         GOTESTSUM_JUNITFILE: "e2e-tests.xml"
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
         KONG_TEST_KONNECT_ACCESS_TOKEN: ${{ secrets.konnect-pat }}
         KONG_TEST_KONNECT_SERVER_URL: us.api.konghq.tech
 

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -39,6 +39,7 @@ jobs:
       gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }}
       gh-pat: ${{ secrets.PAT_GITHUB }}
       konnect-pat: ${{ secrets.KONG_TEST_KONNECT_ACCESS_TOKEN }}
+      op-service-account-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
     with:
       dockerhub-push-username: ${{ vars.DOCKERHUB_PUSH_USERNAME  }}
       image-name: ${{ vars.DOCKERHUB_IMAGE_NAME_KO }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Add required kong license to tests in release job.
