### PR TITLE
tests(kongintegration): fix container port binding

### DIFF
--- a/ingress-controller/test/kongintegration/containers/kong.go
+++ b/ingress-controller/test/kongintegration/containers/kong.go
@@ -61,31 +61,40 @@ type Kong struct {
 // NewKong spawns a docker container running Kong (its image is determined by environment variables).
 // It sets up a cleanup function that will terminate the container when the test finishes.
 func NewKong(ctx context.Context, t *testing.T, opts ...KongOpt) Kong {
-	req := testcontainers.ContainerRequest{
-		Image: kongImageUnderTest(t),
-		Env: map[string]string{
-			"KONG_DATABASE":      "off",
-			"KONG_ADMIN_LISTEN":  fmt.Sprintf("0.0.0.0:%s", kongAdminPort),
-			"KONG_PROXY_LISTEN":  fmt.Sprintf("0.0.0.0:%s", kongProxyPort),
-			"KONG_ROUTER_FLAVOR": defaultRouterFlavor,
-			"KONG_LICENSE_DATA":  testhelpers.KongLicenseData(),
-		},
-		WaitingFor: wait.ForAll(
-			wait.ForListeningPort(kongAdminPort),
-			wait.ForListeningPort(kongProxyPort),
-		),
+	// newRequest is built fresh on every retry attempt so BindLocalPort picks a new
+	// host port each time. GetFreePort only proves a port was free at check time, not
+	// at bind time, so reusing a request whose ports were bound once means a retry
+	// would rebind the same doomed port. BindLocalPort also appends to
+	// req.ExposedPorts and chains req.HostConfigModifier, so calling it twice on the
+	// same req (rather than a fresh one) would accumulate stale bindings.
+	newRequest := func() testcontainers.ContainerRequest {
+		req := testcontainers.ContainerRequest{
+			Image: kongImageUnderTest(t),
+			Env: map[string]string{
+				"KONG_DATABASE":      "off",
+				"KONG_ADMIN_LISTEN":  fmt.Sprintf("0.0.0.0:%s", kongAdminPort),
+				"KONG_PROXY_LISTEN":  fmt.Sprintf("0.0.0.0:%s", kongProxyPort),
+				"KONG_ROUTER_FLAVOR": defaultRouterFlavor,
+				"KONG_LICENSE_DATA":  testhelpers.KongLicenseData(),
+			},
+			WaitingFor: wait.ForAll(
+				wait.ForListeningPort(kongAdminPort),
+				wait.ForListeningPort(kongProxyPort),
+			),
+		}
+		for _, opt := range opts {
+			opt(&req)
+		}
+		BindLocalPort(t, &req, kongAdminPort)
+		BindLocalPort(t, &req, kongProxyPort)
+		return req
 	}
-	for _, opt := range opts {
-		opt(&req)
-	}
-	BindLocalPort(t, &req, kongAdminPort)
-	BindLocalPort(t, &req, kongProxyPort)
 
 	kongC, err := retry.NewWithData[testcontainers.Container](
 		retry.Context(ctx),
-		retry.Attempts(100),
-		retry.Delay(10*time.Millisecond),
-		retry.DelayType(retry.FixedDelay),
+		retry.Attempts(10),
+		retry.Delay(200*time.Millisecond),
+		retry.DelayType(retry.BackOffDelay),
 		retry.LastErrorOnly(true),
 		retry.OnRetry(func(_ uint, err error) {
 			t.Logf("failed creating Kong container: %v", err)
@@ -93,7 +102,7 @@ func NewKong(ctx context.Context, t *testing.T, opts ...KongOpt) Kong {
 	).Do(
 		func() (testcontainers.Container, error) {
 			return testcontainers.GenericContainer(ctx, testcontainers.GenericContainerRequest{
-				ContainerRequest: req,
+				ContainerRequest: newRequest(),
 				Started:          true,
 			})
 		},

--- a/ingress-controller/test/kongintegration/kong_client_golden_tests_outputs_test.go
+++ b/ingress-controller/test/kongintegration/kong_client_golden_tests_outputs_test.go
@@ -33,8 +33,16 @@ import (
 )
 
 const (
-	timeout = 5 * time.Second
-	tick    = 250 * time.Millisecond
+	// timeout is the total budget for a golden output to be accepted by Kong.
+	// It must comfortably exceed requestTimeout so more than one attempt fits -
+	// otherwise a single slow request consumes the whole budget and the retry
+	// loop never runs a second time.
+	timeout = 60 * time.Second
+	// requestTimeout bounds a single POST /config. The Admin API client has no
+	// http.Client.Timeout (see internal/adminapi/kong.go), so without this the
+	// only deadline is the long-lived parent test context.
+	requestTimeout = 15 * time.Second
+	tick           = 250 * time.Millisecond
 )
 
 // TestKongClientGoldenTestsOutputs ensures that the KongClient's golden tests outputs are accepted by Kong.
@@ -58,7 +66,7 @@ func TestKongClientGoldenTestsOutputs(t *testing.T) {
 		return strings.Contains(path, "default_")
 	})
 
-	t.Logf("will test %d expression routes outputs and %d default ones", len(goldenTestsOutputsPaths), len(defaultOutputsPaths))
+	t.Logf("will test %d expression routes outputs and %d default ones", len(expressionRoutesOutputsPaths), len(defaultOutputsPaths))
 
 	t.Run("expressions router", func(t *testing.T) {
 		t.Parallel()
@@ -192,7 +200,10 @@ func ensureGoldenTestOutputIsAccepted(ctx context.Context, t *testing.T, goldenT
 	require.NoError(t, err)
 
 	require.EventuallyWithT(t, func(t *assert.CollectT) {
-		err := kongClient.ReloadDeclarativeRawConfig(ctx, bytes.NewReader(cfgAsJSON), true, true)
+		reqCtx, cancel := context.WithTimeout(ctx, requestTimeout)
+		defer cancel()
+
+		err := kongClient.ReloadDeclarativeRawConfig(reqCtx, bytes.NewReader(cfgAsJSON), true, true)
 		if !assert.NoErrorf(t, err, "failed to reload declarative config") {
 			if apiErr, ok := errors.AsType[*kong.APIError](err); ok {
 				t.Errorf("Kong Admin API response: %s", apiErr.Raw())


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix flaky failures like: https://github.com/Kong/kong-operator/actions/runs/31107351936/job/92635942209#step:14:492

```
=== Failed
=== FAIL: ingress-controller/test/kongintegration TestKongClientGoldenTestsOutputs/default/../../internal/dataplane/testdata/golden/credentials/default_golden.yaml (5.00s)
    kong_client_golden_tests_outputs_test.go:194: 
        	Error Trace:	/home/runner/work/kong-operator/kong-operator/ingress-controller/test/kongintegration/kong_client_golden_tests_outputs_test.go:194
        	            				/home/runner/work/kong-operator/kong-operator/ingress-controller/test/kongintegration/kong_client_golden_tests_outputs_test.go:87
        	Error:      	Condition never satisfied
        	Test:       	TestKongClientGoldenTestsOutputs/default/../../internal/dataplane/testdata/golden/credentials/default_golden.yaml

=== FAIL: ingress-controller/test/kongintegration TestKongClientGoldenTestsOutputs/default (19.88s)
Warning: import/export of basic-authcredentials using decK doesn't work due to hashing of passwords in Kong.
    kong.go:146: using Kong instance (version: "3.15.0.2") reachable at http://localhost:45135

=== FAIL: ingress-controller/test/kongintegration TestKongClientGoldenTestsOutputs (0.01s)
    kong_client_golden_tests_outputs_test.go:61: will test 58 expression routes outputs and 37 default ones
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
