### PR TITLE
chore: remove copying `.git` dir during image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,6 @@ COPY pkg/ pkg/
 COPY api/ api/
 COPY internal/ internal/
 COPY Makefile Makefile
-COPY .git/ .git/
 
 ARG TARGETPLATFORM
 ARG TARGETOS

--- a/debug.Dockerfile
+++ b/debug.Dockerfile
@@ -54,7 +54,6 @@ COPY pkg/ pkg/
 COPY api/ api/
 COPY internal/ internal/
 COPY Makefile Makefile
-COPY .git/ .git/
 
 # Use cache mounts to cache Go dependencies and bind mounts to avoid unnecessary
 # layers when using COPY instructions for go.mod and go.sum.


### PR DESCRIPTION
**What this PR does / why we need it**:

All needed git related metadata is set in `Makefile` running from this branch `make docker.build` looks like

```
TAG=v2.3.0-rc.3-17-g4483f3097 TARGET=distroless /Library/Developer/CommandLineTools/usr/bin/make _docker.build
docker build -t docker.io/kong/kong-operator:v2.3.0-rc.3-17-g4483f3097 \
                --target distroless \
                --build-arg GOPATH=/Users/jakub.warczarek@konghq.com/go \
                --build-arg GOCACHE=/Users/jakub.warczarek@konghq.com/Library/Caches/go-build \
                --build-arg TAG=v2.3.0-rc.3-17-g4483f3097 \
                --build-arg COMMIT=4483f3097 \
                --build-arg REPO_INFO=git@github.com:Kong/gateway-operator.git \
                 \
                .
```

thus it seems that copying `.git` to the build context is a blast from the past and can be safely removed.
