### PR TITLE
test/e2e: add chainsaw coverage for AIGatewayModel route-model selectors

### DIFF
--- a/test/e2e/chainsaw/aigateway/model-route-selectors/01-assert-programmed.yaml
+++ b/test/e2e/chainsaw/aigateway/model-route-selectors/01-assert-programmed.yaml
@@ -1,0 +1,39 @@
+apiVersion: konnect.konghq.com/v1alpha1
+kind: AIGatewayModelProvider
+metadata:
+  name: openai-provider
+  namespace: ($namespace)
+status:
+  (conditions[?type == 'Programmed']):
+    - status: 'True'
+  (id != null): true
+---
+apiVersion: konnect.konghq.com/v1alpha1
+kind: AIGatewayModel
+metadata:
+  name: model-headers-selector
+  namespace: ($namespace)
+status:
+  (conditions[?type == 'Programmed']):
+    - status: 'True'
+  (id != null): true
+---
+apiVersion: konnect.konghq.com/v1alpha1
+kind: AIGatewayModel
+metadata:
+  name: model-body-selector
+  namespace: ($namespace)
+status:
+  (conditions[?type == 'Programmed']):
+    - status: 'True'
+  (id != null): true
+---
+apiVersion: konnect.konghq.com/v1alpha1
+kind: AIGatewayModel
+metadata:
+  name: model-path-selector
+  namespace: ($namespace)
+status:
+  (conditions[?type == 'Programmed']):
+    - status: 'True'
+  (id != null): true

--- a/test/e2e/chainsaw/aigateway/model-route-selectors/01-provider-and-models.yaml
+++ b/test/e2e/chainsaw/aigateway/model-route-selectors/01-provider-and-models.yaml
@@ -1,0 +1,155 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openai-provider-credentials
+  namespace: ($namespace)
+  labels:
+    konghq.com/secret: "true"
+type: Opaque
+stringData:
+  apikey: test-ai-gateway-key
+---
+apiVersion: konnect.konghq.com/v1alpha1
+kind: AIGatewayModelProvider
+metadata:
+  name: openai-provider
+  namespace: ($namespace)
+spec:
+  aiGatewayRef:
+    type: namespacedRef
+    namespacedRef:
+      name: ($aigw_cp_name)
+  apiSpec:
+    type: openai
+    openai:
+      name: openai-provider
+      displayName: OpenAI (mock)
+      config:
+        auth:
+          headers:
+            - name: apikey
+              value:
+                type: secretRef
+                secretRef:
+                  name: openai-provider-credentials
+                  key: apikey
+---
+# headers selector: reused for the negative/non-matching-alias case.
+apiVersion: konnect.konghq.com/v1alpha1
+kind: AIGatewayModel
+metadata:
+  name: model-headers-selector
+  namespace: ($namespace)
+spec:
+  aiGatewayRef:
+    type: namespacedRef
+    namespacedRef:
+      name: ($aigw_cp_name)
+  apiSpec:
+    type: model
+    model:
+      name: model-headers-selector
+      displayName: Model routed via headers selector
+      enabled: Enabled
+      formats:
+        - type: openai
+      capabilities:
+        - generate
+      config:
+        model:
+          nameHeader: Enabled
+        route:
+          model:
+            headerParam: X-Kong-LLM-Model
+            values:
+              - qwen2.5:0.5b
+          paths:
+            - /model-route/headers/chat
+      targets:
+        - name: qwen2.5:0.5b
+          provider:
+            name: openai-provider
+          config:
+            type: openai
+            openai:
+              upstreamURL: http://kong-mock.kong-aigateway-mock.svc.cluster.local:8000/provider-a
+---
+# body selector: routes on the "model" property of the JSON request body.
+apiVersion: konnect.konghq.com/v1alpha1
+kind: AIGatewayModel
+metadata:
+  name: model-body-selector
+  namespace: ($namespace)
+spec:
+  aiGatewayRef:
+    type: namespacedRef
+    namespacedRef:
+      name: ($aigw_cp_name)
+  apiSpec:
+    type: model
+    model:
+      name: model-body-selector
+      displayName: Model routed via body selector
+      enabled: Enabled
+      formats:
+        - type: openai
+      capabilities:
+        - generate
+      config:
+        model:
+          nameHeader: Enabled
+        route:
+          model:
+            bodyParam: model
+            values:
+              - gemma3:270m
+          paths:
+            - /model-route/body/chat
+      targets:
+        - name: gemma3:270m
+          provider:
+            name: openai-provider
+          config:
+            type: openai
+            openai:
+              upstreamURL: http://kong-mock.kong-aigateway-mock.svc.cluster.local:8000/provider-a
+---
+# path selector: routes on a named capture group within the route's path regex.
+apiVersion: konnect.konghq.com/v1alpha1
+kind: AIGatewayModel
+metadata:
+  name: model-path-selector
+  namespace: ($namespace)
+spec:
+  aiGatewayRef:
+    type: namespacedRef
+    namespacedRef:
+      name: ($aigw_cp_name)
+  apiSpec:
+    type: model
+    model:
+      name: model-path-selector
+      displayName: Model routed via path selector
+      enabled: Enabled
+      formats:
+        - type: openai
+      capabilities:
+        - generate
+      config:
+        model:
+          nameHeader: Enabled
+        route:
+          model:
+            pathParam: model_name
+            values:
+              - qwen2.5:0.5b
+          paths:
+            - ~/model-route/path/(?<model_name>[^/]+)/chat
+      targets:
+        - name: qwen2.5:0.5b
+          provider:
+            name: openai-provider
+          config:
+            type: openai
+            openai:
+              upstreamURL: http://kong-mock.kong-aigateway-mock.svc.cluster.local:8000/provider-a

