### PR TITLE
fix: fix DataPlaneMetricsExtension error not being returned and requeued

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,15 @@
   the behavior that already applied to every other Konnect entity.
   [#5207](https://github.com/Kong/kong-operator/pull/5207)
 
+### Fixes
+
+- DataPlaneMetricsExtension: the reconciler now returns an error (and gets
+  requeued with backoff) when it fails to create, update or delete the
+  Prometheus `KongPlugin` for a Service, instead of logging and giving up.
+  Previously a single transient failure (e.g. a rejected admission webhook
+  call) left the Service without its `konghq.com/plugins` annotation
+  indefinitely, since nothing else would trigger another reconcile.
+
 ## [v2.3.0-rc.3]
 
 > Release date: 2026-08-06

--- a/controller/cpextensions/controller.go
+++ b/controller/cpextensions/controller.go
@@ -206,7 +206,7 @@ func (r *Reconciler) ensureDataPlaneMetricsExtensions(ctx context.Context, contr
 					client.ObjectKeyFromObject(&ext), svcNN, client.ObjectKeyFromObject(v),
 				)
 				logger.Error(err, "failed to ensure metrics extension", "extension", client.ObjectKeyFromObject(&ext))
-				return err
+				return errors.Join(append(errs, err)...)
 			}
 			svcToExt[svcNN] = &ext
 		}
