### PR TITLE
feat: avoid UDPRoutes/TCPRoutes which attach to same listener but lose arbitration become Programmed=True for on-prem

### DIFF
--- a/ingress-controller/internal/dataplane/translator/translate_tcproute.go
+++ b/ingress-controller/internal/dataplane/translator/translate_tcproute.go
@@ -70,19 +70,16 @@ func (t *Translator) ingressRulesFromTCPRoutes() ingressRules {
 		if err := t.translateTCPRouteWithPorts(&result, r, ports); err != nil {
 			errs = append(errs, fmt.Errorf("TCPRoute %s/%s can't be routed: %w",
 				r.Namespace, r.Name, err))
+			continue
 		}
-	}
 
-	// Only the winner produced Kong entities, so only the winner is reported as
-	// successfully translated. A route that loses arbitration on every listener
-	// it attached to is left unreported (Programmed stays Unknown) - this way
-	// Programmed reflects the route's real dataplane status: it flips to True
-	// only once the route actually wins arbitration (e.g. after the current
-	// winner is deleted) and its config is genuinely pushed.
-	for _, r := range valid {
-		if _, isWinner := winningPorts[r]; isWinner {
-			t.registerSuccessfullyTranslatedObject(r)
-		}
+		// Only the winner produced Kong entities, so only the winner is reported as
+		// successfully translated. A route that loses arbitration on every listener
+		// it attached to is left unreported (Programmed stays Unknown) - this way
+		// Programmed reflects the route's real dataplane status: it flips to True
+		// only once the route actually wins arbitration (e.g. after the current
+		// winner is deleted) and its config is genuinely pushed.
+		t.registerSuccessfullyTranslatedObject(r)
 	}
 
 	if t.featureFlags.ExpressionRoutes {

--- a/ingress-controller/internal/dataplane/translator/translate_tcproute.go
+++ b/ingress-controller/internal/dataplane/translator/translate_tcproute.go
@@ -43,12 +43,10 @@ func (t *Translator) ingressRulesFromTCPRoutes() ingressRules {
 
 	// Group routes by l4ListenerKey.
 	attachments := make(map[l4ListenerKey][]*gatewayapi.TCPRoute)
-	attachedRoutes := make(map[*gatewayapi.TCPRoute]struct{})
 	for _, r := range valid {
 		listenerKeys := l4RouteListenerAttachments(r, t.logger, t.storer, listenersByGateway)
 		for _, k := range listenerKeys {
 			attachments[k] = append(attachments[k], r)
-			attachedRoutes[r] = struct{}{}
 		}
 	}
 
@@ -75,12 +73,14 @@ func (t *Translator) ingressRulesFromTCPRoutes() ingressRules {
 		}
 	}
 
-	// Every TCPRoute that successfully attached to at least one listener (even
-	// if it lost arbitration on all of them) is reported as successfully
-	// translated — the route is "attached" per spec; arbitration is a
-	// translation-layer detail.
+	// Only the winner produced Kong entities, so only the winner is reported as
+	// successfully translated. A route that loses arbitration on every listener
+	// it attached to is left unreported (Programmed stays Unknown) - this way
+	// Programmed reflects the route's real dataplane status: it flips to True
+	// only once the route actually wins arbitration (e.g. after the current
+	// winner is deleted) and its config is genuinely pushed.
 	for _, r := range valid {
-		if _, ok := attachedRoutes[r]; ok {
+		if _, isWinner := winningPorts[r]; isWinner {
 			t.registerSuccessfullyTranslatedObject(r)
 		}
 	}

--- a/ingress-controller/internal/dataplane/translator/translate_tcproute_test.go
+++ b/ingress-controller/internal/dataplane/translator/translate_tcproute_test.go
@@ -8,10 +8,12 @@ import (
 	"github.com/go-logr/zapr"
 	"github.com/kong/go-kong/kong"
 	"github.com/samber/lo"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"go.uber.org/zap"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/dataplane/failures"
@@ -824,4 +826,85 @@ func TestIngressRulesFromTCPRoutes(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestIngressRulesFromTCPRoutes_ArbitrationReporting verifies that, for two
+// TCPRoutes attached to the same listener, only the GEP-2645 winner is reported
+// through registerSuccessfullyTranslatedObject (ConfiguredKubernetesObjects).
+// The loser must be left unreported entirely, so its Programmed condition stays
+// Unknown - reflecting that it has no real config on the dataplane - rather than
+// being reported as configured just because it's attached to a listener.
+func TestIngressRulesFromTCPRoutes_ArbitrationReporting(t *testing.T) {
+	tcpRouteTypeMeta := metav1.TypeMeta{Kind: "TCPRoute", APIVersion: gatewayv1.GroupVersion.String()}
+
+	gw := &gatewayapi.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "tcp-gw"},
+		Spec: gatewayapi.GatewaySpec{
+			Listeners: []gatewayapi.Listener{{
+				Name:     "tcp",
+				Protocol: gatewayapi.TCPProtocolType,
+				Port:     9999,
+			}},
+		},
+		Status: tcpProgrammedStatus("tcp"),
+	}
+	older := &gatewayapi.TCPRoute{
+		TypeMeta: tcpRouteTypeMeta,
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:         "default",
+			Name:              "older",
+			CreationTimestamp: metav1.NewTime(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC)),
+		},
+		Spec: gatewayapi.TCPRouteSpec{
+			CommonRouteSpec: gatewayapi.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{{Name: gatewayv1.ObjectName("tcp-gw")}},
+			},
+			Rules: []gatewayapi.TCPRouteRule{{
+				BackendRefs: []gatewayv1.BackendRef{{
+					BackendObjectReference: gatewayv1.BackendObjectReference{
+						Name: "svc-older", Kind: new(gatewayv1.Kind("Service")), Port: new(gatewayv1.PortNumber(8080)),
+					},
+				}},
+			}},
+		},
+	}
+	newer := &gatewayapi.TCPRoute{
+		TypeMeta: tcpRouteTypeMeta,
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace:         "default",
+			Name:              "newer",
+			CreationTimestamp: metav1.NewTime(time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC)),
+		},
+		Spec: gatewayapi.TCPRouteSpec{
+			CommonRouteSpec: gatewayapi.CommonRouteSpec{
+				ParentRefs: []gatewayv1.ParentReference{{Name: gatewayv1.ObjectName("tcp-gw")}},
+			},
+			Rules: []gatewayapi.TCPRouteRule{{
+				BackendRefs: []gatewayv1.BackendRef{{
+					BackendObjectReference: gatewayv1.BackendObjectReference{
+						Name: "svc-newer", Kind: new(gatewayv1.Kind("Service")), Port: new(gatewayv1.PortNumber(9090)),
+					},
+				}},
+			}},
+		},
+	}
+
+	fakestore, err := store.NewFakeStore(store.FakeObjects{
+		GatewayClasses: []*gatewayapi.GatewayClass{defaultOwnedGatewayClass},
+		Gateways:       []*gatewayapi.Gateway{gw},
+		TCPRoutes:      []*gatewayapi.TCPRoute{older, newer},
+		Services: []*corev1.Service{
+			{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "svc-older"}},
+			{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "svc-newer"}},
+		},
+	})
+	require.NoError(t, err)
+	tr := mustNewTranslator(t, fakestore)
+
+	tr.ingressRulesFromTCPRoutes()
+
+	configured := tr.popConfiguredKubernetesObjects()
+
+	assert.ElementsMatch(t, []client.Object{older}, configured,
+		"only the winner must be reported as successfully translated; the loser must not appear at all")
 }

