### PR TITLE
chore(hybridgateway): refactor namegen for Kong objects

### DIFF
--- a/controller/hybridgateway/namegen/name.go
+++ b/controller/hybridgateway/namegen/name.go
@@ -119,64 +119,45 @@ func newNameWithHashSuffix(readableElements []string, hashElements []string) str
 	return name
 }
 
+// serviceLikeName generates the shared name shape used by both KongUpstream and KongService
+// names: a protocol prefix and backend-ref display names as the readable part, plus a
+// caller-supplied hash suffix.
+func serviceLikeName[T gwtypes.SupportedBackendRef](protocolPrefix, namespace string, backendRefs []T, hashElements []string) string {
+	readableElements := append(
+		[]string{protocolPrefix},
+		backendRefDisplayNames(namespace, backendRefs)...,
+	)
+	return newNameWithHashSuffix(readableElements, hashElements)
+}
+
 // NewKongUpstreamNameForHTTPRouteRule generates a KongUpstream name based on the ControlPlaneRef and HTTPRouteRule passed as arguments.
 func NewKongUpstreamNameForHTTPRouteRule(route *gwtypes.HTTPRoute, cp *commonv1alpha1.ControlPlaneRef, rule gatewayv1.HTTPRouteRule) string {
-	readableElements := append(
-		[]string{httpProtocolPrefix},
-		backendRefDisplayNames(route.Namespace, rule.BackendRefs)...,
-	)
-	hashElements := hashElementsForServiceLikeName(route, cp, rule)
-	return newNameWithHashSuffix(readableElements, hashElements)
+	return serviceLikeName(httpProtocolPrefix, route.Namespace, rule.BackendRefs, hashElementsForServiceLikeName(route, cp, rule))
 }
 
 // NewKongUpstreamNameForGRPCRouteRule generates a KongUpstream name based on the ControlPlaneRef and GRPCRouteRule passed as arguments.
 func NewKongUpstreamNameForGRPCRouteRule(route *gwtypes.GRPCRoute, cp *commonv1alpha1.ControlPlaneRef, rule gatewayv1.GRPCRouteRule) string {
-	readableElements := append(
-		[]string{grpcProtocolPrefix},
-		backendRefDisplayNames(route.Namespace, rule.BackendRefs)...,
-	)
-	hashElements := hashElementsForServiceLikeNameGRPCRouteRule(route, cp, rule)
-	return newNameWithHashSuffix(readableElements, hashElements)
+	return serviceLikeName(grpcProtocolPrefix, route.Namespace, rule.BackendRefs, hashElementsForServiceLikeNameGRPCRouteRule(route, cp, rule))
 }
 
 // NewKongUpstreamNameForTLSRouteRule generates a KongUpstream name based on the ControlPlaneRef and TLSRouteRule passed as arguments.
 func NewKongUpstreamNameForTLSRouteRule(route *gwtypes.TLSRoute, cp *commonv1alpha1.ControlPlaneRef, rule gatewayv1.TLSRouteRule) string {
-	readableElements := append(
-		[]string{tlsProtocolPrefix},
-		backendRefDisplayNames(route.Namespace, rule.BackendRefs)...,
-	)
-	hashElements := hashElementsForServiceLikeNameTLSRouteRule(cp, rule)
-	return newNameWithHashSuffix(readableElements, hashElements)
+	return serviceLikeName(tlsProtocolPrefix, route.Namespace, rule.BackendRefs, hashElementsForServiceLikeNameSimple(cp, rule.BackendRefs))
 }
 
 // NewKongUpstreamNameForTCPRouteRule generates a KongUpstream name based on the ControlPlaneRef and TCPRouteRule passed as arguments.
 func NewKongUpstreamNameForTCPRouteRule(route *gwtypes.TCPRoute, cp *commonv1alpha1.ControlPlaneRef, rule gwtypes.TCPRouteRule) string {
-	readableElements := append(
-		[]string{tcpProtocolPrefix},
-		backendRefDisplayNames(route.Namespace, rule.BackendRefs)...,
-	)
-	hashElements := hashElementsForServiceLikeNameTCPRouteRule(cp, rule)
-	return newNameWithHashSuffix(readableElements, hashElements)
+	return serviceLikeName(tcpProtocolPrefix, route.Namespace, rule.BackendRefs, hashElementsForServiceLikeNameSimple(cp, rule.BackendRefs))
 }
 
 // NewKongUpstreamNameForUDPRouteRule generates a KongUpstream name based on the ControlPlaneRef and UDPRouteRule passed as arguments.
 func NewKongUpstreamNameForUDPRouteRule(route *gwtypes.UDPRoute, cp *commonv1alpha1.ControlPlaneRef, rule gwtypes.UDPRouteRule) string {
-	readableElements := append(
-		[]string{udpProtocolPrefix},
-		backendRefDisplayNames(route.Namespace, rule.BackendRefs)...,
-	)
-	hashElements := hashElementsForServiceLikeNameUDPRouteRule(cp, rule)
-	return newNameWithHashSuffix(readableElements, hashElements)
+	return serviceLikeName(udpProtocolPrefix, route.Namespace, rule.BackendRefs, hashElementsForServiceLikeNameSimple(cp, rule.BackendRefs))
 }
 
 // NewKongServiceNameForHTTPRouteRule generates a KongService name based on the ControlPlaneRef and HTTPRouteRule passed as arguments.
 func NewKongServiceNameForHTTPRouteRule(route *gwtypes.HTTPRoute, cp *commonv1alpha1.ControlPlaneRef, rule gatewayv1.HTTPRouteRule) string {
-	readableElements := append(
-		[]string{httpProtocolPrefix},
-		backendRefDisplayNames(route.Namespace, rule.BackendRefs)...,
-	)
-	hashElements := hashElementsForServiceLikeName(route, cp, rule)
-	return newNameWithHashSuffix(readableElements, hashElements)
+	return serviceLikeName(httpProtocolPrefix, route.Namespace, rule.BackendRefs, hashElementsForServiceLikeName(route, cp, rule))
 }
 
 // NewKongServiceNameForHTTPRouteRuleBackendNotFound generates a route-scoped KongService name