--- a/test/e2e/chainsaw/aigateway/model-route-selectors/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/aigateway/model-route-selectors/chainsaw-test.yaml
@@ -1,0 +1,171 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: aigateway-model-route-selectors
+spec:
+  description: |
+    AIGatewayModel route selectors. Stands up a Konnect AIGateway
+    control plane, a shared OpenAI-compatible provider, and three AIGatewayModel
+    resources - one per `config.route.model` selector type (headers, body, path) -
+    then drives real chat-completions traffic to verify each selector type routes
+    requests to the correct target based on its configured alias `values`, and
+    that a non-matching alias is consistently rejected.
+  bindings:
+    - name: test_name
+      value: ($namespace)
+    - name: konnect_token
+      value: (env('KONNECT_TOKEN'))
+    - name: konnect_url
+      value: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
+    - name: auth_secret_name
+      value: (join('-', [($test_name), 'konnect-auth-secret']))
+    - name: auth_secret_namespace
+      value: ($namespace)
+    - name: konnect_auth_name
+      value: (join('-', [($test_name), 'konnect-api-auth']))
+    - name: konnect_auth_namespace
+      value: ($namespace)
+    - name: aigw_cp_name
+      value: (join('-', [($test_name), 'cp']))
+    - name: aigw_cp_namespace
+      value: ($namespace)
+    - name: aigw_dp_name
+      value: (join('-', [($test_name), 'dp']))
+    - name: aigw_dp_image
+      value: (env('AIGW_DP_IMAGE'))
+  steps:
+    - name: 1-Create-auth-secret
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAuthSecret.yaml
+    - name: 2-Create-konnect-api-auth
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration-secretref.yaml
+    - name: 3-Create-konnect-aigateway
+      bindings:
+        - name: auth_name
+          value: ($konnect_auth_name)
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAIGateway.yaml
+    - name: 4-Create-provider-and-models
+      description: |
+        Create a shared provider and three AIGatewayModel resources, one per
+        `config.route.model` selector type (headers, body, path).
+      try:
+        - apply:
+            file: 01-provider-and-models.yaml
+        - assert:
+            file: 01-assert-programmed.yaml
+    - name: 5-Create-aigateway-dataplane
+      bindings:
+        - name: namespace
+          value: ($namespace)
+      use:
+        template: ../../common/_step_templates/apply-assert-aigatewayDataPlane.yaml
+    - name: 6-Verify-headers-selector-routes-matching-alias
+      description: A request carrying the configured header alias is routed to the model.
+      try:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+              - name: DP_SVC
+                value: (join('', [($aigw_dp_name), '-ingress']))
+              - name: ROUTE_PATH
+                value: /model-route/headers/chat
+              - name: MODEL_ALIAS
+                value: qwen2.5:0.5b
+            content: |
+              bash ../../common/scripts/aigw_chat_completion.sh
+    - name: 7-Verify-headers-selector-rejects-non-matching-alias
+      description: A request carrying an alias absent from the selector's `values` never resolves to the model.
+      try:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+              - name: DP_SVC
+                value: (join('', [($aigw_dp_name), '-ingress']))
+              - name: ROUTE_PATH
+                value: /model-route/headers/chat
+              - name: MODEL_ALIAS
+                value: headers-alias-wrong
+              - name: EXPECT_SUCCESS
+                value: 'false'
+            content: |
+              bash ../../common/scripts/aigw_chat_completion.sh
+    - name: 8-Verify-body-selector-routes-matching-alias
+      description: A request carrying the configured body property alias is routed to the model.
+      try:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+              - name: DP_SVC
+                value: (join('', [($aigw_dp_name), '-ingress']))
+              - name: ROUTE_PATH
+                value: /model-route/body/chat
+              - name: MODEL_ALIAS
+                value: gemma3:270m
+            content: |
+              bash ../../common/scripts/aigw_chat_completion.sh
+    - name: 9-Verify-path-selector-routes-matching-alias
+      description: A request whose path segment matches the selector's `values` is routed to the model.
+      try:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+              - name: DP_SVC
+                value: (join('', [($aigw_dp_name), '-ingress']))
+              - name: ROUTE_PATH
+                value: /model-route/path/qwen2.5:0.5b/chat
+              - name: MODEL_ALIAS
+                value: qwen2.5:0.5b
+            content: |
+              bash ../../common/scripts/aigw_chat_completion.sh
+    - name: 10-Verify-body-selector-rejects-non-matching-alias
+      description: A request carrying a body property alias absent from the selector's `values` never resolves to the model.
+      try:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+              - name: DP_SVC
+                value: (join('', [($aigw_dp_name), '-ingress']))
+              - name: ROUTE_PATH
+                value: /model-route/body/chat
+              - name: MODEL_ALIAS
+                value: body-alias-wrong
+              - name: EXPECT_SUCCESS
+                value: 'false'
+            content: |
+              bash ../../common/scripts/aigw_chat_completion.sh
+    - name: 11-Verify-path-selector-rejects-non-matching-alias
+      description: A request whose path segment is absent from the selector's `values` never resolves to the model.
+      try:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+              - name: DP_SVC
+                value: (join('', [($aigw_dp_name), '-ingress']))
+              - name: ROUTE_PATH
+                value: /model-route/path/path-alias-wrong/chat
+              - name: MODEL_ALIAS
+                value: path-alias-wrong
+              - name: EXPECT_SUCCESS
+                value: 'false'
+            content: |
+              bash ../../common/scripts/aigw_chat_completion.sh
+  catch:
+    - description: Capture debug snapshot on test failure.
+      script:
+        env:
+          - name: TEST_NAME
+            value: aigateway-model-route-selectors
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: OPERATOR_NAMESPACE
+            value: kong-system
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh

--- a/test/e2e/chainsaw/common/scripts/aigw_chat_completion.sh
+++ b/test/e2e/chainsaw/common/scripts/aigw_chat_completion.sh
@@ -15,6 +15,16 @@
 # Optional env:
 #   EXPECT_HEADER Response header proving AI Gateway processed the request.
 #                 Default: X-Kong-LLM-Model.
+#   EXPECT_SUCCESS
+#                 "true" (default): succeed once a 200 with EXPECT_HEADER is seen.
+#                 "false": the alias is expected to NOT resolve to a model
+#                 (e.g. a value absent from the selector's `values`). Succeeds
+#                 once REJECT_CONFIRMATIONS consecutive attempts fail to
+#                 produce a 200-with-header, guarding against a transient
+#                 blip while the route is still propagating.
+#   REJECT_CONFIRMATIONS
+#                 Consecutive non-matches required when EXPECT_SUCCESS=false.
+#                 Default: 3.
 #   PORT          Ingress Service port. Default: 443.
 #   CURL_IMAGE    Image for the in-cluster curl Pod. Default: curlimages/curl:latest.
 #   MAX_RETRIES   Retry attempts. Default: 60.
@@ -28,6 +38,8 @@ DP_SVC="${DP_SVC}"
 ROUTE_PATH="${ROUTE_PATH}"
 MODEL_ALIAS="${MODEL_ALIAS}"
 EXPECT_HEADER="${EXPECT_HEADER:-X-Kong-LLM-Model}"