@@ -214,7 +214,7 @@ func (r *Reconciler) ensureDataPlaneMetricsExtensions(ctx context.Context, contr
 
 	svcListWithManagedLabel, err := listServicesThatHavePluginsManagedByControlPlane(ctx, controlplane, r.Client)
 	if err != nil {
-		return err
+		return errors.Join(append(errs, err)...)
 	}
 
 	// Find all services with GatewayOperatorControlPlaneManagingPluginsLabel

--- a/controller/cpextensions/controller.go
+++ b/controller/cpextensions/controller.go
@@ -236,7 +236,7 @@ func (r *Reconciler) ensureDataPlaneMetricsExtensions(ctx context.Context, contr
 		}
 		ensureKongPluginsAnnotationIsUnsetForPrometheusPlugin(&svc, prometheusPluginName)
 		if err := r.Patch(ctx, &svc, client.MergeFrom(old)); err != nil {
-			errs = append(errs, fmt.Errorf("failed to Service %s: %w", client.ObjectKeyFromObject(&svc), err))
+			errs = append(errs, fmt.Errorf("failed to patch Service %s: %w", client.ObjectKeyFromObject(&svc), err))
 			continue
 		}
 

--- a/controller/cpextensions/controller.go
+++ b/controller/cpextensions/controller.go
@@ -2,6 +2,7 @@ package cpextensions
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"slices"
 	"strings"
@@ -176,10 +177,14 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 // ServiceSelector.MatchNames.
 func (r *Reconciler) ensureDataPlaneMetricsExtensions(ctx context.Context, controlplane *gwtypes.ControlPlane) error {
 	logger := log.GetLogger(ctx, "controlplane_dataplanemetrics_extension", r.LoggingMode)
+
+	var errs []error
+
 	extensions, err := extensions.GetAllDataPlaneMetricExtensionsForControlPlane(ctx, r.Client, controlplane)
 	// In case there is an error, we don't want to return early because we still want to perform the cleanup.
 	if err != nil {
 		log.Error(logger, err, "failed to get DataPlaneMetricsExtensions for ControlPlane", "controlplane")
+		errs = append(errs, err)
 	}
 
 	if len(extensions) > 0 {
@@ -231,7 +236,8 @@ func (r *Reconciler) ensureDataPlaneMetricsExtensions(ctx context.Context, contr
 		}
 		ensureKongPluginsAnnotationIsUnsetForPrometheusPlugin(&svc, prometheusPluginName)
 		if err := r.Patch(ctx, &svc, client.MergeFrom(old)); err != nil {
-			return fmt.Errorf("failed to Service %s: %w", client.ObjectKeyFromObject(&svc), err)
+			errs = append(errs, fmt.Errorf("failed to Service %s: %w", client.ObjectKeyFromObject(&svc), err))
+			continue
 		}
 
 		prometheusPlugin := configurationv1.KongPlugin{
@@ -240,8 +246,9 @@ func (r *Reconciler) ensureDataPlaneMetricsExtensions(ctx context.Context, contr
 				Namespace: svc.Namespace,
 			},
 		}
-		if err := r.Delete(ctx, &prometheusPlugin); err != nil {
-			return fmt.Errorf("failed to delete Prometheus KongPlugin for Service %s: %w", client.ObjectKeyFromObject(&svc), err)
+		if err := client.IgnoreNotFound(r.Delete(ctx, &prometheusPlugin)); err != nil {
+			errs = append(errs, fmt.Errorf("failed to delete Prometheus KongPlugin for Service %s: %w", client.ObjectKeyFromObject(&svc), err))
+			continue
 		}
 	}
 
@@ -251,12 +258,14 @@ func (r *Reconciler) ensureDataPlaneMetricsExtensions(ctx context.Context, contr
 		svc := corev1.Service{}
 		if err := r.Get(ctx, svcNN, &svc); err != nil {
 			logger.Error(err, "failed to get Service to enable metrics plugin on", "service", svcNN)
+			errs = append(errs, err)
 			continue
 		}
 
 		prometheusPlugin, err := r.ensurePrometheusPlugin(ctx, &svc, controlplane, ext)
 		if err != nil {
 			logger.Error(err, "failed to ensure Prometheus Plugin for Service", "service", svcNN)
+			errs = append(errs, err)
 			continue
 		}
 
@@ -270,10 +279,11 @@ func (r *Reconciler) ensureDataPlaneMetricsExtensions(ctx context.Context, contr
 		ensureKongPluginsAnnotationIsSetForPrometheusPlugin(&svc, prometheusPlugin)
 		if err := r.Patch(ctx, &svc, client.MergeFrom(old)); err != nil {
 			logger.Error(err, "failed to patch Service to enable metrics plugin on", "service", svcNN)
+			errs = append(errs, err)
 			continue
 		}
 	}
-	return err
+	return errors.Join(errs...)
 }
 
 func listServicesThatHavePluginsManagedByControlPlane(

--- a/controller/cpextensions/controller_test.go
+++ b/controller/cpextensions/controller_test.go
@@ -2,19 +2,24 @@ package cpextensions
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	commonv1alpha1 "github.com/kong/kong-operator/v2/api/common/v1alpha1"
+	configurationv1 "github.com/kong/kong-operator/v2/api/configuration/v1"
 	operatorv1alpha1 "github.com/kong/kong-operator/v2/api/gateway-operator/v1alpha1"
 	gwtypes "github.com/kong/kong-operator/v2/internal/types"
 	"github.com/kong/kong-operator/v2/modules/manager/scheme"
+	"github.com/kong/kong-operator/v2/pkg/consts"
 )
 
 type countingUpdateClient struct {
@@ -27,6 +32,28 @@ func (c *countingUpdateClient) Update(ctx context.Context, obj client.Object, op
 	c.updateCalls++
 	return c.Client.Update(ctx, obj, opts...)
 }
+
+// failingKongPluginCreateClient fails every Create() call for KongPlugin objects,
+// simulating e.g. a validating webhook rejecting the object.
+type failingKongPluginCreateClient struct {
+	client.Client
+
+	err error
+}
+
+func (c *failingKongPluginCreateClient) Create(ctx context.Context, obj client.Object, opts ...client.CreateOption) error {
+	if _, ok := obj.(*configurationv1.KongPlugin); ok {
+		return c.err
+	}
+	return c.Client.Create(ctx, obj, opts...)
+}
+
+// noopScraperNotifier is a no-op ScrapeUpdateNotifier for tests that don't
+// exercise the metrics scraper wiring.
+type noopScraperNotifier struct{}
+
+func (noopScraperNotifier) NotifyAdd(context.Context, *gwtypes.ControlPlane)   {}
+func (noopScraperNotifier) NotifyRemove(context.Context, types.NamespacedName) {}
 
 func TestEnsurePrometheusPlugin_DoesNotUpdateWhenPluginIsAlreadyUpToDate(t *testing.T) {
 	ctx := t.Context()
@@ -134,4 +161,126 @@ func TestEnsurePrometheusPlugin_UpdatesWhenPluginDiffers(t *testing.T) {
 	expectedPlugin, err := prometheusPluginForSvc(svc, cp, newExt)
 	require.NoError(t, err)
 	require.Equal(t, string(expectedPlugin.Config.Raw), string(updatedPlugin.Config.Raw))
+}
+
+// TestReconcile_ReturnsErrorWhenPluginCreateFails guards against a regression
+// where a failed KongPlugin creation (e.g. rejected by a validating webhook)
+// was silently swallowed: the reconciler logged the error and returned nil,
+// so controller-runtime never requeued and the Service was left without its
+// plugin annotation indefinitely.
+func TestReconcile_ReturnsErrorWhenPluginCreateFails(t *testing.T) {
+	ctx := t.Context()
+	testScheme := scheme.Get()
+
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc",
+			Namespace: "default",
+		},
+	}
+	ext := &operatorv1alpha1.DataPlaneMetricsExtension{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "metrics-ext",
+			Namespace: "default",
+		},
+		Spec: operatorv1alpha1.DataPlaneMetricsExtensionSpec{
+			ServiceSelector: operatorv1alpha1.ServiceSelector{
+				MatchNames: []operatorv1alpha1.ServiceSelectorEntry{{Name: svc.Name}},
+			},
+			Config: operatorv1alpha1.MetricsConfig{Latency: true},
+		},
+	}
+	cp := &gwtypes.ControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cp",
+			Namespace: "default",
+			UID:       types.UID("cp-uid"),
+		},
+		Spec: gwtypes.ControlPlaneSpec{
+			Extensions: []commonv1alpha1.ExtensionRef{
+				{
+					Group: operatorv1alpha1.SchemeGroupVersion.Group,
+					Kind:  operatorv1alpha1.DataPlaneMetricsExtensionKind,
+					NamespacedRef: commonv1alpha1.NamespacedRef{
+						Name: ext.Name,
+					},
+				},
+			},
+		},
+	}
+
+	baseClient := fakectrlruntimeclient.NewClientBuilder().
+		WithScheme(testScheme).
+		WithObjects(cp, svc, ext).
+		Build()
+	injectedErr := errors.New("admission webhook denied the request")
+	wrappedClient := &failingKongPluginCreateClient{Client: baseClient, err: injectedErr}
+
+	r := &Reconciler{
+		Client:                          wrappedClient,
+		DataPlaneScraperManagerNotifier: noopScraperNotifier{},
+	}
+
+	_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(cp)})
+	require.Error(t, err)
+	require.ErrorIs(t, err, injectedErr)
+
+	var gotSvc corev1.Service
+	require.NoError(t, baseClient.Get(ctx, client.ObjectKeyFromObject(svc), &gotSvc))
+	_, ok := gotSvc.Annotations[consts.KongIngressControllerPluginsAnnotation]
+	require.False(t, ok, "Service should not be annotated when plugin creation failed")
+}
+
+// TestReconcile_IgnoresNotFoundOnPluginDelete guards against a regression
+// where cleaning up a Service that's no longer selected by any extension
+// would fail forever if its Prometheus KongPlugin was already gone (e.g.
+// deleted by a previous reconcile or manually): r.Delete returned NotFound,
+// which was treated as a real error.
+func TestReconcile_IgnoresNotFoundOnPluginDelete(t *testing.T) {
+	ctx := t.Context()
+	testScheme := scheme.Get()
+
+	cp := &gwtypes.ControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cp",
+			Namespace: "default",
+			UID:       types.UID("cp-uid"),
+		},
+		// No extensions: this Service is no longer selected by anything.
+	}
+	svc := &corev1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "svc",
+			Namespace: "default",
+			Labels: map[string]string{
+				GatewayOperatorControlPlaneNameManagingPluginsLabel:      cp.Name,
+				GatewayOperatorControlPlaneNamespaceManagingPluginsLabel: cp.Namespace,
+			},
+			Annotations: map[string]string{
+				consts.KongIngressControllerPluginsAnnotation: "svc-metrics-prometheus",
+			},
+		},
+	}
+	// Note: no KongPlugin object exists in the fake client, so r.Delete()
+	// will return a NotFound error.
+
+	baseClient := fakectrlruntimeclient.NewClientBuilder().
+		WithScheme(testScheme).
+		WithObjects(cp, svc).
+		Build()
+
+	r := &Reconciler{
+		Client:                          baseClient,
+		DataPlaneScraperManagerNotifier: noopScraperNotifier{},
+	}
+
+	_, err := r.Reconcile(ctx, ctrl.Request{NamespacedName: client.ObjectKeyFromObject(cp)})
+	require.NoError(t, err)
+
+	var gotSvc corev1.Service
+	require.NoError(t, baseClient.Get(ctx, client.ObjectKeyFromObject(svc), &gotSvc))
+	_, hasLabel := gotSvc.Labels[GatewayOperatorControlPlaneNameManagingPluginsLabel]
+	require.False(t, hasLabel, "managing-plugins label should be cleared")
+	_, hasAnnotation := gotSvc.Annotations[consts.KongIngressControllerPluginsAnnotation]
+	require.False(t, hasAnnotation, "plugins annotation should be cleared")
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix errors which were causing failures in `TestControlPlaneExtensionsDataPlaneMetrics/verify_Prometheus_plugin_is_re-created_and_Service_gets_konghq.com/plugins_annotation_set_again_equal_to_created_Plugins's_name` e.g. in https://github.com/Kong/kong-operator/actions/runs/31209788038/job/92969692779?pr=5209

```
2026-08-07T19:18:12.4692080Z     controlplane_extensions_dataplanemetrics_test.go:272: 
2026-08-07T19:18:12.4694315Z         	Error Trace:	/home/runner/work/kong-operator/kong-operator/test/integration/ko/controlplane_extensions_dataplanemetrics_test.go:272
2026-08-07T19:18:12.4695824Z         	Error:      	Condition never satisfied
2026-08-07T19:18:12.4697877Z         	Test:       	TestControlPlaneExtensionsDataPlaneMetrics/verify_Prometheus_plugin_is_re-created_and_Service_gets_konghq.com/plugins_annotation_set_again_equal_to_created_Plugins's_name
2026-08-07T19:18:12.4699947Z --- FAIL: TestControlPlaneExtensionsDataPlaneMetrics/verify_Prometheus_plugin_is_re-created_and_Service_gets_konghq.com/plugins_annotation_set_again_equal_to_created_Plugins's_name (180.01s)
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