@@ -207,12 +188,7 @@ func NewKongServiceNameForHTTPRouteRuleBackendNotFound(
 
 // NewKongServiceNameForGRPCRouteRule generates a KongService name based on the ControlPlaneRef and GRPCRouteRule passed as arguments.
 func NewKongServiceNameForGRPCRouteRule(route *gwtypes.GRPCRoute, cp *commonv1alpha1.ControlPlaneRef, rule gatewayv1.GRPCRouteRule) string {
-	readableElements := append(
-		[]string{grpcProtocolPrefix},
-		backendRefDisplayNames(route.Namespace, rule.BackendRefs)...,
-	)
-	hashElements := hashElementsForServiceLikeNameGRPCRouteRule(route, cp, rule)
-	return newNameWithHashSuffix(readableElements, hashElements)
+	return serviceLikeName(grpcProtocolPrefix, route.Namespace, rule.BackendRefs, hashElementsForServiceLikeNameGRPCRouteRule(route, cp, rule))
 }
 
 // NewKongServiceNameForGRPCRouteRuleBackendNotFound generates a route-scoped KongService name
@@ -244,32 +220,17 @@ func NewKongServiceNameForGRPCRouteRuleBackendNotFound(
 
 // NewKongServiceNameForTLSRouteRule generates a KongService name based on the ControlPlaneRef and TLSRouteRule passed as arguments.
 func NewKongServiceNameForTLSRouteRule(route *gwtypes.TLSRoute, cp *commonv1alpha1.ControlPlaneRef, rule gatewayv1.TLSRouteRule) string {
-	readableElements := append(
-		[]string{tlsProtocolPrefix},
-		backendRefDisplayNames(route.Namespace, rule.BackendRefs)...,
-	)
-	hashElements := hashElementsForServiceLikeNameTLSRouteRule(cp, rule)
-	return newNameWithHashSuffix(readableElements, hashElements)
+	return serviceLikeName(tlsProtocolPrefix, route.Namespace, rule.BackendRefs, hashElementsForServiceLikeNameSimple(cp, rule.BackendRefs))
 }
 
 // NewKongServiceNameForTCPRouteRule generates a KongService name based on the ControlPlaneRef and TCPRouteRule passed as arguments.
 func NewKongServiceNameForTCPRouteRule(route *gwtypes.TCPRoute, cp *commonv1alpha1.ControlPlaneRef, rule gwtypes.TCPRouteRule) string {
-	readableElements := append(
-		[]string{tcpProtocolPrefix},
-		backendRefDisplayNames(route.Namespace, rule.BackendRefs)...,
-	)
-	hashElements := hashElementsForServiceLikeNameTCPRouteRule(cp, rule)
-	return newNameWithHashSuffix(readableElements, hashElements)
+	return serviceLikeName(tcpProtocolPrefix, route.Namespace, rule.BackendRefs, hashElementsForServiceLikeNameSimple(cp, rule.BackendRefs))
 }
 
 // NewKongServiceNameForUDPRouteRule generates a KongService name based on the ControlPlaneRef and UDPRouteRule passed as arguments.
 func NewKongServiceNameForUDPRouteRule(route *gwtypes.UDPRoute, cp *commonv1alpha1.ControlPlaneRef, rule gwtypes.UDPRouteRule) string {
-	readableElements := append(
-		[]string{udpProtocolPrefix},
-		backendRefDisplayNames(route.Namespace, rule.BackendRefs)...,
-	)
-	hashElements := hashElementsForServiceLikeNameUDPRouteRule(cp, rule)
-	return newNameWithHashSuffix(readableElements, hashElements)
+	return serviceLikeName(udpProtocolPrefix, route.Namespace, rule.BackendRefs, hashElementsForServiceLikeNameSimple(cp, rule.BackendRefs))
 }
 
 func hashElementsForServiceLikeName(
@@ -356,39 +317,38 @@ func hashForGRPCRouteRuleServiceLikeName(route *gwtypes.GRPCRoute, rule gatewayv
 	return hash
 }
 
-func hashElementsForServiceLikeNameTLSRouteRule(
+// hashElementsForServiceLikeNameSimple builds the hash suffix for route kinds whose rules
+// require at least one BackendRef (TLSRoute, TCPRoute, UDPRoute), so no zero-backend fallback
+// is needed.
+func hashElementsForServiceLikeNameSimple[T gwtypes.SupportedBackendRef](
 	cp *commonv1alpha1.ControlPlaneRef,
-	rule gwtypes.TLSRouteRule,
+	backendRefs []T,
 ) []string {
-	// Since in TLSRoute, `backendRefs` list is required in rules and has at least one backend reference,
-	// We can directly run hash on backendRefs.
-	hash := utils.Hash32(rule.BackendRefs)
 	return []string{
 		defaultCPPrefix + utils.Hash32(cp),
-		hash,
+		utils.Hash32(backendRefs),
 	}
 }
 
-func hashElementsForServiceLikeNameTCPRouteRule(
+// kongRouteName generates the shared name shape for KongRoute names: a protocol prefix and
+// "<namespace>-<name>" as the readable part, plus a ControlPlaneRef hash, an optional ParentRef
+// hash, and caller-supplied extra hash elements (e.g. match/rule identity, match/rule indexes).
+func kongRouteName(
+	protocolPrefix, namespace, name string,
 	cp *commonv1alpha1.ControlPlaneRef,
-	rule gwtypes.TCPRouteRule,
-) []string {
-	hash := utils.Hash32(rule.BackendRefs)
-	return []string{
-		defaultCPPrefix + utils.Hash32(cp),
-		hash,
+	parentRef *gwtypes.ParentReference,
+	extraHashElements ...string,
+) string {
+	readableElements := []string{
+		protocolPrefix,
+		namespace + "-" + name,
 	}
-}
-
-func hashElementsForServiceLikeNameUDPRouteRule(
-	cp *commonv1alpha1.ControlPlaneRef,
-	rule gwtypes.UDPRouteRule,
-) []string {
-	hash := utils.Hash32(rule.BackendRefs)
-	return []string{
-		defaultCPPrefix + utils.Hash32(cp),
-		hash,
+	hashElements := []string{defaultCPPrefix + utils.Hash32(cp)}
+	if parentRef != nil {
+		hashElements = append(hashElements, parentRefHashElement(parentRef))
 	}
+	hashElements = append(hashElements, extraHashElements...)
+	return newNameWithHashSuffix(readableElements, hashElements)
 }
 
 // NewKongRouteNameForMatch generates a KongRoute name based on HTTPRoute, ControlPlaneRef,
@@ -401,16 +361,8 @@ func NewKongRouteNameForMatch(
 	match gatewayv1.HTTPRouteMatch,
 	index int,
 ) string {
-	readableElements := []string{
-		httpProtocolPrefix,
-		route.Namespace + "-" + route.Name,
-	}
-	hashElements := []string{defaultCPPrefix + utils.Hash32(cp)}
-	if parentRef != nil {
-		hashElements = append(hashElements, parentRefHashElement(parentRef))
-	}
-	hashElements = append(hashElements, utils.Hash32(match), fmt.Sprintf("m%02d", index))
-	return newNameWithHashSuffix(readableElements, hashElements)
+	return kongRouteName(httpProtocolPrefix, route.Namespace, route.Name, cp, parentRef,
+		utils.Hash32(match), fmt.Sprintf("m%02d", index))
 }
 
 // NewKongRouteNameForGRPCRouteMatch generates a KongRoute name based on GRPCRoute, ControlPlaneRef,
@@ -424,16 +376,8 @@ func NewKongRouteNameForGRPCRouteMatch(
 	ruleIndex int,
 	matchIndex int,
 ) string {
-	readableElements := []string{
-		grpcProtocolPrefix,
-		route.Namespace + "-" + route.Name,
-	}
-	hashElements := []string{defaultCPPrefix + utils.Hash32(cp)}
-	if parentRef != nil {
-		hashElements = append(hashElements, parentRefHashElement(parentRef))
-	}
-	hashElements = append(hashElements, utils.Hash32(match), fmt.Sprintf("r%02d", ruleIndex), fmt.Sprintf("m%02d", matchIndex))
-	return newNameWithHashSuffix(readableElements, hashElements)
+	return kongRouteName(grpcProtocolPrefix, route.Namespace, route.Name, cp, parentRef,
+		utils.Hash32(match), fmt.Sprintf("r%02d", ruleIndex), fmt.Sprintf("m%02d", matchIndex))
 }
 
 // NewKongRouteNameForTLSRouteRule generates a KongRoute name based on the TLSRoute rule,
@@ -444,16 +388,7 @@ func NewKongRouteNameForTLSRouteRule(
 	parentRef *gwtypes.ParentReference,
 	rule gatewayv1.TLSRouteRule,
 ) string {
-	readableElements := []string{
-		tlsProtocolPrefix,
-		route.Namespace + "-" + route.Name,
-	}
-	hashElements := []string{defaultCPPrefix + utils.Hash32(cp)}
-	if parentRef != nil {
-		hashElements = append(hashElements, parentRefHashElement(parentRef))
-	}
-	hashElements = append(hashElements, utils.Hash32(rule))
-	return newNameWithHashSuffix(readableElements, hashElements)
+	return kongRouteName(tlsProtocolPrefix, route.Namespace, route.Name, cp, parentRef, utils.Hash32(rule))
 }
 
 // NewKongRouteNameForTCPRouteRule generates a KongRoute name based on the TCPRoute rule,
@@ -464,16 +399,7 @@ func NewKongRouteNameForTCPRouteRule(
 	parentRef *gwtypes.ParentReference,
 	rule gwtypes.TCPRouteRule,
 ) string {
-	readableElements := []string{
-		tcpProtocolPrefix,
-		route.Namespace + "-" + route.Name,
-	}
-	hashElements := []string{defaultCPPrefix + utils.Hash32(cp)}
-	if parentRef != nil {
-		hashElements = append(hashElements, parentRefHashElement(parentRef))
-	}
-	hashElements = append(hashElements, utils.Hash32(rule))
-	return newNameWithHashSuffix(readableElements, hashElements)
+	return kongRouteName(tcpProtocolPrefix, route.Namespace, route.Name, cp, parentRef, utils.Hash32(rule))
 }
 
 // NewKongRouteNameForUDPRouteRule generates a KongRoute name based on the UDPRoute rule,
@@ -484,16 +410,7 @@ func NewKongRouteNameForUDPRouteRule(
 	parentRef *gwtypes.ParentReference,
 	rule gwtypes.UDPRouteRule,
 ) string {
-	readableElements := []string{
-		udpProtocolPrefix,
-		route.Namespace + "-" + route.Name,
-	}
-	hashElements := []string{defaultCPPrefix + utils.Hash32(cp)}
-	if parentRef != nil {
-		hashElements = append(hashElements, parentRefHashElement(parentRef))
-	}
-	hashElements = append(hashElements, utils.Hash32(rule))
-	return newNameWithHashSuffix(readableElements, hashElements)
+	return kongRouteName(udpProtocolPrefix, route.Namespace, route.Name, cp, parentRef, utils.Hash32(rule))
 }
 
 func parentRefHashElement(parentRef *gwtypes.ParentReference) string {

--- a/controller/hybridgateway/namegen/name_test.go
+++ b/controller/hybridgateway/namegen/name_test.go
@@ -1254,6 +1254,54 @@ func TestNameGenerationConsistency(t *testing.T) {
 	})
 }
 
+// TestRefactorGoldenNames locks in name strings captured from the pre-refactor implementation
+// of NewKongUpstreamNameFor{TLS,TCP,UDP}RouteRule, NewKongServiceNameFor{TLS,TCP,UDP}RouteRule,
+// NewKongRouteNameFor{TLS,TCP,UDP}RouteRule, NewKongRouteNameForMatch, and
+// NewKongRouteNameForGRPCRouteMatch, so that introducing the shared serviceLikeName/
+// kongRouteName helpers cannot silently rename existing Kong objects.
+func TestRefactorGoldenNames(t *testing.T) {
+	cp := testControlPlaneRef("test-cp")
+	port := gwtypes.PortNumber(443)
+	listener1 := gatewayv1.SectionName("listener-1")
+	parentRef := testParentRef(&listener1)
+
+	tlsRoute := &gwtypes.TLSRoute{ObjectMeta: metav1.ObjectMeta{Name: "tls-route", Namespace: "default"}}
+	tlsRule := gwtypes.TLSRouteRule{BackendRefs: []gwtypes.BackendRef{{
+		BackendObjectReference: gwtypes.BackendObjectReference{Name: "tls-backend", Port: &port},
+	}}}
+	assert.Equal(t, "tls.default-tls-backend-443.1.cp1fbfa93f.ea981935", NewKongUpstreamNameForTLSRouteRule(tlsRoute, cp, tlsRule))
+	assert.Equal(t, "tls.default-tls-backend-443.1.cp1fbfa93f.ea981935", NewKongServiceNameForTLSRouteRule(tlsRoute, cp, tlsRule))
+	assert.Equal(t, "tls.default-tls-route.cp1fbfa93f.pr4557fd4c.7d7f1d3d", NewKongRouteNameForTLSRouteRule(tlsRoute, cp, parentRef, tlsRule))
+	assert.Equal(t, "tls.default-tls-route.cp1fbfa93f.7d7f1d3d", NewKongRouteNameForTLSRouteRule(tlsRoute, cp, nil, tlsRule))
+
+	tcpRoute := &gwtypes.TCPRoute{ObjectMeta: metav1.ObjectMeta{Name: "tcp-route", Namespace: "default"}}
+	tcpRule := gwtypes.TCPRouteRule{BackendRefs: []gwtypes.BackendRef{{
+		BackendObjectReference: gwtypes.BackendObjectReference{Name: "tcp-backend", Port: &port},
+	}}}
+	assert.Equal(t, "tcp.default-tcp-backend-443.1.cp1fbfa93f.e8e7532f", NewKongUpstreamNameForTCPRouteRule(tcpRoute, cp, tcpRule))
+	assert.Equal(t, "tcp.default-tcp-backend-443.1.cp1fbfa93f.e8e7532f", NewKongServiceNameForTCPRouteRule(tcpRoute, cp, tcpRule))
+	assert.Equal(t, "tcp.default-tcp-route.cp1fbfa93f.pr4557fd4c.196de16d", NewKongRouteNameForTCPRouteRule(tcpRoute, cp, parentRef, tcpRule))
+	assert.Equal(t, "tcp.default-tcp-route.cp1fbfa93f.196de16d", NewKongRouteNameForTCPRouteRule(tcpRoute, cp, nil, tcpRule))
+
+	udpRoute := &gwtypes.UDPRoute{ObjectMeta: metav1.ObjectMeta{Name: "udp-route", Namespace: "default"}}
+	udpRule := gwtypes.UDPRouteRule{BackendRefs: []gwtypes.BackendRef{{
+		BackendObjectReference: gwtypes.BackendObjectReference{Name: "udp-backend", Port: &port},
+	}}}
+	assert.Equal(t, "udp.default-udp-backend-443.1.cp1fbfa93f.a1dd4f9f", NewKongUpstreamNameForUDPRouteRule(udpRoute, cp, udpRule))
+	assert.Equal(t, "udp.default-udp-backend-443.1.cp1fbfa93f.a1dd4f9f", NewKongServiceNameForUDPRouteRule(udpRoute, cp, udpRule))
+	assert.Equal(t, "udp.default-udp-route.cp1fbfa93f.pr4557fd4c.f6d7e16d", NewKongRouteNameForUDPRouteRule(udpRoute, cp, parentRef, udpRule))
+	assert.Equal(t, "udp.default-udp-route.cp1fbfa93f.f6d7e16d", NewKongRouteNameForUDPRouteRule(udpRoute, cp, nil, udpRule))
+
+	httpRoute := testRoute("default", "http-route")
+	matchType := gatewayv1.PathMatchPathPrefix
+	match := gatewayv1.HTTPRouteMatch{Path: &gatewayv1.HTTPPathMatch{Type: &matchType, Value: new("/foo")}}
+	assert.Equal(t, "http.default-http-route.cp1fbfa93f.pr4557fd4c.5cff32e8.m02", NewKongRouteNameForMatch(httpRoute, cp, parentRef, match, 2))
+
+	grpcRoute := testGRPCRoute("default", "grpc-route")
+	gmatch := gatewayv1.GRPCRouteMatch{Method: &gatewayv1.GRPCMethodMatch{Service: new("svc.Echo")}}
+	assert.Equal(t, "grpc.default-grpc-route.cp1fbfa93f.pr4557fd4c.a7d8418e.r01.m03", NewKongRouteNameForGRPCRouteMatch(grpcRoute, cp, parentRef, gmatch, 1, 3))
+}
+
 func TestNewKongCertificateName_Generated(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/controller/hybridgateway/namegen/name_test.go
+++ b/controller/hybridgateway/namegen/name_test.go
@@ -1254,6 +1254,91 @@ func TestNameGenerationConsistency(t *testing.T) {
 	})
 }
 
+// TestRefactorGoldenNames locks in name strings captured from the pre-refactor implementation
+// of NewKongUpstreamNameFor{HTTP,TLS,TCP,UDP}RouteRule, NewKongServiceNameFor{HTTP,TLS,TCP,UDP}RouteRule,
+// NewKongRouteNameFor{TLS,TCP,UDP}RouteRule, NewKongRouteNameForMatch, and
+// NewKongRouteNameForGRPCRouteMatch, so that introducing the shared serviceLikeName/
+// kongRouteName helpers cannot silently rename existing Kong objects. The HTTPRoute cases cover
+// basic, multi-backend, zero-backend (fallback identity), and backendRequest-timeout-fold hashing,
+// since those are the paths unique to HTTPRoute's hashElementsForServiceLikeName wiring.
+func TestRefactorGoldenNames(t *testing.T) {
+	cp := testControlPlaneRef("test-cp")
+	port := gwtypes.PortNumber(443)
+	listener1 := gatewayv1.SectionName("listener-1")
+	parentRef := testParentRef(&listener1)
+
+	httpBackendRef := func(name string) gatewayv1.HTTPBackendRef {
+		return gatewayv1.HTTPBackendRef{
+			BackendRef: gatewayv1.BackendRef{
+				BackendObjectReference: gatewayv1.BackendObjectReference{
+					Name: gatewayv1.ObjectName(name),
+					Port: new(gatewayv1.PortNumber(8080)),
+				},
+			},
+		}
+	}
+	httpRouteForServiceLike := &gwtypes.HTTPRoute{ObjectMeta: metav1.ObjectMeta{Name: "http-route", Namespace: "default"}}
+
+	basicRule := gatewayv1.HTTPRouteRule{BackendRefs: []gatewayv1.HTTPBackendRef{httpBackendRef("http-backend")}}
+	assert.Equal(t, "http.default-http-backend-8080.1.cp1fbfa93f.29652d0c", NewKongUpstreamNameForHTTPRouteRule(httpRouteForServiceLike, cp, basicRule))
+	assert.Equal(t, "http.default-http-backend-8080.1.cp1fbfa93f.29652d0c", NewKongServiceNameForHTTPRouteRule(httpRouteForServiceLike, cp, basicRule))
+
+	multiRule := gatewayv1.HTTPRouteRule{BackendRefs: []gatewayv1.HTTPBackendRef{httpBackendRef("http-backend-2"), httpBackendRef("http-backend-1")}}
+	assert.Equal(t, "http.default-http-backend-1-8080.2.cp1fbfa93f.6a6f4809", NewKongUpstreamNameForHTTPRouteRule(httpRouteForServiceLike, cp, multiRule))
+	assert.Equal(t, "http.default-http-backend-1-8080.2.cp1fbfa93f.6a6f4809", NewKongServiceNameForHTTPRouteRule(httpRouteForServiceLike, cp, multiRule))
+
+	httpMatchType := gatewayv1.PathMatchPathPrefix
+	zeroRule := gatewayv1.HTTPRouteRule{
+		Matches: []gatewayv1.HTTPRouteMatch{{Path: &gatewayv1.HTTPPathMatch{Type: &httpMatchType, Value: new("/zero")}}},
+	}
+	assert.Equal(t, "http.cp1fbfa93f.49d1cfbf", NewKongUpstreamNameForHTTPRouteRule(httpRouteForServiceLike, cp, zeroRule))
+	assert.Equal(t, "http.cp1fbfa93f.49d1cfbf", NewKongServiceNameForHTTPRouteRule(httpRouteForServiceLike, cp, zeroRule))
+
+	httpTimeout := gatewayv1.Duration("750ms")
+	timeoutRule := gatewayv1.HTTPRouteRule{
+		BackendRefs: []gatewayv1.HTTPBackendRef{httpBackendRef("http-backend")},
+		Timeouts:    &gatewayv1.HTTPRouteTimeouts{BackendRequest: &httpTimeout},
+	}
+	assert.Equal(t, "http.default-http-backend-8080.1.cp1fbfa93f.ea93d3e7", NewKongUpstreamNameForHTTPRouteRule(httpRouteForServiceLike, cp, timeoutRule))
+	assert.Equal(t, "http.default-http-backend-8080.1.cp1fbfa93f.ea93d3e7", NewKongServiceNameForHTTPRouteRule(httpRouteForServiceLike, cp, timeoutRule))
+
+	tlsRoute := &gwtypes.TLSRoute{ObjectMeta: metav1.ObjectMeta{Name: "tls-route", Namespace: "default"}}
+	tlsRule := gwtypes.TLSRouteRule{BackendRefs: []gwtypes.BackendRef{{
+		BackendObjectReference: gwtypes.BackendObjectReference{Name: "tls-backend", Port: &port},
+	}}}
+	assert.Equal(t, "tls.default-tls-backend-443.1.cp1fbfa93f.ea981935", NewKongUpstreamNameForTLSRouteRule(tlsRoute, cp, tlsRule))
+	assert.Equal(t, "tls.default-tls-backend-443.1.cp1fbfa93f.ea981935", NewKongServiceNameForTLSRouteRule(tlsRoute, cp, tlsRule))
+	assert.Equal(t, "tls.default-tls-route.cp1fbfa93f.pr4557fd4c.7d7f1d3d", NewKongRouteNameForTLSRouteRule(tlsRoute, cp, parentRef, tlsRule))
+	assert.Equal(t, "tls.default-tls-route.cp1fbfa93f.7d7f1d3d", NewKongRouteNameForTLSRouteRule(tlsRoute, cp, nil, tlsRule))
+
+	tcpRoute := &gwtypes.TCPRoute{ObjectMeta: metav1.ObjectMeta{Name: "tcp-route", Namespace: "default"}}
+	tcpRule := gwtypes.TCPRouteRule{BackendRefs: []gwtypes.BackendRef{{
+		BackendObjectReference: gwtypes.BackendObjectReference{Name: "tcp-backend", Port: &port},
+	}}}
+	assert.Equal(t, "tcp.default-tcp-backend-443.1.cp1fbfa93f.e8e7532f", NewKongUpstreamNameForTCPRouteRule(tcpRoute, cp, tcpRule))
+	assert.Equal(t, "tcp.default-tcp-backend-443.1.cp1fbfa93f.e8e7532f", NewKongServiceNameForTCPRouteRule(tcpRoute, cp, tcpRule))
+	assert.Equal(t, "tcp.default-tcp-route.cp1fbfa93f.pr4557fd4c.196de16d", NewKongRouteNameForTCPRouteRule(tcpRoute, cp, parentRef, tcpRule))
+	assert.Equal(t, "tcp.default-tcp-route.cp1fbfa93f.196de16d", NewKongRouteNameForTCPRouteRule(tcpRoute, cp, nil, tcpRule))
+
+	udpRoute := &gwtypes.UDPRoute{ObjectMeta: metav1.ObjectMeta{Name: "udp-route", Namespace: "default"}}
+	udpRule := gwtypes.UDPRouteRule{BackendRefs: []gwtypes.BackendRef{{
+		BackendObjectReference: gwtypes.BackendObjectReference{Name: "udp-backend", Port: &port},
+	}}}
+	assert.Equal(t, "udp.default-udp-backend-443.1.cp1fbfa93f.a1dd4f9f", NewKongUpstreamNameForUDPRouteRule(udpRoute, cp, udpRule))
+	assert.Equal(t, "udp.default-udp-backend-443.1.cp1fbfa93f.a1dd4f9f", NewKongServiceNameForUDPRouteRule(udpRoute, cp, udpRule))
+	assert.Equal(t, "udp.default-udp-route.cp1fbfa93f.pr4557fd4c.f6d7e16d", NewKongRouteNameForUDPRouteRule(udpRoute, cp, parentRef, udpRule))
+	assert.Equal(t, "udp.default-udp-route.cp1fbfa93f.f6d7e16d", NewKongRouteNameForUDPRouteRule(udpRoute, cp, nil, udpRule))
+
+	httpRoute := testRoute("default", "http-route")
+	matchType := gatewayv1.PathMatchPathPrefix
+	match := gatewayv1.HTTPRouteMatch{Path: &gatewayv1.HTTPPathMatch{Type: &matchType, Value: new("/foo")}}
+	assert.Equal(t, "http.default-http-route.cp1fbfa93f.pr4557fd4c.5cff32e8.m02", NewKongRouteNameForMatch(httpRoute, cp, parentRef, match, 2))
+
+	grpcRoute := testGRPCRoute("default", "grpc-route")
+	gmatch := gatewayv1.GRPCRouteMatch{Method: &gatewayv1.GRPCMethodMatch{Service: new("svc.Echo")}}
+	assert.Equal(t, "grpc.default-grpc-route.cp1fbfa93f.pr4557fd4c.a7d8418e.r01.m03", NewKongRouteNameForGRPCRouteMatch(grpcRoute, cp, parentRef, gmatch, 1, 3))
+}
+
 func TestNewKongCertificateName_Generated(t *testing.T) {
 	tests := []struct {
 		name         string

--- a/controller/hybridgateway/namegen/name_test.go
+++ b/controller/hybridgateway/namegen/name_test.go
@@ -1255,12 +1255,12 @@ func TestNameGenerationConsistency(t *testing.T) {
 }
 
 // TestRefactorGoldenNames locks in name strings captured from the pre-refactor implementation
-// of NewKongUpstreamNameFor{HTTP,TLS,TCP,UDP}RouteRule, NewKongServiceNameFor{HTTP,TLS,TCP,UDP}RouteRule,
-// NewKongRouteNameFor{TLS,TCP,UDP}RouteRule, NewKongRouteNameForMatch, and
-// NewKongRouteNameForGRPCRouteMatch, so that introducing the shared serviceLikeName/
-// kongRouteName helpers cannot silently rename existing Kong objects. The HTTPRoute cases cover
-// basic, multi-backend, zero-backend (fallback identity), and backendRequest-timeout-fold hashing,
-// since those are the paths unique to HTTPRoute's hashElementsForServiceLikeName wiring.
+// of NewKongUpstreamNameFor{HTTP,GRPC,TLS,TCP,UDP}RouteRule, NewKongServiceNameFor{HTTP,GRPC,TLS,TCP,UDP}RouteRule,
+// NewKongServiceNameFor{HTTP,GRPC}RouteRuleBackendNotFound, NewKongRouteNameFor{TLS,TCP,UDP}RouteRule,
+// NewKongRouteNameForMatch, and NewKongRouteNameForGRPCRouteMatch, so that introducing the shared
+// serviceLikeName/kongRouteName helpers cannot silently rename existing Kong objects. The HTTPRoute
+// cases cover basic, multi-backend, zero-backend (fallback identity), and backendRequest-timeout-fold
+// hashing, since those are the paths unique to HTTPRoute's hashElementsForServiceLikeName wiring.
 func TestRefactorGoldenNames(t *testing.T) {
 	cp := testControlPlaneRef("test-cp")
 	port := gwtypes.PortNumber(443)
@@ -1301,6 +1301,24 @@ func TestRefactorGoldenNames(t *testing.T) {
 	}
 	assert.Equal(t, "http.default-http-backend-8080.1.cp1fbfa93f.ea93d3e7", NewKongUpstreamNameForHTTPRouteRule(httpRouteForServiceLike, cp, timeoutRule))
 	assert.Equal(t, "http.default-http-backend-8080.1.cp1fbfa93f.ea93d3e7", NewKongServiceNameForHTTPRouteRule(httpRouteForServiceLike, cp, timeoutRule))
+
+	assert.Equal(t, "http.default-http-backend-8080.1.cp1fbfa93f.bnfa610931f.29652d0c", NewKongServiceNameForHTTPRouteRuleBackendNotFound(httpRouteForServiceLike, cp, basicRule))
+
+	grpcBackendRef := func(name string) gatewayv1.GRPCBackendRef {
+		return gatewayv1.GRPCBackendRef{
+			BackendRef: gatewayv1.BackendRef{
+				BackendObjectReference: gatewayv1.BackendObjectReference{
+					Name: gatewayv1.ObjectName(name),
+					Port: new(gatewayv1.PortNumber(8080)),
+				},
+			},
+		}
+	}
+	grpcRouteForServiceLike := &gwtypes.GRPCRoute{ObjectMeta: metav1.ObjectMeta{Name: "grpc-route", Namespace: "default"}}
+	grpcBasicRule := gatewayv1.GRPCRouteRule{BackendRefs: []gatewayv1.GRPCBackendRef{grpcBackendRef("grpc-backend")}}
+	assert.Equal(t, "grpc.default-grpc-backend-8080.1.cp1fbfa93f.b6d9a138", NewKongUpstreamNameForGRPCRouteRule(grpcRouteForServiceLike, cp, grpcBasicRule))
+	assert.Equal(t, "grpc.default-grpc-backend-8080.1.cp1fbfa93f.b6d9a138", NewKongServiceNameForGRPCRouteRule(grpcRouteForServiceLike, cp, grpcBasicRule))
+	assert.Equal(t, "grpc.default-grpc-backend-8080.1.cp1fbfa93f.bnf3748ad33.b6d9a138", NewKongServiceNameForGRPCRouteRuleBackendNotFound(grpcRouteForServiceLike, cp, grpcBasicRule))
 
 	tlsRoute := &gwtypes.TLSRoute{ObjectMeta: metav1.ObjectMeta{Name: "tls-route", Namespace: "default"}}
 	tlsRule := gwtypes.TLSRouteRule{BackendRefs: []gwtypes.BackendRef{{


### PR DESCRIPTION
**What this PR does / why we need it**:

Refactors hybridgateway Kong object name generation to remove duplicated name-building logic while preserving the existing generated names.

The change introduces shared helpers for:

- KongService/KongUpstream service-like names
- KongRoute names across HTTP, GRPC, TLS, TCP, and UDP routes
- Simple backend-ref hash suffix generation for TLS/TCP/UDP route rules

To guard against accidental renames, this PR adds `TestRefactorGoldenNames`, which locks in representative names captured from the pre-refactor implementation, including:

- HTTPRoute service/upstream names with single backend, multiple backends, zero backends, and backendRequest timeout hashing
- TLS/TCP/UDP service/upstream names
- TLS/TCP/UDP KongRoute names with and without ParentRef
- HTTPRoute and GRPCRoute match-based KongRoute names

**Which issue this PR fixes**

Fixes #5103 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
