### PR TITLE
perf: add caching in ssa provider

### DIFF
--- a/controller/pkg/ssa/provider.go
+++ b/controller/pkg/ssa/provider.go
@@ -174,6 +174,11 @@ func (p *TypeConverterProvider) Rebuild(ctx context.Context, logger logr.Logger,
 	crdSpecs := make([]*kubespec3.OpenAPI, 0, len(crds))
 	for _, crd := range crds {
 		for _, v := range crd.Spec.Versions {
+			if !v.Served {
+				// Not served, so no client (including this provider's own callers) ever
+				// applies against it - building and caching its schema would be waste.
+				continue
+			}
 			key := crd.Name + "/" + v.Name
 			if entry, ok := specCacheSnapshot[key]; ok && entry.rv == crd.ResourceVersion {
 				newCache[key] = entry
@@ -219,19 +224,40 @@ func (p *TypeConverterProvider) Ready(_ *http.Request) error {
 	return nil
 }
 
-// listRelevantCRDs lists all CRDs in the configured groups using the given reader.
+// crdListPageSize bounds how many full CRD objects (each carrying its complete OpenAPI
+// schema) are held in memory at once while listing. Without pagination, a single List
+// would decode every CRD in the cluster - including ones outside crdGroups - before any
+// of them could be discarded.
+const crdListPageSize = 32
+
+// listRelevantCRDs lists all CRDs in the configured groups using the given reader,
+// paginating so irrelevant CRDs from other pages can be GC'd before the next page is
+// fetched instead of holding the whole cluster's CRDs in memory at once.
 func listRelevantCRDs(ctx context.Context, r client.Reader, crdGroups map[string]struct{}) ([]*apiextensionsv1.CustomResourceDefinition, error) {
-	allCRDs := &apiextensionsv1.CustomResourceDefinitionList{}
-	if err := r.List(ctx, allCRDs); err != nil {
-		return nil, err
-	}
-	relevant := make([]*apiextensionsv1.CustomResourceDefinition, 0, len(allCRDs.Items))
-	for i := range allCRDs.Items {
-		if isCRDGroupRelevant(crdGroups, allCRDs.Items[i].Spec.Group) {
-			relevant = append(relevant, &allCRDs.Items[i])
+	var relevant []*apiextensionsv1.CustomResourceDefinition
+	continueToken := ""
+	for {
+		page := &apiextensionsv1.CustomResourceDefinitionList{}
+		opts := []client.ListOption{client.Limit(crdListPageSize)}
+		if continueToken != "" {
+			opts = append(opts, client.Continue(continueToken))
 		}
+		if err := r.List(ctx, page, opts...); err != nil {
+			return nil, err
+		}
+		for i := range page.Items {
+			if isCRDGroupRelevant(crdGroups, page.Items[i].Spec.Group) {
+				// Copy the crd to prevent Go from keeping the entire backing array
+				// in memory while we hold a reference to the slice element.
+				crd := page.Items[i].DeepCopy()
+				relevant = append(relevant, crd)
+			}
+		}
+		if page.Continue == "" {
+			return relevant, nil
+		}
+		continueToken = page.Continue
 	}
-	return relevant, nil
 }
 
 // mergeApplyModels merges pre-built CRD OpenAPI specs with the cached built-in

--- a/controller/pkg/ssa/provider_test.go
+++ b/controller/pkg/ssa/provider_test.go
@@ -17,8 +17,10 @@ limitations under the License.
 package ssa
 
 import (
+	"context"
 	"fmt"
 	"net/http"
+	"strconv"
 	"sync"
 	"testing"
 
@@ -33,6 +35,7 @@ import (
 	kubespec3 "k8s.io/kube-openapi/pkg/spec3"
 	validationspec "k8s.io/kube-openapi/pkg/validation/spec"
 	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -152,6 +155,29 @@ func Test_TypeConverterProvider_Rebuild_CachesUnchangedCRDVersions(t *testing.T)
 	assert.Equal(t, "2", p.specCache[key].rv)
 }
 
+func Test_TypeConverterProvider_Rebuild_SkipsNonServedVersions(t *testing.T) {
+	p := &TypeConverterProvider{
+		crdGroups: map[string]struct{}{"example.konghq.com": {}},
+		specCache: make(map[string]crdSpecCache),
+	}
+
+	crd := testCRD("example.konghq.com", "Widget", "v1", "1")
+	crd.Spec.Versions = append(crd.Spec.Versions, apiextensionsv1.CustomResourceDefinitionVersion{
+		Name:   "v1beta1",
+		Served: false,
+		Schema: &apiextensionsv1.CustomResourceValidation{
+			OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{Type: "object"},
+		},
+	})
+
+	require.NoError(t, p.Rebuild(t.Context(), logr.Discard(), []*apiextensionsv1.CustomResourceDefinition{crd}))
+
+	_, servedCached := p.specCache[crd.Name+"/v1"]
+	assert.True(t, servedCached, "served version should be built and cached")
+	_, nonServedCached := p.specCache[crd.Name+"/v1beta1"]
+	assert.False(t, nonServedCached, "non-served version should not be built or cached")
+}
+
 func Test_TypeConverterProvider_Rebuild_ConcurrentCallsDoNotRace(t *testing.T) {
 	p := &TypeConverterProvider{
 		crdGroups: map[string]struct{}{"example.konghq.com": {}},
@@ -206,6 +232,81 @@ func Test_listRelevantCRDs(t *testing.T) {
 	require.NoError(t, err)
 	require.Len(t, crds, 1)
 	assert.Equal(t, relevant.Name, crds[0].Name)
+}
+
+// pagingReader is a client.Reader backed by a plain slice of CRDs that actually
+// honors client.Limit/client.Continue, unlike the fake client (which returns
+// every item in one page regardless of Limit). It lets tests prove that a
+// caller follows Continue tokens across multiple List calls instead of relying
+// on a single unpaginated List that happens to return everything at once.
+type pagingReader struct {
+	client.Reader
+
+	crds  []*apiextensionsv1.CustomResourceDefinition
+	calls int
+}
+
+func (r *pagingReader) List(_ context.Context, list client.ObjectList, opts ...client.ListOption) error {
+	r.calls++
+
+	listOpts := &client.ListOptions{}
+	for _, opt := range opts {
+		opt.ApplyToList(listOpts)
+	}
+
+	start := 0
+	if listOpts.Continue != "" {
+		var err error
+		start, err = strconv.Atoi(listOpts.Continue)
+		if err != nil {
+			return err
+		}
+	}
+	limit := int(listOpts.Limit)
+	if limit <= 0 || limit > len(r.crds)-start {
+		limit = len(r.crds) - start
+	}
+	end := start + limit
+
+	page := list.(*apiextensionsv1.CustomResourceDefinitionList)
+	for _, crd := range r.crds[start:end] {
+		page.Items = append(page.Items, *crd)
+	}
+	if end < len(r.crds) {
+		page.Continue = strconv.Itoa(end)
+	}
+	return nil
+}
+
+// Test_listRelevantCRDs_Pagination exercises listRelevantCRDs across more CRDs than
+// crdListPageSize, using a pagingReader that actually hands back a Continue token,
+// so the test fails if listRelevantCRDs stops following pages after the first List.
+func Test_listRelevantCRDs_Pagination(t *testing.T) {
+	ctx := t.Context()
+
+	const total = crdListPageSize*2 + 7 // deliberately not a multiple of the page size
+	crds := make([]*apiextensionsv1.CustomResourceDefinition, 0, total)
+	wantNames := make(map[string]bool, total/2)
+	for i := range total {
+		group := "unrelated.example.com"
+		if i%2 == 0 {
+			group = "eventgateway.konghq.com"
+		}
+		crd := testCRD(group, fmt.Sprintf("Widget%d", i), "v1", "1")
+		if group == "eventgateway.konghq.com" {
+			wantNames[crd.Name] = true
+		}
+		crds = append(crds, crd)
+	}
+
+	r := &pagingReader{crds: crds}
+	got, err := listRelevantCRDs(ctx, r, map[string]struct{}{"eventgateway.konghq.com": {}})
+	require.NoError(t, err)
+	require.Len(t, got, len(wantNames))
+	require.Equal(t, 3, r.calls, "expected 3 List calls to page through %d CRDs with page size %d", total, crdListPageSize)
+	for _, crd := range got {
+		assert.True(t, wantNames[crd.Name], "unexpected CRD %q returned", crd.Name)
+	}
 }
 
 func Test_NewTypeConverterProvider_error(t *testing.T) {

--- a/modules/manager/cache_options.go
+++ b/modules/manager/cache_options.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -39,9 +40,6 @@ func createCacheOptions(l logr.Logger, cfg Config) (cache.Options, error) {
 }
 
 func createCacheByObject(cfg Config) (map[client.Object]cache.ByObject, error) {
-	if cfg.ConfigMapLabelSelector == "" && cfg.SecretLabelSelector == "" {
-		return nil, nil
-	}
 	byObject := map[client.Object]cache.ByObject{}
 	if cfg.SecretLabelSelector != "" {
 		if err := setByObjectFor[corev1.Secret](cfg.SecretLabelSelector, byObject); err != nil {
@@ -53,6 +51,38 @@ func createCacheByObject(cfg Config) (map[client.Object]cache.ByObject, error) {
 			return nil, fmt.Errorf("failed to set byObject for ConfigMaps: %w", err)
 		}
 	}
+	byObject[&apiextensionsv1.CustomResourceDefinition{}] = crdCacheByObject()
 
 	return byObject, nil
+}
+
+// crdCacheByObject strips the OpenAPI schema - the bulk of a CRD's size - from every
+// CustomResourceDefinition outside ssaCRDGroups before it enters the cache.
+//
+// The crdschema controller (controller/crdschema) watches every CRD in the cluster (its
+// predicate filters which reconcile events fire, not what the informer caches), but only
+// ever rebuilds the SSA TypeConverter for ssaCRDGroups. Without this, the cache holds full
+// schemas for every other CRD in the cluster too - including large, unrelated CRDs like
+// gateway-operator.konghq.com's GatewayConfiguration - for no reason.
+func crdCacheByObject() cache.ByObject {
+	return cache.ByObject{
+		Transform: func(obj any) (any, error) {
+			crd, ok := obj.(*apiextensionsv1.CustomResourceDefinition)
+			if !ok {
+				return obj, nil
+			}
+			if _, relevant := ssaCRDGroups[crd.Spec.Group]; relevant {
+				return crd, nil
+			}
+			// NOTE: We do not need to deep-copy the CRD here because the cache
+			// will do that for us before storing it.
+			for i := range crd.Spec.Versions {
+				// NOTE: We strip the schema here as its unused.
+				// Any future controller that needs the schema should add its own
+				// ByObject entry for CRDs in its group.
+				crd.Spec.Versions[i].Schema = nil
+			}
+			return crd, nil
+		},
+	}
 }

--- a/modules/manager/cache_options_test.go
+++ b/modules/manager/cache_options_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
+	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 )
 
 func TestCreateCacheByObject(t *testing.T) {
@@ -12,18 +13,16 @@ func TestCreateCacheByObject(t *testing.T) {
 		name                   string
 		cfg                    Config
 		expectError            bool
-		expectNil              bool
 		expectedConfigMapLabel string
 		expectedSecretLabel    string
 	}{
 		{
-			name: "no label selectors returns nil",
+			name: "no label selectors still registers the CRD schema-stripping entry",
 			cfg: Config{
 				ConfigMapLabelSelector: "",
 				SecretLabelSelector:    "",
 			},
 			expectError: false,
-			expectNil:   true,
 		},
 		{
 			name: "only secret label selector",
@@ -31,7 +30,6 @@ func TestCreateCacheByObject(t *testing.T) {
 				SecretLabelSelector: "app",
 			},
 			expectError:         false,
-			expectNil:           false,
 			expectedSecretLabel: "app",
 		},
 		{
@@ -40,7 +38,6 @@ func TestCreateCacheByObject(t *testing.T) {
 				ConfigMapLabelSelector: "configmap.konghq.com",
 			},
 			expectError:            false,
-			expectNil:              false,
 			expectedConfigMapLabel: "configmap.konghq.com",
 		},
 		{
@@ -50,7 +47,6 @@ func TestCreateCacheByObject(t *testing.T) {
 				SecretLabelSelector:    "app",
 			},
 			expectError:            false,
-			expectNil:              false,
 			expectedConfigMapLabel: "configmap.konghq.com",
 			expectedSecretLabel:    "app",
 		},
@@ -80,13 +76,17 @@ func TestCreateCacheByObject(t *testing.T) {
 			}
 
 			require.NoError(t, err)
-
-			if tt.expectNil {
-				require.Nil(t, result)
-				return
-			}
-
 			require.NotNil(t, result)
+
+			// The CRD schema-stripping entry is registered unconditionally, regardless of
+			// Secret/ConfigMap label selector configuration.
+			var foundCRDEntry bool
+			for obj := range result {
+				if _, ok := obj.(*apiextensionsv1.CustomResourceDefinition); ok {
+					foundCRDEntry = true
+				}
+			}
+			require.True(t, foundCRDEntry, "expected a cache.ByObject entry for CustomResourceDefinition")
 
 			if tt.expectedSecretLabel != "" {
 				for obj, v := range result {
@@ -109,4 +109,48 @@ func TestCreateCacheByObject(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestCRDCacheByObjectTransform(t *testing.T) {
+	newCRD := func(group string) *apiextensionsv1.CustomResourceDefinition {
+		return &apiextensionsv1.CustomResourceDefinition{
+			Spec: apiextensionsv1.CustomResourceDefinitionSpec{
+				Group: group,
+				Versions: []apiextensionsv1.CustomResourceDefinitionVersion{
+					{
+						Name:   "v1",
+						Schema: &apiextensionsv1.CustomResourceValidation{OpenAPIV3Schema: &apiextensionsv1.JSONSchemaProps{}},
+					},
+				},
+			},
+		}
+	}
+
+	transform := crdCacheByObject().Transform
+	require.NotNil(t, transform)
+
+	t.Run("strips schema for CRDs outside ssaCRDGroups", func(t *testing.T) {
+		out, err := transform(newCRD("gateway-operator.konghq.com"))
+		require.NoError(t, err)
+		crd, ok := out.(*apiextensionsv1.CustomResourceDefinition)
+		require.True(t, ok)
+		require.Nil(t, crd.Spec.Versions[0].Schema)
+	})
+
+	t.Run("keeps schema for CRDs in ssaCRDGroups", func(t *testing.T) {
+		for group := range ssaCRDGroups {
+			out, err := transform(newCRD(group))
+			require.NoError(t, err)
+			crd, ok := out.(*apiextensionsv1.CustomResourceDefinition)
+			require.True(t, ok)
+			require.NotNil(t, crd.Spec.Versions[0].Schema, "group %q should keep its schema", group)
+		}
+	})
+
+	t.Run("passes through non-CRD objects unchanged", func(t *testing.T) {
+		secret := &corev1.Secret{}
+		out, err := transform(secret)
+		require.NoError(t, err)
+		require.Same(t, secret, out)
+	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Add caching in SSA provider to decrease memory needed by the SSA provider.

Measured impact: this removes the 3.68 MB (of 7.2 MB total) of CRD YAML — including the 2.16 MB `gatewayconfigurations` CRD — that this cache currently holds for groups it never acts on.

Additionally add pagination to the list calls.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
