### PR TITLE
ci: disable dependabot for Golang dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,47 +1,5 @@
 version: 2
 updates:
-- package-ecosystem: gomod
-  directories:
-  - /
-  - /crd-from-oas/
-  schedule:
-    interval: daily
-  cooldown:
-    semver-major-days: 5
-    semver-minor-days: 2
-    semver-patch-days: 2
-    exclude:
-    - "github.com/Kong/*"
-    - "github.com/kong/*"
-    - "sigs.k8s.io/*"
-  labels:
-  - dependencies
-  # Create a group of dependencies to be updated together in one pull request
-  groups:
-     # Specify a name for the group, which will be used in pull request titles and branch names
-     k8s.io:
-        # Define patterns to include dependencies in the group (based on dependency name)
-        applies-to: version-updates # Applies the group rule to version updates
-        patterns:
-          - "k8s.io/*"
-        exclude-patterns:
-        - k8s.io/klog/*
-        - k8s.io/utils
-        - k8s.io/kube-openapi
-      # Specify a name for the group, which will be used in pull request titles and branch names
-     gateway-api:
-        # Define patterns to include dependencies in the group (based on dependency name)
-        applies-to: version-updates # Applies the group rule to version updates
-        patterns:
-          - "sigs.k8s.io/gateway-api"
-          - "sigs.k8s.io/gateway-api/*"
-     # Specify a name for the group, which will be used in pull request titles and branch names.
-     aws-sdk-go-v2:
-        # Define patterns to include dependencies in the group (based on dependency name).
-        applies-to: version-updates # Applies the group rule to version updates.
-        patterns:
-          - "github.com/aws/aws-sdk-go-v2"
-          - "github.com/aws/aws-sdk-go-v2/*"
 - package-ecosystem: github-actions
   directory: /
   schedule:

--- a/renovate.json
+++ b/renovate.json
@@ -12,7 +12,6 @@
   "enabledManagers": [
     "custom.regex",
     "kustomize",
-    // Only for Go toolchain updates, not module updates. Modules are still update via dependabot.
      "gomod",
      "dockerfile"
   ],
@@ -177,18 +176,58 @@
   ],
   "packageRules": [
     {
+      "description": "Cooldown for Go module major updates (was dependabot cooldown.semver-major-days)",
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["major"],
+      "minimumReleaseAge": "5 days"
+    },
+    {
+      "description": "Cooldown for Go module minor and patch updates (was dependabot cooldown.semver-{minor,patch}-days)",
+      "matchManagers": ["gomod"],
+      "matchUpdateTypes": ["minor", "patch"],
+      "minimumReleaseAge": "2 days"
+    },
+    {
+      "description": "No cooldown for Kong-owned and sigs.k8s.io modules (was dependabot cooldown.exclude)",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": [
+        "github.com/kong/**",
+        "github.com/Kong/**",
+        "sigs.k8s.io/**"
+      ],
+      "minimumReleaseAge": null
+    },
+    {
       "description": "Group all k8s.io/* module updates into one PR",
       "matchManagers": ["gomod"],
-      "matchPackageNames": ["/^k8s\\.io\\/.*/"],
-      "excludePackageNames": [
-        "k8s.io/utils",
-        "k8s.io/kube-openapi"
-      ],
-      "excludePackagePatterns": [
-        "^k8s\\.io/klog/.*$"
+      "matchPackageNames": [
+        "k8s.io/**",
+        "!k8s.io/utils",
+        "!k8s.io/kube-openapi",
+        "!k8s.io/klog/**"
       ],
       "groupName": "k8s.io modules",
       "groupSlug": "k8s-io-modules"
+    },
+    {
+      "description": "Group all sigs.k8s.io/gateway-api module updates into one PR",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": [
+        "sigs.k8s.io/gateway-api",
+        "sigs.k8s.io/gateway-api/**"
+      ],
+      "groupName": "gateway-api",
+      "groupSlug": "gateway-api"
+    },
+    {
+      "description": "Group all aws-sdk-go-v2 module updates into one PR",
+      "matchManagers": ["gomod"],
+      "matchPackageNames": [
+        "github.com/aws/aws-sdk-go-v2",
+        "github.com/aws/aws-sdk-go-v2/**"
+      ],
+      "groupName": "aws-sdk-go-v2",
+      "groupSlug": "aws-sdk-go-v2"
     },
     {
       "description": "Strip kustomize/ version prefix",
@@ -222,16 +261,6 @@
     },
 
     // Latest release branch specific rules for updating patch versions of Go toolchain and Dockerfiles.
-    {
-      "description": "Disable Go dependencies updates (still handled by dependabot)",
-      "matchManagers": ["gomod"],
-      "matchBaseBranches": [
-        "$default",
-        "release/2.1.x",
-        "release/2.2.x"
-      ],
-      "enabled": false
-    },
     {
       "description": "Disable dependency updates on 2.1 and 2.2",
       "matchBaseBranches": [


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR prevents multiple PRs to be created to bump the same Go dependency by disabling dependabot for Go deps and migrating to Renovate.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