--- a/ingress-controller/internal/dataplane/translator/translate_udproute.go
+++ b/ingress-controller/internal/dataplane/translator/translate_udproute.go
@@ -71,19 +71,16 @@ func (t *Translator) ingressRulesFromUDPRoutes() ingressRules {
 		if err := t.translateUDPRouteWithPorts(&result, r, ports); err != nil {
 			errs = append(errs, fmt.Errorf("UDPRoute %s/%s can't be routed: %w",
 				r.Namespace, r.Name, err))
+			continue
 		}
-	}
 
-	// Only the winner produced Kong entities, so only the winner is reported as
-	// successfully translated. A route that loses arbitration on every listener
-	// it attached to is left unreported (Programmed stays Unknown) - this way
-	// Programmed reflects the route's real dataplane status: it flips to True
-	// only once the route actually wins arbitration (e.g. after the current
-	// winner is deleted) and its config is genuinely pushed.
-	for _, r := range valid {
-		if _, isWinner := winningPorts[r]; isWinner {
-			t.registerSuccessfullyTranslatedObject(r)
-		}
+		// Only the winner produced Kong entities, so only the winner is reported as
+		// successfully translated. A route that loses arbitration on every listener
+		// it attached to is left unreported (Programmed stays Unknown) - this way
+		// Programmed reflects the route's real dataplane status: it flips to True
+		// only once the route actually wins arbitration (e.g. after the current
+		// winner is deleted) and its config is genuinely pushed.
+		t.registerSuccessfullyTranslatedObject(r)
 	}
 
 	if t.featureFlags.ExpressionRoutes {

--- a/ingress-controller/internal/dataplane/translator/translate_udproute.go
+++ b/ingress-controller/internal/dataplane/translator/translate_udproute.go
@@ -44,12 +44,10 @@ func (t *Translator) ingressRulesFromUDPRoutes() ingressRules {
 
 	// Group routes by l4ListenerKey.
 	attachments := make(map[l4ListenerKey][]*gatewayapi.UDPRoute)
-	attachedRoutes := make(map[*gatewayapi.UDPRoute]struct{})
 	for _, r := range valid {
 		listenerKeys := l4RouteListenerAttachments(r, t.logger, t.storer, listenersByGateway)
 		for _, k := range listenerKeys {
 			attachments[k] = append(attachments[k], r)
-			attachedRoutes[r] = struct{}{}
 		}
 	}
 
@@ -76,12 +74,14 @@ func (t *Translator) ingressRulesFromUDPRoutes() ingressRules {
 		}
 	}
 
-	// Every UDPRoute that successfully attached to at least one listener (even
-	// if it lost arbitration on all of them) is reported as successfully
-	// translated — the route is "attached" per spec; arbitration is a
-	// translation-layer detail.
+	// Only the winner produced Kong entities, so only the winner is reported as
+	// successfully translated. A route that loses arbitration on every listener
+	// it attached to is left unreported (Programmed stays Unknown) - this way
+	// Programmed reflects the route's real dataplane status: it flips to True
+	// only once the route actually wins arbitration (e.g. after the current
+	// winner is deleted) and its config is genuinely pushed.
 	for _, r := range valid {
-		if _, ok := attachedRoutes[r]; ok {
+		if _, isWinner := winningPorts[r]; isWinner {
 			t.registerSuccessfullyTranslatedObject(r)
 		}
 	}

--- a/ingress-controller/internal/dataplane/translator/translate_udproute_conflict_test.go
+++ b/ingress-controller/internal/dataplane/translator/translate_udproute_conflict_test.go
@@ -10,6 +10,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/gatewayapi"
@@ -314,4 +315,65 @@ func TestUDPRouteListenerAttachments_Predicates(t *testing.T) {
 			assert.ElementsMatch(t, tc.wantTargets, got)
 		})
 	}
