### PR TITLE
chart: bump memory limits from operator's default deployment spec

### DIFF
--- a/charts/kong-operator/CHANGELOG.md
+++ b/charts/kong-operator/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Bump operator's memory limits from `256Mi` to `512Mi` to prevent throttling and OOMKilled issues
   with default settings in environments with a lot of cluster resources.
+  [#5248](https://github.com/Kong/kong-operator/pull/5248)
 
 ## 1.4.0-rc.2
 

--- a/charts/kong-operator/CHANGELOG.md
+++ b/charts/kong-operator/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Bump operator's memory limits from `256Mi` to `512Mi` to prevent throttling and OOMKilled issues
+- Bump operator's memory limits from `256Mi` to `512Mi` to prevent OOM issues
   with default settings in environments with a lot of cluster resources.
   [#5248](https://github.com/Kong/kong-operator/pull/5248)
 

--- a/charts/kong-operator/CHANGELOG.md
+++ b/charts/kong-operator/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Bump operator's memory limits to prevent throttling and OOMKilled issues
+  with default settings in environments with a lot of cluster resources.
+
 ## 1.4.0-rc.2
 
 ### Changed

--- a/charts/kong-operator/CHANGELOG.md
+++ b/charts/kong-operator/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Bump operator's memory limits to prevent throttling and OOMKilled issues
+- Bump operator's memory limits from `256Mi` to `512Mi` to prevent throttling and OOMKilled issues
   with default settings in environments with a lot of cluster resources.
 
 ## 1.4.0-rc.2

--- a/charts/kong-operator/ci/__snapshots__/affinity-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/affinity-values.snap
@@ -104035,7 +104035,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 256Mi
+            memory: 512Mi
           requests:
             cpu: 10m
             memory: 128Mi

--- a/charts/kong-operator/ci/__snapshots__/cert-manager-enabled-everywhere.snap
+++ b/charts/kong-operator/ci/__snapshots__/cert-manager-enabled-everywhere.snap
@@ -103960,7 +103960,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 256Mi
+            memory: 512Mi
           requests:
             cpu: 10m
             memory: 128Mi

--- a/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
+++ b/charts/kong-operator/ci/__snapshots__/controlplane-config-dump.snap
@@ -104048,7 +104048,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 256Mi
+            memory: 512Mi
           requests:
             cpu: 10m
             memory: 128Mi

--- a/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/disable-gateway-controller-values.snap
@@ -104027,7 +104027,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 256Mi
+            memory: 512Mi
           requests:
             cpu: 10m
             memory: 128Mi

--- a/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-args-values.snap
@@ -104029,7 +104029,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 256Mi
+            memory: 512Mi
           requests:
             cpu: 10m
             memory: 128Mi

--- a/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/env-and-customenv-values.snap
@@ -104029,7 +104029,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 256Mi
+            memory: 512Mi
           requests:
             cpu: 10m
             memory: 128Mi

--- a/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/extra-labels-values.snap
@@ -104028,7 +104028,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 256Mi
+            memory: 512Mi
           requests:
             cpu: 10m
             memory: 128Mi

--- a/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/image-pull-secrets-and-image-digest-values.snap
@@ -104027,7 +104027,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 256Mi
+            memory: 512Mi
           requests:
             cpu: 10m
             memory: 128Mi

--- a/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/nightly-can-be-used-values.snap
@@ -104025,7 +104025,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 256Mi
+            memory: 512Mi
           requests:
             cpu: 10m
             memory: 128Mi

--- a/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/pod-annotations-values.snap
@@ -104026,7 +104026,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 256Mi
+            memory: 512Mi
           requests:
             cpu: 10m
             memory: 128Mi

--- a/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/probes-and-args-values.snap
@@ -104027,7 +104027,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 256Mi
+            memory: 512Mi
           requests:
             cpu: 10m
             memory: 128Mi

--- a/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/tolerations-values.snap
@@ -104029,7 +104029,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 256Mi
+            memory: 512Mi
           requests:
             cpu: 10m
             memory: 128Mi

--- a/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
+++ b/charts/kong-operator/ci/__snapshots__/validating-policies-dataplane-ports-disabled.snap
@@ -104025,7 +104025,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 256Mi
+            memory: 512Mi
           requests:
             cpu: 10m
             memory: 128Mi

--- a/charts/kong-operator/ci/__snapshots__/webhook-cert-manager-fullname-override.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-cert-manager-fullname-override.snap
@@ -103975,7 +103975,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 256Mi
+            memory: 512Mi
           requests:
             cpu: 10m
             memory: 128Mi

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-disabled-values.snap
@@ -77427,7 +77427,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 256Mi
+            memory: 512Mi
           requests:
             cpu: 10m
             memory: 128Mi

--- a/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhook-conversion-enabled-cert-manager.snap
@@ -103975,7 +103975,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 256Mi
+            memory: 512Mi
           requests:
             cpu: 10m
             memory: 128Mi

--- a/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
+++ b/charts/kong-operator/ci/__snapshots__/webhooks-validating-and-conversion-disabled-values.snap
@@ -77387,7 +77387,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 256Mi
+            memory: 512Mi
           requests:
             cpu: 10m
             memory: 128Mi

--- a/charts/kong-operator/values.yaml
+++ b/charts/kong-operator/values.yaml
@@ -66,7 +66,7 @@ readinessProbe:
 resources:
   limits:
     cpu: 500m
-    memory: 256Mi
+    memory: 512Mi
   requests:
     cpu: 10m
     memory: 128Mi

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -58,7 +58,7 @@ spec:
         resources:
           limits:
             cpu: 500m
-            memory: 256Mi
+            memory: 512Mi
           requests:
             cpu: 10m
             memory: 128Mi


### PR DESCRIPTION
**What this PR does / why we need it**:

Bump default memory limit for operator deployment to 512Mi to prevent OOMs.

Noticed in e2e tests in https://github.com/Kong/kong-operator/actions/runs/31485004120/job/93759129090?pr=5234

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