+EXPECT_SUCCESS="${EXPECT_SUCCESS:-true}"
+REJECT_CONFIRMATIONS="${REJECT_CONFIRMATIONS:-3}"
 PORT="${PORT:-443}"
 CURL_IMAGE="${CURL_IMAGE:-curlimages/curl:latest}"
 MAX_RETRIES="${MAX_RETRIES:-60}"
@@ -47,6 +59,7 @@ kubectl -n "${NAMESPACE}" run "${POD}" \
   --command -- sleep 3600 >/dev/null
 kubectl -n "${NAMESPACE}" wait --for=condition=Ready "pod/${POD}" --timeout=120s >/dev/null
 
+REJECTIONS=0
 for ATTEMPT in $(seq 1 "${MAX_RETRIES}"); do
   OUT="$(kubectl -n "${NAMESPACE}" exec "${POD}" -- sh -c \
     "curl -sk -m 60 -o /tmp/b -D /tmp/h -w '%{http_code}' -X POST '${URL}' \
@@ -58,14 +71,34 @@ for ATTEMPT in $(seq 1 "${MAX_RETRIES}"); do
     2>/dev/null || true)"
   CODE="$(printf '%s\n' "${OUT}" | sed -n '1p')"
   HDR="$(printf '%s\n' "${OUT}" | sed -n '2p')"
-  RESP_BODY="$(printf '%s\n' "${OUT}" | sed -n '3p')"
-  if [ "${CODE}" = "200" ] && [ -n "${HDR}" ]; then
-    echo "ok: status=${CODE} ${EXPECT_HEADER}=${HDR}"
-    exit 0
+  MATCHED=false
+  [ "${CODE}" = "200" ] && [ -n "${HDR}" ] && MATCHED=true
+
+  if [ "${EXPECT_SUCCESS}" = "false" ]; then
+    if [ "${MATCHED}" = "false" ]; then
+      REJECTIONS=$((REJECTIONS + 1))
+      echo "attempt ${ATTEMPT}/${MAX_RETRIES}: rejection ${REJECTIONS}/${REJECT_CONFIRMATIONS} (status='${CODE}')" >&2
+      if [ "${REJECTIONS}" -ge "${REJECT_CONFIRMATIONS}" ]; then
+        echo "ok: alias consistently unmatched (status='${CODE}')"
+        exit 0
+      fi
+    else
+      echo "attempt ${ATTEMPT}/${MAX_RETRIES}: alias unexpectedly matched (status='${CODE}' ${EXPECT_HEADER}=${HDR})" >&2
+      REJECTIONS=0
+    fi
+  else
+    if [ "${MATCHED}" = "true" ]; then
+      echo "ok: status=${CODE} ${EXPECT_HEADER}=${HDR}"
+      exit 0
+    fi
+    echo "attempt ${ATTEMPT}/${MAX_RETRIES}: status='${CODE}' header='${HDR}'" >&2
   fi
-  echo "attempt ${ATTEMPT}/${MAX_RETRIES}: status='${CODE}' header='${HDR}' body='${RESP_BODY}'" >&2
   sleep "${RETRY_DELAY}"
 done
 
-echo "FAILED: no 200 with ${EXPECT_HEADER} after ${MAX_RETRIES} attempts (last status='${CODE}' body='${RESP_BODY}')" >&2
+if [ "${EXPECT_SUCCESS}" = "false" ]; then
+  echo "FAILED: alias matched a model after ${MAX_RETRIES} attempts, expected it to stay unmatched" >&2
+else
+  echo "FAILED: no 200 with ${EXPECT_HEADER} after ${MAX_RETRIES} attempts (last status='${CODE}')" >&2
+fi
 exit 1


### PR DESCRIPTION


**What this PR does / why we need it**:

Add a new e2e suite (aigateway/model-route-selectors) covering the `headers`, `body`, and `path` selector types on AIGatewayModel's config.route.model. Provisions a shared provider and one AIGatewayModel per selector type, then drives real chat-completions traffic to verify each selector type routes requests to the correct target based on its configured alias values, and that a non-matching alias is rejected.

Extend the shared aigw_chat_completion.sh script to support this suite's traffic verification steps.

**Which issue this PR fixes**

Fixes #5216 

**Special notes for your reviewer**:
The `path` selector type is not supported by Konnect yet, so step 9 (Verify-path-selector-routes-matching-alias) is expected to fail until Konnect ships support for it. Kept in as real coverage rather than removed/skipped.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