+}
+
+// TestIngressRulesFromUDPRoutes_ArbitrationReporting verifies that, for two
+// UDPRoutes attached to the same listener, only the GEP-2645 winner is reported
+// through registerSuccessfullyTranslatedObject (ConfiguredKubernetesObjects).
+// The loser must be left unreported entirely, so its Programmed condition stays
+// Unknown - reflecting that it has no real config on the dataplane - rather than
+// being reported as configured just because it's attached to a listener.
+func TestIngressRulesFromUDPRoutes_ArbitrationReporting(t *testing.T) {
+	gw := &gatewayapi.Gateway{
+		ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "udp-gw"},
+		Spec: gatewayapi.GatewaySpec{
+			Listeners: []gatewayapi.Listener{{
+				Name:     "udp",
+				Protocol: gatewayapi.UDPProtocolType,
+				Port:     9999,
+			}},
+		},
+		Status: udpProgrammedStatus("udp"),
+	}
+	older := mkUDPRouteWithParents("default", parentRef("", "udp-gw", "", 0))
+	older.TypeMeta = udpRouteTypeMeta
+	older.Name = "older"
+	older.CreationTimestamp = metav1.NewTime(time.Date(2025, 1, 1, 0, 0, 0, 0, time.UTC))
+	older.Spec.Rules = []gatewayapi.UDPRouteRule{{
+		BackendRefs: []gatewayv1.BackendRef{{
+			BackendObjectReference: gatewayv1.BackendObjectReference{
+				Name: "svc-older", Kind: new(gatewayv1.Kind("Service")), Port: new(gatewayv1.PortNumber(53)),
+			},
+		}},
+	}}
+	newer := mkUDPRouteWithParents("default", parentRef("", "udp-gw", "", 0))
+	newer.TypeMeta = udpRouteTypeMeta
+	newer.Name = "newer"
+	newer.CreationTimestamp = metav1.NewTime(time.Date(2025, 1, 2, 0, 0, 0, 0, time.UTC))
+	newer.Spec.Rules = []gatewayapi.UDPRouteRule{{
+		BackendRefs: []gatewayv1.BackendRef{{
+			BackendObjectReference: gatewayv1.BackendObjectReference{
+				Name: "svc-newer", Kind: new(gatewayv1.Kind("Service")), Port: new(gatewayv1.PortNumber(53)),
+			},
+		}},
+	}}
+
+	fakestore, err := store.NewFakeStore(store.FakeObjects{
+		GatewayClasses: []*gatewayapi.GatewayClass{defaultOwnedGatewayClass},
+		Gateways:       []*gatewayapi.Gateway{gw},
+		UDPRoutes:      []*gatewayapi.UDPRoute{older, newer},
+		Services: []*corev1.Service{
+			{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "svc-older"}},
+			{ObjectMeta: metav1.ObjectMeta{Namespace: "default", Name: "svc-newer"}},
+		},
+	})
+	require.NoError(t, err)
+	tr := mustNewTranslator(t, fakestore)
+
+	tr.ingressRulesFromUDPRoutes()
+
+	configured := tr.popConfiguredKubernetesObjects()
+
+	assert.ElementsMatch(t, []client.Object{older}, configured,
+		"only the winner must be reported as successfully translated; the loser must not appear at all")
 }

