### PR TITLE
test(e2e): fix flaky revoked-secret rejection check in openid-connect

### DIFF
--- a/test/e2e/chainsaw/aigateway/agent-types/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/aigateway/agent-types/chainsaw-test.yaml
@@ -76,6 +76,8 @@ spec:
       value: ''
     - name: oidc_scope
       value: ''
+    - name: expected_success
+      value: 'true'
   steps:
     - name: Create-auth-secret
       use:

--- a/test/e2e/chainsaw/aigateway/consumers-and-credentials-keyauth/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/aigateway/consumers-and-credentials-keyauth/chainsaw-test.yaml
@@ -127,6 +127,8 @@ spec:
       value: ''
     - name: oidc_scope
       value: ''
+    - name: expected_success
+      value: 'true'
   steps:
     - name: 1-Create-auth-secret
       use:

--- a/test/e2e/chainsaw/aigateway/consumers-and-credentials-openid-connect/00-oidc-mock.yaml
+++ b/test/e2e/chainsaw/aigateway/consumers-and-credentials-openid-connect/00-oidc-mock.yaml
@@ -12,6 +12,15 @@ metadata:
   labels: { app: oidc-mock }
 spec:
   replicas: 1
+  # Recreate (not the default RollingUpdate): with RollingUpdate, the old and new pods
+  # briefly co-exist and both match the Service's label selector, so secret-rotation
+  # steps below (01/02-oidc-mock-secret-*.yaml) can have the revoked-secret pod still
+  # serving requests for a moment even after the Deployment reports ready/updated,
+  # flaking the "reject request with revoked secret" assertion. Recreate guarantees the
+  # old pod is fully gone before the new one starts, so there's never a window where a
+  # revoked secret is still accepted.
+  strategy:
+    type: Recreate
   selector:
     matchLabels: { app: oidc-mock }
   template:

--- a/test/e2e/chainsaw/aigateway/consumers-and-credentials-openid-connect/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/aigateway/consumers-and-credentials-openid-connect/chainsaw-test.yaml
@@ -124,6 +124,8 @@ spec:
       value: ''
     - name: oidc_client_secret
       value: ''
+    - name: expected_success
+      value: 'true'
   steps:
     - name: 1-Create-auth-secret
       use:
@@ -444,49 +446,17 @@ spec:
                 readyReplicas: 1
                 updatedReplicas: 1
     - name: 27-Reject-request-with-revoked-first-secret-from-cluster
-      try:
-        - script:
-            env:
-              - name: NAMESPACE
-                value: ($namespace)
-              - name: DP_SVC
-                value: (join('', [($aigw_dp_name), '-ingress']))
-              - name: METHOD
-                value: GET
-              - name: ROUTE_PATH
-                value: ($http_agent_route_path)
-              - name: REQUEST_HEADERS
-                value: ''
-              - name: REQUEST_BODY
-                value: ''
-              - name: CONTENT_TYPE
-                value: application/json
-              - name: EXPECTED_STATUS
-                value: ''
-              - name: EXPECTED_STATUS_NOT
-                value: ''
-              - name: EXPECTED_BODY
-                value: ''
-              - name: UNEXPECTED_BODY
-                value: ''
-              - name: EXPECTED_JSONRPC
-                value: ''
-              - name: EXPECTED_JSON_ID
-                value: ''
-              - name: EXPECTED_JSON_RESULT_TEXT
-                value: ''
-              - name: OIDC_TOKEN_URL
-                value: ($oidc_token_url)
-              - name: OIDC_CLIENT_ID
-                value: ($oidc_client_id)
-              - name: OIDC_CLIENT_SECRET
-                value: ($oidc_client_secret_value)
-              - name: OIDC_SCOPE
-                value: ($oidc_scope)
-            content: |
-              bash ../../common/scripts/aigw_agent_request_from_cluster.sh
-            check:
-              (json_parse($stdout).success == `false`): true
+      bindings:
+        - name: method
+          value: GET
+        - name: route_path
+          value: ($http_agent_route_path)
+        - name: oidc_client_secret
+          value: ($oidc_client_secret_value)
+        - name: expected_success
+          value: 'false'
+      use:
+        template: ../../common/_step_templates/verify-aigw-agent-request-from-cluster.yaml
     - name: 28-Restore-first-client-secret
       try:
         - patch:

--- a/test/e2e/chainsaw/aigateway/dataplane-scaling/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/aigateway/dataplane-scaling/chainsaw-test.yaml
@@ -72,6 +72,8 @@ spec:
       value: ''
     - name: oidc_scope
       value: ''
+    - name: expected_success
+      value: 'true'
   steps:
     - name: 1-Create-auth-secret
       use:

--- a/test/e2e/chainsaw/aigateway/identity-provider-keyauth/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/aigateway/identity-provider-keyauth/chainsaw-test.yaml
@@ -90,6 +90,8 @@ spec:
       value: ''
     - name: oidc_scope
       value: ''
+    - name: expected_success
+      value: 'true'
   steps:
     - name: 1-Create-auth-secret
       use:

--- a/test/e2e/chainsaw/aigateway/identity-provider-openid-connect/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/aigateway/identity-provider-openid-connect/chainsaw-test.yaml
@@ -100,6 +100,8 @@ spec:
       value: ''
     - name: oidc_client_secret
       value: ''
+    - name: expected_success
+      value: 'true'
   steps:
     - name: 1-Create-auth-secret
       use:
@@ -280,54 +282,18 @@ spec:
                 replicas: 1
                 readyReplicas: 1
                 updatedReplicas: 1
-    # A standard verify-aigw-agent-request-from-cluster.yaml step can't be used here:
-    # the revoked secret makes the token fetch itself fail (invalid_client), so the
-    # script never gets to make the HTTP request and reports success: false directly,
-    # rather than a real HTTP status to compare against expected_status.
     - name: 16-Reject-request-after-secret-revoked-from-cluster
-      try:
-        - script:
-            env:
-              - name: NAMESPACE
-                value: ($namespace)
-              - name: DP_SVC
-                value: (join('', [($aigw_dp_name), '-ingress']))
-              - name: METHOD
-                value: GET
-              - name: ROUTE_PATH
-                value: ($http_agent_route_path)
-              - name: REQUEST_HEADERS
-                value: ''
-              - name: REQUEST_BODY
-                value: ''
-              - name: CONTENT_TYPE
-                value: application/json
-              - name: EXPECTED_STATUS
-                value: ''
-              - name: EXPECTED_STATUS_NOT
-                value: ''
-              - name: EXPECTED_BODY
-                value: ''
-              - name: UNEXPECTED_BODY
-                value: ''
-              - name: EXPECTED_JSONRPC
-                value: ''
-              - name: EXPECTED_JSON_ID
-                value: ''
-              - name: EXPECTED_JSON_RESULT_TEXT
-                value: ''
-              - name: OIDC_TOKEN_URL
-                value: ($oidc_token_url)
-              - name: OIDC_CLIENT_ID
-                value: ($oidc_client_id)
-              - name: OIDC_CLIENT_SECRET
-                value: ($oidc_client_secret_value)
-              - name: OIDC_SCOPE
-                value: ($oidc_scope)
-            content: |
-              bash ../../common/scripts/aigw_agent_request_from_cluster.sh
-            check:
-              (json_parse($stdout).success == `false`): true
+      bindings:
+        - name: method
+          value: GET
+        - name: route_path
+          value: ($http_agent_route_path)
+        - name: oidc_client_secret
+          value: ($oidc_client_secret_value)
+        - name: expected_success
+          value: 'false'
+      use:
+        template: ../../common/_step_templates/verify-aigw-agent-request-from-cluster.yaml
   catch:
     - description: Capture debug snapshot on test failure.
       script:

--- a/test/e2e/chainsaw/common/_step_templates/verify-aigw-agent-request-from-cluster.yaml
+++ b/test/e2e/chainsaw/common/_step_templates/verify-aigw-agent-request-from-cluster.yaml
@@ -23,6 +23,10 @@
 #   - oidc_client_id: client_id for the client_credentials grant, or ''.
 #   - oidc_client_secret: client_secret for the client_credentials grant, or ''.
 #   - oidc_scope: Optional scope parameter for the client_credentials grant, or ''.
+#   - expected_success: (optional) 'true' (default) if the request/credential is
+#     expected to eventually work, 'false' if it's expected to be (or become, e.g.
+#     after revoking a credential) permanently rejected. See aigw_agent_request.sh
+#     for how this flips its retry-until-match loop.
 apiVersion: chainsaw.kyverno.io/v1alpha1
 kind: StepTemplate
 metadata:
@@ -67,6 +71,8 @@ spec:
             value: ($oidc_client_secret)
           - name: OIDC_SCOPE
             value: ($oidc_scope)
+          - name: EXPECTED_SUCCESS
+            value: ($expected_success)
         content: |
           bash ../../common/scripts/aigw_agent_request_from_cluster.sh
         check:

--- a/test/e2e/chainsaw/common/scripts/aigw_agent_request.sh
+++ b/test/e2e/chainsaw/common/scripts/aigw_agent_request.sh
@@ -37,9 +37,26 @@
 #                     wherever this script runs) before issuing the request, and adds
 #                     it as an "Authorization: Bearer <token>" header (in addition to
 #                     any REQUEST_HEADERS). Requires OIDC_CLIENT_ID and OIDC_CLIENT_SECRET.
+#                     Re-fetched on every retry attempt (not just once), since a
+#                     credential can flip from valid to rejected (or vice versa)
+#                     between attempts (e.g. right after revoking a client secret).
 #   OIDC_CLIENT_ID    client_id for the client_credentials grant.
 #   OIDC_CLIENT_SECRET  client_secret for the client_credentials grant.
 #   OIDC_SCOPE        Optional scope parameter for the client_credentials grant.
+#   EXPECTED_SUCCESS  'true' (default) if the request/credential is expected to
+#                     eventually succeed, 'false' if it's expected to be (or
+#                     become) rejected. When 'false', the retry loop below inverts:
+#                     it keeps retrying while the token mint/request still succeeds,
+#                     and only reports overall success once a rejection is observed
+#                     (a single stale success, e.g. right after a revoked-secret
+#                     Deployment rollout, isn't enough to conclude the credential
+#                     still works).
+#   REJECT_CONFIRMATIONS  Only used when EXPECTED_SUCCESS='false'. Number of
+#                     *consecutive* rejections required before concluding the
+#                     credential/request is genuinely rejected. Default: 3.
+#                     Symmetric with the stale-success protection above: a lone
+#                     transient blip (e.g. a connection failure mid-rollout, which
+#                     also counts as a non-match) can't prematurely pass the check.
 set -o errexit
 set -o nounset
 set -o pipefail
@@ -53,7 +70,7 @@ EXPECTED_JSONRPC="${EXPECTED_JSONRPC:-}"
 EXPECTED_JSON_ID="${EXPECTED_JSON_ID:-}"
 EXPECTED_JSON_RESULT_TEXT="${EXPECTED_JSON_RESULT_TEXT:-}"
 REQUEST_BODY="${REQUEST_BODY:-}"
-REQUEST_HEADERS="${REQUEST_HEADERS:-}"
+BASE_REQUEST_HEADERS="${REQUEST_HEADERS:-}"
 CONTENT_TYPE="${CONTENT_TYPE:-application/json}"
 EXPECTED_STATUS="${EXPECTED_STATUS:-200}"
 EXPECTED_STATUS_NOT="${EXPECTED_STATUS_NOT:-}"
@@ -64,10 +81,13 @@ OIDC_TOKEN_URL="${OIDC_TOKEN_URL:-}"
 OIDC_CLIENT_ID="${OIDC_CLIENT_ID:-}"
 OIDC_CLIENT_SECRET="${OIDC_CLIENT_SECRET:-}"
 OIDC_SCOPE="${OIDC_SCOPE:-}"
+EXPECTED_SUCCESS="${EXPECTED_SUCCESS:-true}"
+REJECT_CONFIRMATIONS="${REJECT_CONFIRMATIONS:-3}"
 
 URL="https://${ADDRESS}:${PORT}${ROUTE_PATH}"
 BODY_FILE=$(mktemp /tmp/aigw_agent_body.XXXXXX)
-cleanup() { rm -f "${BODY_FILE}"; }
+TOKEN_RESPONSE_FILE=$(mktemp /tmp/aigw_agent_token.XXXXXX)
+cleanup() { rm -f "${BODY_FILE}" "${TOKEN_RESPONSE_FILE}"; }
 trap cleanup EXIT
 # Set before print_result() is usable (curl_command is only known once build_curl_cmd runs).
 CURL_CMD=""
