### PR TITLE
fix(konnect): don't enforce KongReferenceGrant while an entity is deleting

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -89,6 +89,11 @@
 
 ### Fixes
 
+- Konnect entities whose cross-namespace `controlPlaneRef` was permitted by a
+  `KongReferenceGrant` no longer get stuck during deletion when that grant is
+  removed first. The grant is now enforced only while the entity is not being
+  deleted, allowing its Konnect counterpart and cleanup finalizer to be removed.
+  [#5229](https://github.com/Kong/kong-operator/pull/5229)
 - DataPlaneMetricsExtension: the reconciler now returns an error (and gets
   requeued with backoff) when it fails to create, update or delete the
   Prometheus `KongPlugin` for a Service, instead of logging and giving up.

--- a/controller/konnect/reconciler_controlplaneref.go
+++ b/controller/konnect/reconciler_controlplaneref.go
@@ -181,6 +181,14 @@ func ensureKongReferenceGrant[
 	ent TEnt,
 	cpRef commonv1alpha1.ControlPlaneRef,
 ) (ctrl.Result, error) {
+	// While the entity is being deleted its Konnect counterpart has to be removed
+	// regardless of what the grants say. Blocking here would require every
+	// KongReferenceGrant to outlive the entities referencing through it, which
+	// would leave those entities stuck with their cleanup finalizer.
+	if !ent.GetDeletionTimestamp().IsZero() {
+		return ctrl.Result{}, nil
+	}
+
 	fromNamespace := ent.GetNamespace()
 	toNamespace := ""
 	if cpRef.KonnectNamespacedRef != nil {

--- a/test/envtest/konnect-api-gw/konnect_entities_kongservice_test.go
+++ b/test/envtest/konnect-api-gw/konnect_entities_kongservice_test.go
@@ -603,6 +603,79 @@ func TestKongService(t *testing.T) {
 		envtest.EventuallyAssertSDKExpectations(t, factory.SDK.ServicesSDK, consts.WaitTime, consts.TickTime)
 	})
 
+	t.Run("removing the KongReferenceGrant of a cross namespace ref does not block deletion", func(t *testing.T) {
+		const (
+			host = "grantless-delete.example.com"
+			id   = "service-grantless-delete"
+		)
+
+		w := envtest.SetupWatch[configurationv1alpha1.KongServiceList](t, ctx, cl2, client.InNamespace(ns2.Name))
+
+		t.Log("Setting up SDK expectations on Service creation")
+		sdk.ServicesSDK.EXPECT().
+			CreateService(
+				mock.Anything,
+				cp.GetKonnectID(),
+				mock.MatchedBy(func(req sdkkonnectcomp.Service) bool {
+					return req.Host == host
+				}),
+			).
+			Return(
+				&sdkkonnectops.CreateServiceResponse{
+					Service: &sdkkonnectcomp.ServiceOutput{
+						ID: new(id),
+					},
+				},
+				nil,
+			)
+
+		t.Log("Creating the KongReferenceGrant that permits the cross namespace ControlPlane ref")
+		grant := deploy.KongReferenceGrant(t, ctx, clientNamespaced,
+			deploy.KongReferenceGrantFroms(configurationv1alpha1.ReferenceGrantFrom{
+				Group:     configurationv1alpha1.Group(configurationv1alpha1.GroupVersion.Group),
+				Kind:      "KongService",
+				Namespace: configurationv1alpha1.Namespace(ns2.Name),
+			}),
+			deploy.KongReferenceGrantTos(configurationv1alpha1.ReferenceGrantTo{
+				Group: configurationv1alpha1.Group(konnectv1alpha1.GroupVersion.Group),
+				Kind:  "KonnectGatewayControlPlane",
+			}),
+		)
+
+		createdService := deploy.KongService(t, ctx, clientNamespaced2,
+			deploy.WithKonnectNamespacedRefControlPlaneRef(cp, ns.Name),
+			func(obj client.Object) {
+				s := obj.(*configurationv1alpha1.KongService)
+				s.Spec.Host = host
+			},
+		)
+
+		t.Log("Waiting for KongService to be programmed")
+		envtest.WatchFor(t, ctx, w, apiwatch.Modified, func(ks *configurationv1alpha1.KongService) bool {
+			return ks.GetName() == createdService.GetName() && k8sutils.IsProgrammed(ks)
+		}, "KongService didn't get Programmed")
+
+		envtest.EventuallyAssertSDKExpectations(t, factory.SDK.ServicesSDK, consts.WaitTime, consts.TickTime)
+
+		t.Log("Removing the KongReferenceGrant while the KongService still references the ControlPlane")
+		require.NoError(t, clientNamespaced.Delete(ctx, grant))
+
+		t.Log("Setting up SDK expectations on Service deletion")
+		sdk.ServicesSDK.EXPECT().
+			DeleteService(
+				mock.Anything,
+				cp.GetKonnectID(),
+				id,
+			).
+			Return(&sdkkonnectops.DeleteServiceResponse{}, nil)
+
+		t.Log("Deleting the KongService must still clean up Konnect and drop the finalizer")
+		require.NoError(t, clientNamespaced2.Delete(ctx, createdService))
+		eventually.WaitForObjectToNotExist(t, ctx, cl, createdService, consts.WaitTime, consts.TickTime)
+
+		envtest.EventuallyAssertSDKExpectations(t, factory.SDK.ServicesSDK, consts.WaitTime, consts.TickTime)
+	})
+
 	t.Run("network error on create sets Programmed condition to False", func(t *testing.T) {
 		const host = "network-error-test.com"
 


### PR DESCRIPTION

**What this PR does / why we need it**:

Removing a KongReferenceGrant that permitted a cross-namespace controlPlaneRef left every entity referencing through it stuck: the grant check ran before the deletion handling, so the Konnect counterpart was never removed and the cleanup finalizer never dropped. Skip the check while the entity is being deleted, as the secret and plugin ref handlers already do.

**Which issue this PR fixes**

Fixes https://github.com/Kong/kong-operator/issues/5228

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
