### PR TITLE
fix: fix routes become unaccepted and removed from dataplane when listener is transient unprogrammed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,9 @@
   Previously a single transient failure (e.g. a rejected admission webhook
   call) left the Service without its `konghq.com/plugins` annotation
   indefinitely, since nothing else would trigger another reconcile.
+- fix routes become unaccepted and removed from dataplane when listener is
+  transient unprogrammed
+  [#5237](https://github.com/Kong/kong-operator/pull/5237)
 
 ## [v2.3.0-rc.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,8 +107,8 @@
   Previously a single transient failure (e.g. a rejected admission webhook
   call) left the Service without its `konghq.com/plugins` annotation
   indefinitely, since nothing else would trigger another reconcile.
-- fix routes become unaccepted and removed from dataplane when listener is
-  transient unprogrammed
+- Fix Gateway API routes becoming transiently unaccepted and removed from dataplane
+  when listener is intermittently marked as Programmed=False.
   [#5237](https://github.com/Kong/kong-operator/pull/5237)
 
 ## [v2.3.0-rc.3]

--- a/ingress-controller/internal/controllers/gateway/grpcroute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/grpcroute_controller.go
@@ -329,7 +329,7 @@ func (r *GRPCRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// requeue the object and wait until all supported gateways are ready.
 	debug(log, grpcroute, "Checking if the grpcroute's gateways are ready")
 	for _, gateway := range gateways {
-		if !isGatewaySettledForRoute(gateway) {
+		if !isGatewayProgrammedSettledForRoute(gateway) {
 			debug(log, grpcroute, "Gateway for route was not ready, waiting")
 			return ctrl.Result{Requeue: true}, nil
 		}

--- a/ingress-controller/internal/controllers/gateway/grpcroute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/grpcroute_controller.go
@@ -329,7 +329,7 @@ func (r *GRPCRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// requeue the object and wait until all supported gateways are ready.
 	debug(log, grpcroute, "Checking if the grpcroute's gateways are ready")
 	for _, gateway := range gateways {
-		if !isGatewayProgrammedForRoute(gateway) {
+		if !isGatewaySettledForRoute(gateway) {
 			debug(log, grpcroute, "Gateway for route was not ready, waiting")
 			return ctrl.Result{Requeue: true}, nil
 		}

--- a/ingress-controller/internal/controllers/gateway/httproute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/httproute_controller.go
@@ -453,7 +453,7 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// requeue the object and wait until all supported gateways are ready.
 	debug(log, httproute, "Checking if the httproute's gateways are ready")
 	for _, gateway := range gateways {
-		if !isGatewayProgrammedForRoute(gateway) {
+		if !isGatewaySettledForRoute(gateway) {
 			debug(log, httproute, "Gateway for route was not ready, waiting")
 			return ctrl.Result{Requeue: true}, nil
 		}

--- a/ingress-controller/internal/controllers/gateway/httproute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/httproute_controller.go
@@ -453,7 +453,7 @@ func (r *HTTPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// requeue the object and wait until all supported gateways are ready.
 	debug(log, httproute, "Checking if the httproute's gateways are ready")
 	for _, gateway := range gateways {
-		if !isGatewaySettledForRoute(gateway) {
+		if !isGatewayProgrammedSettledForRoute(gateway) {
 			debug(log, httproute, "Gateway for route was not ready, waiting")
 			return ctrl.Result{Requeue: true}, nil
 		}

--- a/ingress-controller/internal/controllers/gateway/route_utils.go
+++ b/ingress-controller/internal/controllers/gateway/route_utils.go
@@ -259,7 +259,7 @@ func getSupportedGatewayForRoute[T gatewayapi.RouteT](
 			// route would attach to, regardless of whether it's Programmed yet. Record it
 			// here, before the Programmed check, so a transiently-not-yet-Programmed
 			// listener (e.g. while the Gateway controller re-renders listener status) still
-			// shows up in attachedListenerNames. isGatewayProgrammedForRoute relies on this
+			// shows up in attachedListenerNames. isGatewaySettledForRoute relies on this
 			// to tell "no listener could ever attach this route" (terminal) apart from "the
 			// right listener exists but isn't Programmed yet" (transient, should wait).
 			attachedListenerNames = append(attachedListenerNames, listener.Name)
@@ -615,28 +615,23 @@ func isGatewaySettledForRoute(gateway supportedGatewayWithCondition) bool {
 	}
 
 	generation := gateway.gateway.Generation
+	sawTransient := false
 	for _, listenerName := range gateway.attachedListenerNames {
-		// Any one attached listener being Programmed is enough to proceed - mirrors `isRouteAccepted.
+		// Any one attached listener being Programmed is enough to proceed - mirrors `isRouteAccepted`.
 		if err := listenerProgrammedInStatus(listenerName, gateway.gateway.Status.Listeners); err == nil {
 			return true
 		}
-
 		// A listener whose ResolvedRefs condition is explicitly False will never
-		// become Programmed until that reference is fixed.
-		if gatewayapi.ListenerResolvedRefsFalse(listenerName, generation, gateway.gateway.Status.Listeners) {
+		// become Programmed until that reference is fixed. The same holds for other
+		// listener validation failures with dedicated reasons.
+		if gatewayapi.ListenerResolvedRefsFalse(listenerName, generation, gateway.gateway.Status.Listeners) ||
+			gatewayapi.ListenerProgrammedFalseForSettledReason(listenerName, generation, gateway.gateway.Status.Listeners) {
 			continue
 		}
-
-		// Other listener validation failures with dedicated reasons.
-		if gatewayapi.ListenerProgrammedFalseForSettledReason(listenerName, generation, gateway.gateway.Status.Listeners) {
-			continue
-		}
-
-		// Transient not Programmed.
-		return false
+		// Transient not Programmed - keep looking for a Programmed sibling first.
+		sawTransient = true
 	}
-
-	return true
+	return !sawTransient
 }
 
 // isHTTPReferenceGranted checks that the backendRef referenced by the HTTPRoute is granted by a ReferenceGrant.

--- a/ingress-controller/internal/controllers/gateway/route_utils.go
+++ b/ingress-controller/internal/controllers/gateway/route_utils.go
@@ -619,6 +619,13 @@ func isGatewayProgrammedForRoute(gateway supportedGatewayWithCondition) bool {
 		if err := listenerProgrammedInStatus(listenerName, gateway.gateway.Status.Listeners); err == nil {
 			return true
 		}
+
+		// A listener whose ResolvedRefs condition is explicitly False will never become Programmed
+		// until that reference is fixed. That's not a transient NotProgrammed, so treat it as Programmed
+		// to avoid waiting forever.
+		if gatewayapi.ListenerResolvedRefsFalse(listenerName, gateway.gateway.Status.Listeners) {
+			return true
+		}
 	}
 
 	return false

--- a/ingress-controller/internal/controllers/gateway/route_utils.go
+++ b/ingress-controller/internal/controllers/gateway/route_utils.go
@@ -182,7 +182,6 @@ func getSupportedGatewayForRoute[T gatewayapi.RouteT](
 			allowedByAllowedRoutes  = false
 			allowedBySupportedKinds = false
 			allowedByListenerName   = false
-			listenerReady           = false
 
 			attachedListenerNames []gatewayapi.SectionName
 		)
@@ -273,7 +272,6 @@ func getSupportedGatewayForRoute[T gatewayapi.RouteT](
 				listenerLogger.V(logging.DebugLevel).Info("Listener is not ready", "reason", err.Error())
 				continue
 			}
-			listenerReady = true
 
 			matched = true
 		}
@@ -327,7 +325,8 @@ func getSupportedGatewayForRoute[T gatewayapi.RouteT](
 				// If ParentRef specified a Port but none of the listeners matched, the gateway Status
 				// Condition Accepted must be set to False with reason NoMatchingListenerPort
 				reason = gatewayapi.RouteReasonNoMatchingParent
-			case len(attachedListenerNames) > 0 && !listenerReady:
+			case len(attachedListenerNames) > 0:
+				// equals to listenerReady=false
 				reason = gatewayapi.RouteReasonNotAllowedByListeners
 			}
 
@@ -602,7 +601,7 @@ func isRouteAccepted(gateways []supportedGatewayWithCondition) bool {
 	return false
 }
 
-func isGatewayProgrammedForRoute(gateway supportedGatewayWithCondition) bool {
+func isGatewaySettledForRoute(gateway supportedGatewayWithCondition) bool {
 	if !isGatewayProgrammed(gateway.gateway) {
 		return false
 	}
@@ -615,20 +614,29 @@ func isGatewayProgrammedForRoute(gateway supportedGatewayWithCondition) bool {
 		return true
 	}
 
+	generation := gateway.gateway.Generation
 	for _, listenerName := range gateway.attachedListenerNames {
+		// Any one attached listener being Programmed is enough to proceed - mirrors `isRouteAccepted.
 		if err := listenerProgrammedInStatus(listenerName, gateway.gateway.Status.Listeners); err == nil {
 			return true
 		}
 
-		// A listener whose ResolvedRefs condition is explicitly False will never become Programmed
-		// until that reference is fixed. That's not a transient NotProgrammed, so treat it as Programmed
-		// to avoid waiting forever.
-		if gatewayapi.ListenerResolvedRefsFalse(listenerName, gateway.gateway.Status.Listeners) {
-			return true
+		// A listener whose ResolvedRefs condition is explicitly False will never
+		// become Programmed until that reference is fixed.
+		if gatewayapi.ListenerResolvedRefsFalse(listenerName, generation, gateway.gateway.Status.Listeners) {
+			continue
 		}
+
+		// Other listener validation failures with dedicated reasons.
+		if gatewayapi.ListenerProgrammedFalseForSettledReason(listenerName, generation, gateway.gateway.Status.Listeners) {
+			continue
+		}
+
+		// Transient not Programmed.
+		return false
 	}
 
-	return false
+	return true
 }
 
 // isHTTPReferenceGranted checks that the backendRef referenced by the HTTPRoute is granted by a ReferenceGrant.

--- a/ingress-controller/internal/controllers/gateway/route_utils.go
+++ b/ingress-controller/internal/controllers/gateway/route_utils.go
@@ -259,7 +259,7 @@ func getSupportedGatewayForRoute[T gatewayapi.RouteT](
 			// route would attach to, regardless of whether it's Programmed yet. Record it
 			// here, before the Programmed check, so a transiently-not-yet-Programmed
 			// listener (e.g. while the Gateway controller re-renders listener status) still
-			// shows up in attachedListenerNames. isGatewaySettledForRoute relies on this
+			// shows up in attachedListenerNames. isGatewayProgrammedSettledForRoute relies on this
 			// to tell "no listener could ever attach this route" (terminal) apart from "the
 			// right listener exists but isn't Programmed yet" (transient, should wait).
 			attachedListenerNames = append(attachedListenerNames, listener.Name)
@@ -601,7 +601,12 @@ func isRouteAccepted(gateways []supportedGatewayWithCondition) bool {
 	return false
 }
 
-func isGatewaySettledForRoute(gateway supportedGatewayWithCondition) bool {
+// isGatewayProgrammedSettledForRoute checks both programmed status of Gateway and its listeners,
+// settled means ready or permanently failed.
+// It returns false if it's intermittently failed, so that we should requeue and waiting.
+// And returns true if it's ready or permanently failed, then we should stop waiting and let
+// normal Accepted logic decide the terminal status.
+func isGatewayProgrammedSettledForRoute(gateway supportedGatewayWithCondition) bool {
 	if !isGatewayProgrammed(gateway.gateway) {
 		return false
 	}
@@ -615,7 +620,7 @@ func isGatewaySettledForRoute(gateway supportedGatewayWithCondition) bool {
 	}
 
 	generation := gateway.gateway.Generation
-	sawTransient := false
+	transientNotProgrammed := false
 	for _, listenerName := range gateway.attachedListenerNames {
 		// Any one attached listener being Programmed is enough to proceed - mirrors `isRouteAccepted`.
 		if err := listenerProgrammedInStatus(listenerName, gateway.gateway.Status.Listeners); err == nil {
@@ -629,9 +634,9 @@ func isGatewaySettledForRoute(gateway supportedGatewayWithCondition) bool {
 			continue
 		}
 		// Transient not Programmed - keep looking for a Programmed sibling first.
-		sawTransient = true
+		transientNotProgrammed = true
 	}
-	return !sawTransient
+	return !transientNotProgrammed
 }
 
 // isHTTPReferenceGranted checks that the backendRef referenced by the HTTPRoute is granted by a ReferenceGrant.

--- a/ingress-controller/internal/controllers/gateway/route_utils.go
+++ b/ingress-controller/internal/controllers/gateway/route_utils.go
@@ -210,13 +210,6 @@ func getSupportedGatewayForRoute[T gatewayapi.RouteT](
 				allowedBySupportedKinds = true
 			}
 
-			if err := listenerProgrammedInStatus(listener.Name, gateway.Status.Listeners); err != nil {
-				listenerLogger.V(logging.DebugLevel).Info("Listener is not ready", "reason", err.Error())
-				continue
-			} else {
-				listenerReady = true
-			}
-
 			// Check if listener name matches.
 			if parentRef.SectionName != nil {
 				if *parentRef.SectionName != "" && *parentRef.SectionName != listener.Name {
@@ -262,8 +255,27 @@ func getSupportedGatewayForRoute[T gatewayapi.RouteT](
 				continue
 			}
 
-			matched = true
+			// Every structural check (AllowedRoutes, SupportedKinds, SectionName, Port,
+			// protocol, hostname) has passed for this listener - it's the listener this
+			// route would attach to, regardless of whether it's Programmed yet. Record it
+			// here, before the Programmed check, so a transiently-not-yet-Programmed
+			// listener (e.g. while the Gateway controller re-renders listener status) still
+			// shows up in attachedListenerNames. isGatewayProgrammedForRoute relies on this
+			// to tell "no listener could ever attach this route" (terminal) apart from "the
+			// right listener exists but isn't Programmed yet" (transient, should wait).
 			attachedListenerNames = append(attachedListenerNames, listener.Name)
+
+			// Check listener readiness last: it must not gate any of the structural checks
+			// above, or a listener that structurally matches but is momentarily not
+			// Programmed would be indistinguishable, via attachedListenerNames, from a
+			// listener that never matched at all.
+			if err := listenerProgrammedInStatus(listener.Name, gateway.Status.Listeners); err != nil {
+				listenerLogger.V(logging.DebugLevel).Info("Listener is not ready", "reason", err.Error())
+				continue
+			}
+			listenerReady = true
+
+			matched = true
 		}
 
 		if matched {
@@ -307,8 +319,6 @@ func getSupportedGatewayForRoute[T gatewayapi.RouteT](
 				reason = gatewayapi.RouteReasonNoMatchingListenerHostname
 			case !allowedByAllowedRoutes || !allowedBySupportedKinds:
 				reason = gatewayapi.RouteReasonNotAllowedByListeners
-			case !listenerReady:
-				reason = gatewayapi.RouteReasonNotAllowedByListeners
 			case parentRef.SectionName != nil && !allowedByListenerName:
 				// If ParentRef specified listener names but none of the listeners matches the name,
 				// the gateway Status Condition Accepted must be set to False with reason RouteReasonNoMatchingParent.
@@ -317,6 +327,8 @@ func getSupportedGatewayForRoute[T gatewayapi.RouteT](
 				// If ParentRef specified a Port but none of the listeners matched, the gateway Status
 				// Condition Accepted must be set to False with reason NoMatchingListenerPort
 				reason = gatewayapi.RouteReasonNoMatchingParent
+			case len(attachedListenerNames) > 0 && !listenerReady:
+				reason = gatewayapi.RouteReasonNotAllowedByListeners
 			}
 
 			var listenerName string

--- a/ingress-controller/internal/controllers/gateway/route_utils_test.go
+++ b/ingress-controller/internal/controllers/gateway/route_utils_test.go
@@ -36,7 +36,7 @@ func init() {
 	}
 }
 
-func TestIsGatewaySettledForRoute(t *testing.T) {
+func TestIsGatewayProgrammedSettledForRoute(t *testing.T) {
 	udpListener := gatewayapi.Listener{
 		Name:     "udp",
 		Protocol: gatewayapi.UDPProtocolType,
@@ -276,7 +276,7 @@ func TestIsGatewaySettledForRoute(t *testing.T) {
 				listenerName:          tt.listener,
 				attachedListenerNames: tt.attachedListenerNames,
 			}
-			assert.Equal(t, tt.wantReady, isGatewaySettledForRoute(gateway))
+			assert.Equal(t, tt.wantReady, isGatewayProgrammedSettledForRoute(gateway))
 		})
 	}
 }

--- a/ingress-controller/internal/controllers/gateway/route_utils_test.go
+++ b/ingress-controller/internal/controllers/gateway/route_utils_test.go
@@ -155,6 +155,103 @@ func TestIsGatewayProgrammedForRoute(t *testing.T) {
 			attachedListenerNames: []gatewayapi.SectionName{"udp-attached"},
 			wantReady:             false,
 		},
+		{
+			name: "two attached listeners, one programmed and one still transiently pending proceeds via the programmed one",
+			gateway: programmedGatewayForRouteReadinessTest(
+				[]gatewayapi.Listener{
+					{Name: "udp-ready", Protocol: gatewayapi.UDPProtocolType, Port: 9999},
+					{Name: "udp-pending", Protocol: gatewayapi.UDPProtocolType, Port: 9998},
+				},
+				[]gatewayapi.ListenerStatus{
+					programmedListenerStatusForRouteReadinessTest("udp-ready", metav1.ConditionTrue),
+					programmedListenerStatusForRouteReadinessTest("udp-pending", metav1.ConditionFalse),
+				},
+			),
+			attachedListenerNames: []gatewayapi.SectionName{"udp-ready", "udp-pending"},
+			wantReady:             true,
+		},
+		{
+			name: "two attached listeners, one permanently broken and one still transiently pending waits for the pending one",
+			gateway: programmedGatewayForRouteReadinessTest(
+				[]gatewayapi.Listener{
+					{Name: "udp-broken", Protocol: gatewayapi.UDPProtocolType, Port: 9999},
+					{Name: "udp-pending", Protocol: gatewayapi.UDPProtocolType, Port: 9998},
+				},
+				[]gatewayapi.ListenerStatus{
+					{
+						Name: "udp-broken",
+						Conditions: []metav1.Condition{
+							{
+								Type:               string(gatewayapi.ListenerConditionResolvedRefs),
+								Status:             metav1.ConditionFalse,
+								ObservedGeneration: 1,
+								Reason:             string(gatewayapi.ListenerReasonInvalidCertificateRef),
+							},
+							{
+								Type:               string(gatewayapi.ListenerConditionProgrammed),
+								Status:             metav1.ConditionFalse,
+								ObservedGeneration: 1,
+								Reason:             "Pending",
+							},
+						},
+					},
+					programmedListenerStatusForRouteReadinessTest("udp-pending", metav1.ConditionFalse),
+				},
+			),
+			attachedListenerNames: []gatewayapi.SectionName{"udp-broken", "udp-pending"},
+			wantReady:             false,
+		},
+		{
+			name: "two attached listeners, one programmed and one permanently broken proceeds via the programmed one",
+			gateway: programmedGatewayForRouteReadinessTest(
+				[]gatewayapi.Listener{
+					{Name: "udp-ready", Protocol: gatewayapi.UDPProtocolType, Port: 9999},
+					{Name: "udp-broken", Protocol: gatewayapi.UDPProtocolType, Port: 9998},
+				},
+				[]gatewayapi.ListenerStatus{
+					programmedListenerStatusForRouteReadinessTest("udp-ready", metav1.ConditionTrue),
+					{
+						Name: "udp-broken",
+						Conditions: []metav1.Condition{
+							{
+								Type:               string(gatewayapi.ListenerConditionResolvedRefs),
+								Status:             metav1.ConditionFalse,
+								ObservedGeneration: 1,
+								Reason:             string(gatewayapi.ListenerReasonInvalidCertificateRef),
+							},
+							{
+								Type:               string(gatewayapi.ListenerConditionProgrammed),
+								Status:             metav1.ConditionFalse,
+								ObservedGeneration: 1,
+								Reason:             "Pending",
+							},
+						},
+					},
+				},
+			),
+			attachedListenerNames: []gatewayapi.SectionName{"udp-ready", "udp-broken"},
+			wantReady:             true,
+		},
+		{
+			name: "matching listener not programmed for a settled non-ResolvedRefs reason is not transient",
+			gateway: programmedGatewayForRouteReadinessTest(
+				[]gatewayapi.Listener{udpListener},
+				[]gatewayapi.ListenerStatus{{
+					Name: "udp",
+					Conditions: []metav1.Condition{
+						{
+							Type:               string(gatewayapi.ListenerConditionProgrammed),
+							Status:             metav1.ConditionFalse,
+							ObservedGeneration: 1,
+							Reason:             string(gatewayapi.ListenerReasonInvalid),
+						},
+					},
+				}},
+			),
+			listener:              "udp",
+			attachedListenerNames: []gatewayapi.SectionName{"udp"},
+			wantReady:             true,
+		},
 	}
 
 	for _, tt := range testCases {
@@ -164,7 +261,7 @@ func TestIsGatewayProgrammedForRoute(t *testing.T) {
 				listenerName:          tt.listener,
 				attachedListenerNames: tt.attachedListenerNames,
 			}
-			assert.Equal(t, tt.wantReady, isGatewayProgrammedForRoute(gateway))
+			assert.Equal(t, tt.wantReady, isGatewaySettledForRoute(gateway))
 		})
 	}
 }
@@ -194,13 +291,17 @@ func programmedListenerStatusForRouteReadinessTest(
 	name gatewayapi.SectionName,
 	conditionStatus metav1.ConditionStatus,
 ) gatewayapi.ListenerStatus {
+	reason := string(gatewayapi.ListenerReasonProgrammed)
+	if conditionStatus != metav1.ConditionTrue {
+		reason = string(gatewayapi.ListenerReasonPending)
+	}
 	return gatewayapi.ListenerStatus{
 		Name: name,
 		Conditions: []metav1.Condition{{
 			Type:               string(gatewayapi.ListenerConditionProgrammed),
 			Status:             conditionStatus,
 			ObservedGeneration: 1,
-			Reason:             string(gatewayapi.ListenerReasonProgrammed),
+			Reason:             reason,
 		}},
 	}
 }

--- a/ingress-controller/internal/controllers/gateway/route_utils_test.go
+++ b/ingress-controller/internal/controllers/gateway/route_utils_test.go
@@ -727,6 +727,32 @@ func TestGetSupportedGatewayForRoute(t *testing.T) {
 				},
 			},
 			{
+				// Regression test for https://github.com/Kong/kong-operator/issues/4507:
+				// the listener that the route would attach to structurally matches
+				// everything (AllowedRoutes, SupportedKinds, port, protocol, hostname) but
+				// is transiently not Programmed (e.g. while the Gateway controller
+				// re-renders listener status). attachedListenerNames must still contain it
+				// so isGatewayProgrammedForRoute can tell this apart from "no listener could
+				// ever attach" and wait, instead of writing a spurious Accepted=False.
+				name:  "basic HTTPRoute whose only matching listener is not yet Programmed stays in attachedListenerNames",
+				route: basicHTTPRoute(),
+				objects: []client.Object{
+					func() *gatewayapi.Gateway {
+						gw := gatewayWithHTTP80Ready()
+						gw.Status.Listeners[0].Conditions[0].Status = metav1.ConditionFalse
+						return gw
+					}(),
+					gatewayClass,
+					namespace,
+				},
+				expected: []expected{
+					{
+						condition:             routeConditionAccepted(metav1.ConditionFalse, gatewayapi.RouteReasonNotAllowedByListeners),
+						attachedListenerNames: []gatewayapi.SectionName{"http"},
+					},
+				},
+			},
+			{
 				name: "basic HTTPRoute specifying non-existing port does not get Accepted",
 				route: func() *gatewayapi.HTTPRoute {
 					r := basicHTTPRoute()

--- a/ingress-controller/internal/controllers/gateway/route_utils_test.go
+++ b/ingress-controller/internal/controllers/gateway/route_utils_test.go
@@ -117,6 +117,33 @@ func TestIsGatewayProgrammedForRoute(t *testing.T) {
 			wantReady:             false,
 		},
 		{
+			name: "matching listener not programmed because ResolvedRefs is permanently false is not transient",
+			gateway: programmedGatewayForRouteReadinessTest(
+				[]gatewayapi.Listener{udpListener},
+				[]gatewayapi.ListenerStatus{{
+					Name: "udp",
+					Conditions: []metav1.Condition{
+						{
+							Type:               string(gatewayapi.ListenerConditionResolvedRefs),
+							Status:             metav1.ConditionFalse,
+							ObservedGeneration: 1,
+							Reason:             string(gatewayapi.ListenerReasonInvalidCertificateRef),
+						},
+						{
+							Type:               string(gatewayapi.ListenerConditionProgrammed),
+							Status:             metav1.ConditionFalse,
+							ObservedGeneration: 1,
+							Reason:             "Pending",
+							Message:            "Listener references are not resolved yet.",
+						},
+					},
+				}},
+			),
+			listener:              "udp",
+			attachedListenerNames: []gatewayapi.SectionName{"udp"},
+			wantReady:             true,
+		},
+		{
 			name: "no section name ignores same protocol listener that did not attach",
 			gateway: programmedGatewayForRouteReadinessTest(
 				[]gatewayapi.Listener{

--- a/ingress-controller/internal/controllers/gateway/route_utils_test.go
+++ b/ingress-controller/internal/controllers/gateway/route_utils_test.go
@@ -36,7 +36,7 @@ func init() {
 	}
 }
 
-func TestIsGatewayProgrammedForRoute(t *testing.T) {
+func TestIsGatewaySettledForRoute(t *testing.T) {
 	udpListener := gatewayapi.Listener{
 		Name:     "udp",
 		Protocol: gatewayapi.UDPProtocolType,
@@ -168,6 +168,21 @@ func TestIsGatewayProgrammedForRoute(t *testing.T) {
 				},
 			),
 			attachedListenerNames: []gatewayapi.SectionName{"udp-ready", "udp-pending"},
+			wantReady:             true,
+		},
+		{
+			name: "two attached listeners, pending one first and programmed one second still proceeds",
+			gateway: programmedGatewayForRouteReadinessTest(
+				[]gatewayapi.Listener{
+					{Name: "udp-pending", Protocol: gatewayapi.UDPProtocolType, Port: 9998},
+					{Name: "udp-ready", Protocol: gatewayapi.UDPProtocolType, Port: 9999},
+				},
+				[]gatewayapi.ListenerStatus{
+					programmedListenerStatusForRouteReadinessTest("udp-pending", metav1.ConditionFalse),
+					programmedListenerStatusForRouteReadinessTest("udp-ready", metav1.ConditionTrue),
+				},
+			),
+			attachedListenerNames: []gatewayapi.SectionName{"udp-pending", "udp-ready"},
 			wantReady:             true,
 		},
 		{
@@ -855,13 +870,6 @@ func TestGetSupportedGatewayForRoute(t *testing.T) {
 				},
 			},
 			{
-				// Regression test for https://github.com/Kong/kong-operator/issues/4507:
-				// the listener that the route would attach to structurally matches
-				// everything (AllowedRoutes, SupportedKinds, port, protocol, hostname) but
-				// is transiently not Programmed (e.g. while the Gateway controller
-				// re-renders listener status). attachedListenerNames must still contain it
-				// so isGatewayProgrammedForRoute can tell this apart from "no listener could
-				// ever attach" and wait, instead of writing a spurious Accepted=False.
 				name:  "basic HTTPRoute whose only matching listener is not yet Programmed stays in attachedListenerNames",
 				route: basicHTTPRoute(),
 				objects: []client.Object{

--- a/ingress-controller/internal/controllers/gateway/tcproute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/tcproute_controller.go
@@ -401,7 +401,7 @@ func (r *TCPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// requeue the object and wait until all supported gateways are ready.
 	debug(log, tcproute, "Checking if the tcproute's gateways are ready")
 	for _, gateway := range gateways {
-		if !isGatewaySettledForRoute(gateway) {
+		if !isGatewayProgrammedSettledForRoute(gateway) {
 			debug(log, tcproute, "Gateway for route was not ready, waiting")
 			return ctrl.Result{Requeue: true}, nil
 		}

--- a/ingress-controller/internal/controllers/gateway/tcproute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/tcproute_controller.go
@@ -401,7 +401,7 @@ func (r *TCPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// requeue the object and wait until all supported gateways are ready.
 	debug(log, tcproute, "Checking if the tcproute's gateways are ready")
 	for _, gateway := range gateways {
-		if !isGatewayProgrammedForRoute(gateway) {
+		if !isGatewaySettledForRoute(gateway) {
 			debug(log, tcproute, "Gateway for route was not ready, waiting")
 			return ctrl.Result{Requeue: true}, nil
 		}

--- a/ingress-controller/internal/controllers/gateway/tlsroute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/tlsroute_controller.go
@@ -397,7 +397,7 @@ func (r *TLSRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// requeue the object and wait until all supported gateways are ready.
 	debug(log, tlsroute, "Checking if the tlsroute's gateways are ready")
 	for _, gateway := range gateways {
-		if !isGatewaySettledForRoute(gateway) {
+		if !isGatewayProgrammedSettledForRoute(gateway) {
 			debug(log, tlsroute, "Gateway for route was not ready, waiting")
 			return ctrl.Result{Requeue: true}, nil
 		}

--- a/ingress-controller/internal/controllers/gateway/tlsroute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/tlsroute_controller.go
@@ -397,7 +397,7 @@ func (r *TLSRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// requeue the object and wait until all supported gateways are ready.
 	debug(log, tlsroute, "Checking if the tlsroute's gateways are ready")
 	for _, gateway := range gateways {
-		if !isGatewayProgrammedForRoute(gateway) {
+		if !isGatewaySettledForRoute(gateway) {
 			debug(log, tlsroute, "Gateway for route was not ready, waiting")
 			return ctrl.Result{Requeue: true}, nil
 		}

--- a/ingress-controller/internal/controllers/gateway/udproute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/udproute_controller.go
@@ -402,7 +402,7 @@ func (r *UDPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// requeue the object and wait until all supported gateways are ready.
 	debug(log, udproute, "Checking if the udproute's gateways are ready")
 	for _, gateway := range gateways {
-		if !isGatewaySettledForRoute(gateway) {
+		if !isGatewayProgrammedSettledForRoute(gateway) {
 			debug(log, udproute, "Gateway for route was not ready, waiting")
 			return ctrl.Result{Requeue: true}, nil
 		}

--- a/ingress-controller/internal/controllers/gateway/udproute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/udproute_controller.go
@@ -402,7 +402,7 @@ func (r *UDPRouteReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	// requeue the object and wait until all supported gateways are ready.
 	debug(log, udproute, "Checking if the udproute's gateways are ready")
 	for _, gateway := range gateways {
-		if !isGatewayProgrammedForRoute(gateway) {
+		if !isGatewaySettledForRoute(gateway) {
 			debug(log, udproute, "Gateway for route was not ready, waiting")
 			return ctrl.Result{Requeue: true}, nil
 		}

--- a/ingress-controller/internal/gatewayapi/aliases.go
+++ b/ingress-controller/internal/gatewayapi/aliases.go
@@ -164,6 +164,7 @@ const (
 	ListenerReasonInvalidCertificateRef   = gatewayv1.ListenerReasonInvalidCertificateRef
 	ListenerReasonInvalidRouteKinds       = gatewayv1.ListenerReasonInvalidRouteKinds
 	ListenerReasonNoConflicts             = gatewayv1.ListenerReasonNoConflicts
+	ListenerReasonPending                 = gatewayv1.ListenerReasonPending
 	ListenerReasonPortUnavailable         = gatewayv1.ListenerReasonPortUnavailable
 	ListenerReasonProgrammed              = gatewayv1.ListenerReasonProgrammed
 	ListenerReasonProtocolConflict        = gatewayv1.ListenerReasonProtocolConflict

--- a/ingress-controller/internal/gatewayapi/listener_attach.go
+++ b/ingress-controller/internal/gatewayapi/listener_attach.go
@@ -144,6 +144,26 @@ func ListenerSupportsRouteInStatus[T RouteT](route T, listenerName SectionName, 
 	return nil
 }
 
+// ListenerResolvedRefsFalse reports whether listenerName's ResolvedRefs condition
+// in lss is explicitly False.
+func ListenerResolvedRefsFalse(listenerName SectionName, lss []ListenerStatus) bool {
+	listenerStatus, ok := lo.Find(lss, func(ls ListenerStatus) bool {
+		return ls.Name == listenerName
+	})
+	if !ok {
+		return false
+	}
+
+	resolvedRefs, ok := lo.Find(listenerStatus.Conditions, func(condition metav1.Condition) bool {
+		return condition.Type == string(ListenerConditionResolvedRefs)
+	})
+	if !ok {
+		return false
+	}
+
+	return resolvedRefs.Status == metav1.ConditionFalse
+}
+
 // ListenerProgrammed reports whether listenerName's Programmed condition in
 // lss is True.
 func ListenerProgrammed(listenerName SectionName, lss []ListenerStatus) error {

--- a/ingress-controller/internal/gatewayapi/listener_attach.go
+++ b/ingress-controller/internal/gatewayapi/listener_attach.go
@@ -145,8 +145,8 @@ func ListenerSupportsRouteInStatus[T RouteT](route T, listenerName SectionName, 
 }
 
 // ListenerResolvedRefsFalse reports whether listenerName's ResolvedRefs condition
-// in lss is explicitly False.
-func ListenerResolvedRefsFalse(listenerName SectionName, lss []ListenerStatus) bool {
+// in lss is explicitly False as of generation (the Gateway's current generation).
+func ListenerResolvedRefsFalse(listenerName SectionName, generation int64, lss []ListenerStatus) bool {
 	listenerStatus, ok := lo.Find(lss, func(ls ListenerStatus) bool {
 		return ls.Name == listenerName
 	})
@@ -161,7 +161,30 @@ func ListenerResolvedRefsFalse(listenerName SectionName, lss []ListenerStatus) b
 		return false
 	}
 
-	return resolvedRefs.Status == metav1.ConditionFalse
+	return resolvedRefs.Status == metav1.ConditionFalse && resolvedRefs.ObservedGeneration == generation
+}
+
+// ListenerProgrammedFalseForSettledReason reports whether listenerName's
+// Programmed condition in lss is False for a reason other than "Pending", as of
+// generation (the Gateway's current generation).
+func ListenerProgrammedFalseForSettledReason(listenerName SectionName, generation int64, lss []ListenerStatus) bool {
+	listenerStatus, ok := lo.Find(lss, func(ls ListenerStatus) bool {
+		return ls.Name == listenerName
+	})
+	if !ok {
+		return false
+	}
+
+	programmed, ok := lo.Find(listenerStatus.Conditions, func(condition metav1.Condition) bool {
+		return condition.Type == string(ListenerConditionProgrammed)
+	})
+	if !ok {
+		return false
+	}
+
+	return programmed.Status == metav1.ConditionFalse &&
+		programmed.ObservedGeneration == generation &&
+		programmed.Reason != string(ListenerReasonPending)
 }
 
 // ListenerProgrammed reports whether listenerName's Programmed condition in

--- a/ingress-controller/internal/gatewayapi/listener_attach_test.go
+++ b/ingress-controller/internal/gatewayapi/listener_attach_test.go
@@ -114,3 +114,147 @@ func TestGatewayClassControlledBy(t *testing.T) {
 	assert.True(t, GatewayClassControlledBy(gwc, "konghq.com/kic-gateway-controller"))
 	assert.False(t, GatewayClassControlledBy(gwc, "example.com/other-controller"))
 }
+
+func TestListenerResolvedRefsFalse(t *testing.T) {
+	t.Run("listener not found returns false", func(t *testing.T) {
+		assert.False(t, ListenerResolvedRefsFalse("tls", 1, nil))
+	})
+
+	t.Run("listener found but has no ResolvedRefs condition returns false", func(t *testing.T) {
+		lss := []ListenerStatus{{
+			Name:       "tls",
+			Conditions: []metav1.Condition{{Type: string(ListenerConditionProgrammed), Status: metav1.ConditionFalse}},
+		}}
+		assert.False(t, ListenerResolvedRefsFalse("tls", 1, lss))
+	})
+
+	t.Run("listener found with ResolvedRefs=True returns false", func(t *testing.T) {
+		lss := []ListenerStatus{{
+			Name: "tls",
+			Conditions: []metav1.Condition{
+				{Type: string(ListenerConditionResolvedRefs), Status: metav1.ConditionTrue, ObservedGeneration: 1},
+			},
+		}}
+		assert.False(t, ListenerResolvedRefsFalse("tls", 1, lss))
+	})
+
+	t.Run("listener found with ResolvedRefs=False at the current generation returns true", func(t *testing.T) {
+		lss := []ListenerStatus{{
+			Name: "tls",
+			Conditions: []metav1.Condition{
+				{
+					Type:               string(ListenerConditionResolvedRefs),
+					Status:             metav1.ConditionFalse,
+					Reason:             string(ListenerReasonInvalidCertificateRef),
+					ObservedGeneration: 1,
+				},
+			},
+		}}
+		assert.True(t, ListenerResolvedRefsFalse("tls", 1, lss))
+	})
+
+	t.Run("listener found with ResolvedRefs=False from a stale generation returns false", func(t *testing.T) {
+		// The Gateway spec may have been fixed since this condition was
+		// observed, and the controller just hasn't reconciled it yet - a stale
+		// False must not be treated as a settled, permanent failure.
+		lss := []ListenerStatus{{
+			Name: "tls",
+			Conditions: []metav1.Condition{
+				{
+					Type:               string(ListenerConditionResolvedRefs),
+					Status:             metav1.ConditionFalse,
+					Reason:             string(ListenerReasonInvalidCertificateRef),
+					ObservedGeneration: 1,
+				},
+			},
+		}}
+		assert.False(t, ListenerResolvedRefsFalse("tls", 2, lss))
+	})
+
+	t.Run("only matches the requested listener name", func(t *testing.T) {
+		lss := []ListenerStatus{
+			{
+				Name: "other",
+				Conditions: []metav1.Condition{
+					{Type: string(ListenerConditionResolvedRefs), Status: metav1.ConditionFalse, ObservedGeneration: 1},
+				},
+			},
+			{
+				Name: "tls",
+				Conditions: []metav1.Condition{
+					{Type: string(ListenerConditionResolvedRefs), Status: metav1.ConditionTrue, ObservedGeneration: 1},
+				},
+			},
+		}
+		assert.False(t, ListenerResolvedRefsFalse("tls", 1, lss))
+	})
+}
+
+func TestListenerProgrammedFalseForSettledReason(t *testing.T) {
+	t.Run("listener not found returns false", func(t *testing.T) {
+		assert.False(t, ListenerProgrammedFalseForSettledReason("tls", 1, nil))
+	})
+
+	t.Run("listener found but has no Programmed condition returns false", func(t *testing.T) {
+		lss := []ListenerStatus{{
+			Name:       "tls",
+			Conditions: []metav1.Condition{{Type: string(ListenerConditionResolvedRefs), Status: metav1.ConditionTrue}},
+		}}
+		assert.False(t, ListenerProgrammedFalseForSettledReason("tls", 1, lss))
+	})
+
+	t.Run("Programmed=True returns false", func(t *testing.T) {
+		lss := []ListenerStatus{{
+			Name: "tls",
+			Conditions: []metav1.Condition{
+				{Type: string(ListenerConditionProgrammed), Status: metav1.ConditionTrue, ObservedGeneration: 1},
+			},
+		}}
+		assert.False(t, ListenerProgrammedFalseForSettledReason("tls", 1, lss))
+	})
+
+	t.Run("Programmed=False with reason Pending returns false (transient, keep waiting)", func(t *testing.T) {
+		lss := []ListenerStatus{{
+			Name: "tls",
+			Conditions: []metav1.Condition{
+				{
+					Type:               string(ListenerConditionProgrammed),
+					Status:             metav1.ConditionFalse,
+					Reason:             string(ListenerReasonPending),
+					ObservedGeneration: 1,
+				},
+			},
+		}}
+		assert.False(t, ListenerProgrammedFalseForSettledReason("tls", 1, lss))
+	})
+
+	t.Run("Programmed=False with a settled reason at the current generation returns true", func(t *testing.T) {
+		lss := []ListenerStatus{{
+			Name: "tls",
+			Conditions: []metav1.Condition{
+				{
+					Type:               string(ListenerConditionProgrammed),
+					Status:             metav1.ConditionFalse,
+					Reason:             string(ListenerReasonInvalid),
+					ObservedGeneration: 1,
+				},
+			},
+		}}
+		assert.True(t, ListenerProgrammedFalseForSettledReason("tls", 1, lss))
+	})
+
+	t.Run("Programmed=False with a settled reason from a stale generation returns false", func(t *testing.T) {
+		lss := []ListenerStatus{{
+			Name: "tls",
+			Conditions: []metav1.Condition{
+				{
+					Type:               string(ListenerConditionProgrammed),
+					Status:             metav1.ConditionFalse,
+					Reason:             string(ListenerReasonInvalid),
+					ObservedGeneration: 1,
+				},
+			},
+		}}
+		assert.False(t, ListenerProgrammedFalseForSettledReason("tls", 2, lss))
+	})
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

In #4521 we tried to solve #4507, but just solved it partially.
As described in #4507, gateway controller will wipe listeners' status, and write back later, which makes listeners' status transient not Programmed.
Attachable listeners existed but none of them ready caused by such case, the *Route will become not Accepted and be removed from dataplane, which is unexpected.

This PR reordered the per-listener matching loop so the Programmed check runs last, and moved the `attachedListenerNames` append to happen right before it, once every structural check has passed. 
So a listener that's the exact right match but transiently not-yet-Programmed still shows up in `attachedListenerNames`, instead of vanishing from it and tripping the len==0 "no listener could ever attach" escape hatch in `isGatewayProgrammedForRoute`.

**Which issue this PR fixes**

Fixes #4507

**Special notes for your reviewer**:
- This PR split transient not-yet-Programmed with terminal not Programmed by additional checks towards `ResolvedRefs` condition in `isGatewayProgrammedForRoute` to avoid endless requeue.

- This PR reordered the per-listener matching loop so the Programmed check runs last, corresponding move the case `!listenerReady` to the last in:
```
reason := gatewayapi.RouteReasonNoMatchingParent
			switch {
			case matchingHostname != nil && *matchingHostname == metav1.ConditionFalse:
				// If there is no matchingHostname, the gateway Status Condition Accepted
				// must be set to False with reason NoMatchingListenerHostname
				reason = gatewayapi.RouteReasonNoMatchingListenerHostname
			case !allowedByAllowedRoutes || !allowedBySupportedKinds:
				reason = gatewayapi.RouteReasonNotAllowedByListeners
			case parentRef.SectionName != nil && !allowedByListenerName:
				// If ParentRef specified listener names but none of the listeners matches the name,
				// the gateway Status Condition Accepted must be set to False with reason RouteReasonNoMatchingParent.
				reason = gatewayapi.RouteReasonNoMatchingParent
			case parentRef.Port != nil && !portMatched:
				// If ParentRef specified a Port but none of the listeners matched, the gateway Status
				// Condition Accepted must be set to False with reason NoMatchingListenerPort
				reason = gatewayapi.RouteReasonNoMatchingParent
			case len(attachedListenerNames) > 0 && !listenerReady:
				reason = gatewayapi.RouteReasonNotAllowedByListeners
			}
```

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