--- a/test/e2e/chainsaw/gateway/udproute-onprem/04-assert-gateway-with-two-udproutes.yaml
+++ b/test/e2e/chainsaw/gateway/udproute-onprem/04-assert-gateway-with-two-udproutes.yaml
@@ -87,9 +87,6 @@ status:
         - status: 'True'
           reason: Accepted
       (conditions[?type == 'Programmed']):
-        # Loser UDPRoute won't be pushed to DataPlane, configuration won't be changed, status won't be reported
-        # Will be True until DataPlane's configuration change. (This case will be simulated by creating a third UDPRoute
-        # attached to a different listener.)
         - status: Unknown
           reason: Unknown
       (conditions[?type == 'ResolvedRefs']):

--- a/test/e2e/chainsaw/gateway/udproute-onprem/05-assert-gateway-with-three-udproutes.yaml
+++ b/test/e2e/chainsaw/gateway/udproute-onprem/05-assert-gateway-with-three-udproutes.yaml
@@ -1,7 +1,7 @@
 ---
 # The original listener counts both same-listener UDPRoutes. The extra listener
-# has the third route, which creates a DataPlane config change and refreshes
-# object reports for the second route.
+# has the third route, which creates a DataPlane config change. The second route's
+# Programmed condition should be kept as Unknown.
 apiVersion: gateway.networking.k8s.io/v1
 kind: Gateway
 metadata:
@@ -88,8 +88,8 @@ status:
         - status: 'True'
           reason: Accepted
       (conditions[?type == 'Programmed']):
-        - status: 'True'
-          reason: ConfiguredInGateway
+        - status: Unknown
+          reason: Unknown
       (conditions[?type == 'ResolvedRefs']):
         - status: 'True'
           reason: ResolvedRefs