@@ -120,6 +140,7 @@ print_result() {
   "http_status": "${code:-000}",
   "expected_status": "${EXPECTED_STATUS}",
   "expected_status_not": "${EXPECTED_STATUS_NOT}",
+  "expected_success": "${EXPECTED_SUCCESS}",
   "method": "${METHOD}",
   "url": "${URL}",
   "retry_attempt": ${attempt},
@@ -130,57 +151,59 @@ print_result() {
 EOF
 }
 
-if [ -n "${OIDC_TOKEN_URL}" ]; then
-  TOKEN=""
-  # A few retries (distinct from the main request retry loop below) absorb
-  # transient connection blips (e.g. right after an OIDC provider rollout)
-  # so a real invalid_client rejection isn't masked by one. `|| true`: under
-  # `set -e`, a failing curl would otherwise abort the script with no output.
+# Fetches a fresh OIDC access token via client_credentials. Echoes the token
+# (empty on failure) and leaves the raw response in TOKEN_RESPONSE_FILE for
+# error reporting (a plain file, not a variable, since this function runs in
+# a subshell via command substitution and couldn't otherwise propagate a
+# variable back to the caller). A few sub-attempts (distinct from the main
+# request retry loop below) absorb transient connection blips (e.g. right
+# after an OIDC provider rollout) so a real invalid_client rejection isn't
+# masked by one. `|| true`: under `set -e`, a failing curl would otherwise
+# abort the script with no output.
+fetch_oidc_token() {
+  local token=""
+  local response=""
   for TOKEN_ATTEMPT in 1 2 3 4 5; do
-    TOKEN_RESPONSE="$(curl -sk -m 30 \
+    curl -sk -m 30 \
       --data-urlencode "grant_type=client_credentials" \
       --data-urlencode "client_id=${OIDC_CLIENT_ID}" \
       --data-urlencode "client_secret=${OIDC_CLIENT_SECRET}" \
       ${OIDC_SCOPE:+--data-urlencode "scope=${OIDC_SCOPE}"} \
-      "${OIDC_TOKEN_URL}" || true)"
-    # `|| true`: json_field's internal grep returns non-zero when
-    # TOKEN_RESPONSE has no access_token field (e.g. empty, or an error
+      "${OIDC_TOKEN_URL}" > "${TOKEN_RESPONSE_FILE}" 2>/dev/null || true
+    response="$(cat "${TOKEN_RESPONSE_FILE}" 2>/dev/null || echo '')"
+    # `|| true`: json_field's internal grep returns non-zero when the
+    # response has no access_token field (e.g. empty, or an error
     # response). Since this is a standalone `var="$(...)"` assignment, that
     # non-zero status would otherwise trip `errexit` right here, silently
     # killing the script with no output before the invalid_client check
     # below ever runs.
-    TOKEN="$(json_field "${TOKEN_RESPONSE}" access_token || true)"
-    [ -n "${TOKEN}" ] && break
+    token="$(json_field "${response}" access_token || true)"
+    [ -n "${token}" ] && break
     # invalid_client means the credentials were genuinely rejected: no point retrying.
-    printf '%s' "${TOKEN_RESPONSE}" | grep -q '"error"[[:space:]]*:[[:space:]]*"invalid_client"' && break
+    printf '%s' "${response}" | grep -q '"error"[[:space:]]*:[[:space:]]*"invalid_client"' && break
     [ "${TOKEN_ATTEMPT}" -lt 5 ] && sleep 2
   done
-  if [ -z "${TOKEN}" ]; then
-    print_result false "" "" 0 "failed to obtain an OIDC access token from ${OIDC_TOKEN_URL}: ${TOKEN_RESPONSE}"
-    exit 1
-  fi
-  REQUEST_HEADERS="$(printf '%s\nAuthorization:Bearer %s' "${REQUEST_HEADERS}" "${TOKEN}")"
-fi
+  printf '%s' "${token}"
+}
 
 # Build the curl command as a single string, both to execute (via eval, as the
 # other *_connectivity_test.sh scripts do) and to show verbatim in the JSON result.
 build_curl_cmd() {
+  local headers="$1"
   local CMD="curl -sk -m 30 -o ${BODY_FILE} -w '%{http_code}' -X ${METHOD}"
   if [ -n "${REQUEST_BODY}" ]; then
     CMD="${CMD} -H 'Content-Type: ${CONTENT_TYPE}' --data '${REQUEST_BODY}'"
   fi
-  if [ -n "${REQUEST_HEADERS}" ]; then
+  if [ -n "${headers}" ]; then
     while IFS= read -r h; do
       [ -n "${h}" ] && CMD="${CMD} -H '${h}'"
     done <<EOF
-${REQUEST_HEADERS}
+${headers}
 EOF
   fi
   CMD="${CMD} '${URL}'"
   echo "${CMD}"
 }
-
-CURL_CMD="$(build_curl_cmd)"
 
 response_matches() {
   local code="$1"
@@ -193,12 +216,15 @@ response_matches() {
     [ "${code}" = "${EXPECTED_STATUS}" ] || return 1
   fi
 
+  # -F: EXPECTED_BODY/UNEXPECTED_BODY are documented as plain substrings, so match
+  # them literally rather than as regexes (a '.', '[' etc. in an expected value
+  # would otherwise silently change the match semantics).
   if [ -n "${EXPECTED_BODY}" ]; then
-    printf '%s' "${body}" | grep -q "${EXPECTED_BODY}" || return 1
+    printf '%s' "${body}" | grep -qF "${EXPECTED_BODY}" || return 1
   fi
 
   if [ -n "${UNEXPECTED_BODY}" ]; then
-    ! printf '%s' "${body}" | grep -q "${UNEXPECTED_BODY}" || return 1
+    ! printf '%s' "${body}" | grep -qF "${UNEXPECTED_BODY}" || return 1
   fi
 
   if [ -n "${EXPECTED_JSONRPC}" ]; then
@@ -218,19 +244,52 @@ response_matches() {
 
 CODE=""
 BODY=""
+REJECTIONS=0
 for ATTEMPT in $(seq 1 "${MAX_RETRIES}"); do
-  > "${BODY_FILE}"
-  CODE="$(eval "${CURL_CMD}" 2>/dev/null || echo 000)"
-  BODY="$(cat "${BODY_FILE}" 2>/dev/null || echo '')"
-  if response_matches "${CODE}" "${BODY}"; then
-    print_result true "${CODE}" "${BODY}" "${ATTEMPT}"
-    exit 0
+  MATCHED=false
+  if [ -n "${OIDC_TOKEN_URL}" ]; then
+    TOKEN="$(fetch_oidc_token)"
+    if [ -z "${TOKEN}" ]; then
+      CODE=""
+      BODY="failed to obtain an OIDC access token from ${OIDC_TOKEN_URL}: $(cat "${TOKEN_RESPONSE_FILE}" 2>/dev/null || echo '')"
+    else
+      REQUEST_HEADERS="$(printf '%s\nAuthorization:Bearer %s' "${BASE_REQUEST_HEADERS}" "${TOKEN}")"
+      CURL_CMD="$(build_curl_cmd "${REQUEST_HEADERS}")"
+      > "${BODY_FILE}"
+      CODE="$(eval "${CURL_CMD}" 2>/dev/null || echo 000)"
+      BODY="$(cat "${BODY_FILE}" 2>/dev/null || echo '')"
+      response_matches "${CODE}" "${BODY}" && MATCHED=true
+    fi
+  else
+    CURL_CMD="$(build_curl_cmd "${BASE_REQUEST_HEADERS}")"
+    > "${BODY_FILE}"
+    CODE="$(eval "${CURL_CMD}" 2>/dev/null || echo 000)"
+    BODY="$(cat "${BODY_FILE}" 2>/dev/null || echo '')"
+    response_matches "${CODE}" "${BODY}" && MATCHED=true
   fi
-  echo "attempt ${ATTEMPT}/${MAX_RETRIES}: status='${CODE}' body='${BODY}'" >&2
+
+  if [ "${EXPECTED_SUCCESS}" = "false" ]; then
+    if [ "${MATCHED}" = "false" ]; then
+      REJECTIONS=$((REJECTIONS + 1))
+      [ "${REJECTIONS}" -ge "${REJECT_CONFIRMATIONS}" ] && { print_result true "${CODE}" "${BODY}" "${ATTEMPT}"; exit 0; }
+    else
+      # A stale success (e.g. an old pod still serving during a rollout) breaks the
+      # streak: only REJECT_CONFIRMATIONS *consecutive* rejections conclude success.
+      REJECTIONS=0
+    fi
+  else
+    [ "${MATCHED}" = "true" ] && { print_result true "${CODE}" "${BODY}" "${ATTEMPT}"; exit 0; }
+  fi
+
+  echo "attempt ${ATTEMPT}/${MAX_RETRIES}: matched=${MATCHED} status='${CODE}' rejections=${REJECTIONS}/${REJECT_CONFIRMATIONS} body='${BODY}'" >&2
   if [ "${ATTEMPT}" -lt "${MAX_RETRIES}" ]; then
     sleep "${RETRY_DELAY}"
   fi
 done
 
-print_result false "${CODE}" "${BODY}" "${MAX_RETRIES}" "response did not match expectations after ${MAX_RETRIES} attempts"
+if [ "${EXPECTED_SUCCESS}" = "false" ]; then
+  print_result false "${CODE}" "${BODY}" "${MAX_RETRIES}" "expected the request to be rejected ${REJECT_CONFIRMATIONS} consecutive times, but never reached that streak within ${MAX_RETRIES} attempts (last streak: ${REJECTIONS})"
+else
+  print_result false "${CODE}" "${BODY}" "${MAX_RETRIES}" "response did not match expectations after ${MAX_RETRIES} attempts"
+fi
 exit 1

--- a/test/e2e/chainsaw/common/scripts/aigw_agent_request_from_cluster.sh
+++ b/test/e2e/chainsaw/common/scripts/aigw_agent_request_from_cluster.sh
@@ -17,8 +17,9 @@ set -o pipefail
 #   METHOD, ROUTE_PATH, PORT, REQUEST_HEADERS, REQUEST_BODY, CONTENT_TYPE,
 #   EXPECTED_STATUS, EXPECTED_STATUS_NOT, EXPECTED_BODY, UNEXPECTED_BODY,
 #   EXPECTED_JSONRPC, EXPECTED_JSON_ID, EXPECTED_JSON_RESULT_TEXT, MAX_RETRIES,
-#   RETRY_DELAY, OIDC_TOKEN_URL, OIDC_CLIENT_ID, OIDC_CLIENT_SECRET, OIDC_SCOPE:
-#     Forwarded through as-is to aigw_agent_request.sh (see its own env docs).
+#   RETRY_DELAY, OIDC_TOKEN_URL, OIDC_CLIENT_ID, OIDC_CLIENT_SECRET, OIDC_SCOPE,
+#   EXPECTED_SUCCESS: Forwarded through as-is to aigw_agent_request.sh (see its
+#     own env docs).
 
 SCRIPT_PATH="${SCRIPT_PATH:-../../common/scripts/aigw_agent_request.sh}"
 NAMESPACE="${NAMESPACE}"
@@ -51,5 +52,6 @@ cat "${SCRIPT_PATH}" | kubectl run "${POD_NAME}" \
   --env="OIDC_CLIENT_ID=${OIDC_CLIENT_ID:-}" \
   --env="OIDC_CLIENT_SECRET=${OIDC_CLIENT_SECRET:-}" \
   --env="OIDC_SCOPE=${OIDC_SCOPE:-}" \
+  --env="EXPECTED_SUCCESS=${EXPECTED_SUCCESS:-true}" \
   -n "${NAMESPACE}" \
   -- sh -s 2>/dev/null | grep -v '^pod "'


### PR DESCRIPTION


**What this PR does / why we need it**:

Step 27 (reject request after revoking a client secret) in the consumers-and-credentials-openid-connect chainsaw suite was flaky: requests using the revoked secret could still succeed briefly after revocation.

Two causes:
- oidc-mock's Deployment had no explicit strategy (default RollingUpdate), so during the secret-change rollout the old pod (still accepting the revoked secret) briefly stayed reachable alongside the new one via the shared Service selector. Switched to strategy: Recreate to remove that overlap window.
- aigw_agent_request.sh minted its OIDC token once and only retried the HTTP request, so a single stale-pod hit failed the check with no chance to recover. Added an EXPECTED_SUCCESS env var: when 'false', the script re-fetches the token on every retry and keeps retrying until the request is actually rejected.

Also updated verify-aigw-agent-request-from-cluster.yaml to pass through the new expected_success binding (default true), so step 27 now uses the shared template instead of an inline script like every other step.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
