### PR TITLE
tests: fix e2e upgrade test assertions

### DIFF
--- a/.github/workflows/__e2e_tests.yaml
+++ b/.github/workflows/__e2e_tests.yaml
@@ -94,6 +94,8 @@ jobs:
         # This could be changed so that ktf addons have their versions pinned
         # in the test Makefile instead.
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        KONG_TEST_KONNECT_ACCESS_TOKEN: ${{ secrets.KONG_TEST_KONNECT_ACCESS_TOKEN }}
+        KONG_TEST_KONNECT_SERVER_URL: us.api.konghq.tech
 
     - name: upload diagnostics
       if: always()

--- a/test/e2e/helm_install_upgrade_test.go
+++ b/test/e2e/helm_install_upgrade_test.go
@@ -192,9 +192,9 @@ func TestHelmUpgrade(t *testing.T) {
 							},
 						},
 						{
-							Name: "DataPlane deployment is patched after operator upgrade (adjusting securityContext)",
+							Name: "DataPlane deployment is not patched after install",
 							Func: func(c *assert.CollectT, cl *testutils.K8sClients) {
-								gatewayDataPlaneDeploymentIsPatched(hybridGatewayLabelSelector)(ctx, c, cl.MgrClient)
+								gatewayDataPlaneDeploymentIsNotPatched(hybridGatewayLabelSelector)(ctx, c, cl.MgrClient)
 							},
 						},
 						{
@@ -224,9 +224,9 @@ func TestHelmUpgrade(t *testing.T) {
 							},
 						},
 						{
-							Name: "DataPlane deployment is not patched after operator upgrade",
+							Name: "DataPlane deployment is patched after operator upgrade (adjusting securityContext)",
 							Func: func(c *assert.CollectT, cl *testutils.K8sClients) {
-								gatewayDataPlaneDeploymentIsNotPatched(hybridGatewayLabelSelector)(ctx, c, cl.MgrClient)
+								gatewayDataPlaneDeploymentIsPatched(hybridGatewayLabelSelector)(ctx, c, cl.MgrClient)
 							},
 						},
 						{


### PR DESCRIPTION
**What this PR does / why we need it**:

Add Konnect config to e2e tests.

Up until now these tests [were skipped](https://github.com/Kong/kong-operator/actions/runs/31111419493/job/92650994749#step:16:354) because of this config missing:

```
    helm_install_upgrade_test.go:241: Skipping tests for Hybrid Gateway, KONG_TEST_KONNECT_ACCESS_TOKEN and/or KONG_TEST_KONNECT_SERVER_URL env vars are not set
```

This only came up in release workflow: https://github.com/Kong/kong-operator/actions/runs/31103327694/job/92647004941#step:11:331 because that runs e2e tests from falco workflow: https://github.com/Kong/kong-operator/blob/3ef3137f47b44716dde20e90073869af0758f076/.github/workflows/falco-analyzed-e2e.yaml#L79-L87 and that did set these config options.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