--- a/test/e2e/chainsaw/gateway/udproute-onprem/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/gateway/udproute-onprem/chainsaw-test.yaml
@@ -12,10 +12,10 @@ spec:
        traffic reaches the older backend.
     4. Attaching a second UDPRoute to the same listener and verifying GEP-2645
        listener AttachedRoutes=2 behavior.
-    5. Attaching a third UDPRoute to a different listener so it is pushed to
-       the DataPlane and refreshes object reports for the second route. Then
-       verify all routes report Accepted=True at the K8s status layer and UDP
-       traffic still flows to the older same-listener winner.
+    5. Attaching a third UDPRoute to a different listener so it is pushed to the 
+       DataPlane and refreshes object reports, but the Programmed condition for the 
+       second route should still be False. Then verify all routes report Accepted=True
+       at the K8s status layer and UDP traffic still flows to the older same-listener winner.
     6. Deleting the winner (older) UDPRoute and verifying AttachedRoutes drops
        to 1, the loser remains attached, and UDP traffic now reaches the
        newer backend (the loser is promoted to winner).
@@ -122,9 +122,8 @@ spec:
     - name: Create-third-udproute
       description: |
         Create a third UDPRoute attached to a different listener. This route is
-        pushed to the DataPlane and causes a config/report refresh, allowing the
-        second same-listener route to receive status even though it lost
-        arbitration.
+        pushed to the DataPlane and causes a config/report refresh, the second 
+        same-listener route should still with Programmed=False condition.
       try:
         - apply:
             file: 05-udproute-third.yaml
@@ -189,7 +188,8 @@ spec:
     - name: Delete-winner-udproute
       description: |
         Delete the original (older, winner) UDPRoute. The remaining (loser)
-        UDPRoute is now the sole attached route and gets promoted to winner;
+        UDPRoute is now the sole attached route and gets promoted to winner
+        and its Programmed condition should become True;
         the original listener's AttachedRoutes drops to 1.
       try:
         - delete:

--- a/test/e2e/chainsaw/gateway/udproute-onprem/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/gateway/udproute-onprem/chainsaw-test.yaml
@@ -14,7 +14,7 @@ spec:
        listener AttachedRoutes=2 behavior.
     5. Attaching a third UDPRoute to a different listener so it is pushed to the 
        DataPlane and refreshes object reports, but the Programmed condition for the 
-       second route should still be False. Then verify all routes report Accepted=True
+       second route must keep as Unknown. Then verify all routes report Accepted=True
        at the K8s status layer and UDP traffic still flows to the older same-listener winner.
     6. Deleting the winner (older) UDPRoute and verifying AttachedRoutes drops
        to 1, the loser remains attached, and UDP traffic now reaches the
@@ -122,8 +122,8 @@ spec:
     - name: Create-third-udproute
       description: |
         Create a third UDPRoute attached to a different listener. This route is
-        pushed to the DataPlane and causes a config/report refresh, the second 
-        same-listener route should still with Programmed=False condition.
+        pushed to the DataPlane and causes a config/report refresh. The second
+        same-listener route must keep its Programmed condition as Unknown.
       try:
         - apply:
             file: 05-udproute-third.yaml


### PR DESCRIPTION
**What this PR does / why we need it**:

The Accepted condition and Programmed condition of UDPRoute/TCPRoute are updated if `r.DataplaneClient.KubernetesObjectIsConfigured` at the beginning. So for UDPRoutes/TCPRoutes which attach to same listener but lose arbitration, we still call `registerSuccessfullyTranslatedObject` so that the Accepted condition of them can be updated. As a result, the Programmed condition also updated for them, which is not the actual status in DataPlane.

After #5028 and #5075, we updated Accpeted condition before configured, split the update of Accepted condition and Programmed condition.

For UDPRoutes/TCPRoutes which attach to same listener but lose arbitration, they can be updated to Accepted=True now without call `registerSuccessfullyTranslatedObject`, so that the Programmed condition won't be updated. 

**Which issue this PR fixes**

Fixes #5215 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
