### PR TITLE
chore(hybridgateway): refactor HandleOrphanedResource in all Routes' implementation of OrphanedResourceHandler

### DIFF
--- a/controller/hybridgateway/converter/common.go
+++ b/controller/hybridgateway/converter/common.go
@@ -7,11 +7,13 @@ import (
 
 	"github.com/go-logr/logr"
 	"github.com/samber/lo"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	hybridgatewayerrors "github.com/kong/kong-operator/v2/controller/hybridgateway/errors"
+	"github.com/kong/kong-operator/v2/controller/hybridgateway/metadata"
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/refs"
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/utils"
 	"github.com/kong/kong-operator/v2/controller/pkg/log"
@@ -237,4 +239,62 @@ func convertOutputStoreToUnstructured(logger logr.Logger, scheme *runtime.Scheme
 
 	log.Debug(logger, "Successfully converted all objects in output store", "totalObjectsConverted", len(objects))
 	return objects, nil
+}
+
+// handleOrphanedResourceForRoute implements the OrphanedResourceHandler logic shared by every
+// route converter: it removes route from the shared hybrid-routes annotation on resource before
+// orphan deletion, atomically. Multiple Routes (or rules) can share the same Kong resource, so a
+// concurrent Route adding itself must not be lost and the resource must not be deleted while still
+// referenced. We re-read the live object, drop our entry, and either patch with an optimistic lock
+// (when other Routes remain) or surface the validated resourceVersion so the caller can delete with
+// an optimistic-lock precondition. routeKind is the route's Kind (e.g. "TCPRoute"), used to check
+// whether any other routes of the same kind remain in the annotation.
+func handleOrphanedResourceForRoute(
+	ctx context.Context, logger logr.Logger, cl client.Client, route client.Object, routeKind string,
+	resource *unstructured.Unstructured,
+) (skipDelete bool, err error) {
+	am := metadata.NewAnnotationManager(logger)
+	key := client.ObjectKeyFromObject(resource)
+	gvk := resource.GroupVersionKind()
+
+	fresh := &unstructured.Unstructured{}
+	fresh.SetGroupVersionKind(gvk)
+	if err := cl.Get(ctx, key, fresh); err != nil {
+		if apierrors.IsNotFound(err) {
+			// Already gone; nothing to delete.
+			return true, nil
+		}
+		return true, fmt.Errorf("failed to get resource: %w", err)
+	}
+
+	// If the route is not present in the hybrid-routes annotation of the Kong resource, don't touch it.
+	if !am.ContainsRoute(fresh, route) {
+		log.Trace(logger, "Route annotation not found, skipping resource", "kind", fresh.GetKind(), "obj", key)
+		return true, nil
+	}
+
+	base := fresh.DeepCopy()
+	am.RemoveRouteFromAnnotation(fresh, route)
+
+	// If other Routes are still present in the annotation, we just need to update the resource.
+	if len(am.GetRoutesWithKind(fresh, routeKind)) > 0 {
+		log.Debug(logger, "Updating hybrid-routes annotation", "kind", fresh.GetKind(), "obj", key)
+		if err := cl.Patch(ctx, fresh, client.MergeFromWithOptions(base, client.MergeFromWithOptimisticLock{})); err != nil {
+			if apierrors.IsNotFound(err) {
+				return true, nil
+			}
+			return true, fmt.Errorf("failed to update resource: %w", err)
+		}
+		// Reflect the persisted state back onto the caller's resource.
+		resource.SetAnnotations(fresh.GetAnnotations())
+		resource.SetResourceVersion(fresh.GetResourceVersion())
+		return true, nil
+	}
+
+	// No other routes remain. Surface the validated resourceVersion (and the annotation
+	// removal) on the caller's resource so the orphan deletion uses it as an optimistic-lock
+	// precondition, and don't skip deletion.
+	resource.SetAnnotations(fresh.GetAnnotations())
+	resource.SetResourceVersion(fresh.GetResourceVersion())
+	return false, nil
 }

--- a/controller/hybridgateway/converter/grpc_route.go
+++ b/controller/hybridgateway/converter/grpc_route.go
@@ -16,7 +16,6 @@ import (
 	configurationv1alpha1 "github.com/kong/kong-operator/v2/api/configuration/v1alpha1"
 	konnectv1alpha1 "github.com/kong/kong-operator/v2/api/konnect/v1alpha1"
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/kongroute"
-	"github.com/kong/kong-operator/v2/controller/hybridgateway/metadata"
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/namegen"
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/plugin"
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/pluginbinding"
@@ -44,50 +43,7 @@ type grpcRouteConverter struct {
 
 // HandleOrphanedResource removes this GRPCRoute from an orphaned resource's hybrid-routes annotation.
 func (c *grpcRouteConverter) HandleOrphanedResource(ctx context.Context, logger logr.Logger, resource *unstructured.Unstructured) (skipDelete bool, err error) {
-	am := metadata.NewAnnotationManager(logger)
-	key := client.ObjectKeyFromObject(resource)
-	gvk := resource.GroupVersionKind()
-
-	fresh := &unstructured.Unstructured{}
-	fresh.SetGroupVersionKind(gvk)
-	if err := c.Get(ctx, key, fresh); err != nil {
-		if apierrors.IsNotFound(err) {
-			// Already gone; nothing to delete.
-			return true, nil
-		}
-		return true, fmt.Errorf("failed to get resource: %w", err)
-	}
-
-	// If the route is not present in the hybrid-routes annotation of the Kong resource, don't touch it.
-	if !am.ContainsRoute(fresh, c.route) {
-		log.Trace(logger, "Route annotation not found, skipping resource", "kind", fresh.GetKind(), "obj", key)
-		return true, nil
-	}
-
-	base := fresh.DeepCopy()
-	am.RemoveRouteFromAnnotation(fresh, c.route)
-
-	// If other Routes are still present in the annotation, we just need to update the resource.
-	if len(am.GetRoutesWithKind(fresh, "GRPCRoute")) > 0 {
-		log.Debug(logger, "Updating hybrid-routes annotation", "kind", fresh.GetKind(), "obj", key)
-		if err := c.Patch(ctx, fresh, client.MergeFromWithOptions(base, client.MergeFromWithOptimisticLock{})); err != nil {
-			if apierrors.IsNotFound(err) {
-				return true, nil
-			}
-			return true, fmt.Errorf("failed to update resource: %w", err)
-		}
-		// Reflect the persisted state back onto the caller's resource.
-		resource.SetAnnotations(fresh.GetAnnotations())
-		resource.SetResourceVersion(fresh.GetResourceVersion())
-		return true, nil
-	}
-
-	// No other routes remain. Surface the validated resourceVersion (and the annotation
-	// removal) on the caller's resource so the orphan deletion uses it as an optimistic-lock
-	// precondition, and don't skip deletion.
-	resource.SetAnnotations(fresh.GetAnnotations())
-	resource.SetResourceVersion(fresh.GetResourceVersion())
-	return false, nil
+	return handleOrphanedResourceForRoute(ctx, logger, c.Client, c.route, "GRPCRoute", resource)
 }
 
 // DesiredResourcesReady implements DesiredStateReadinessChecker. It decides whether orphan cleanup

--- a/controller/hybridgateway/converter/http_route.go
+++ b/controller/hybridgateway/converter/http_route.go
@@ -18,7 +18,6 @@ import (
 	configurationv1alpha1 "github.com/kong/kong-operator/v2/api/configuration/v1alpha1"
 	konnectv1alpha1 "github.com/kong/kong-operator/v2/api/konnect/v1alpha1"
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/kongroute"
-	"github.com/kong/kong-operator/v2/controller/hybridgateway/metadata"
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/namegen"
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/plugin"
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/pluginbinding"
@@ -234,70 +233,9 @@ func (c *httpRouteConverter) DesiredResourcesReady(ctx context.Context, logger l
 }
 
 // HandleOrphanedResource implements OrphanedResourceHandler.
-//
-// Processes orphaned resources by checking and updating hybrid-routes annotations.
-// This method is called during cleanup to check if the resource passed as argument was part of the set of translated resources
-// derived from the source HTTPRoute. If so, it removes the route reference from the hybrid-routes annotation and determines whether
-// to update the resource and if it should be skipped from deletion.
-//
-// Parameters:
-//   - ctx: The context for API calls and cancellation
-//   - logger: Logger for debugging information
-//   - resource: The orphaned resource to process
-//
-// Returns:
-//   - skipDelete: true if the resource should NOT be deleted (skip deletion), false if it should be deleted
-//   - err: any error that occurred during processing
+// It removes the HTTPRoute reference from shared resources before orphan deletion.
 func (c *httpRouteConverter) HandleOrphanedResource(ctx context.Context, logger logr.Logger, resource *unstructured.Unstructured) (skipDelete bool, err error) {
-	am := metadata.NewAnnotationManager(logger)
-	key := client.ObjectKeyFromObject(resource)
-	gvk := resource.GroupVersionKind()
-
-	// Remove this Route from the shared hybrid-routes annotation atomically. Multiple Routes (or
-	// rules) can share the same Kong resource, so a concurrent Route adding itself must not be lost
-	// and the resource must not be deleted while still referenced. We re-read the live object, drop
-	// our entry, and either patch with an optimistic lock (when other Routes remain) or surface the
-	// validated resourceVersion so the caller can delete with an optimistic-lock precondition.
-	fresh := &unstructured.Unstructured{}
-	fresh.SetGroupVersionKind(gvk)
-	if err := c.Get(ctx, key, fresh); err != nil {
-		if apierrors.IsNotFound(err) {
-			// Already gone; nothing to delete.
-			return true, nil
-		}
-		return true, fmt.Errorf("failed to get resource: %w", err)
-	}
-
-	// If the route is not present in the hybrid-routes annotation of the Kong resource, don't touch it.
-	if !am.ContainsRoute(fresh, c.route) {
-		log.Trace(logger, "Route annotation not found, skipping resource", "kind", fresh.GetKind(), "obj", key)
-		return true, nil
-	}
-
-	base := fresh.DeepCopy()
-	am.RemoveRouteFromAnnotation(fresh, c.route)
-
-	// If other Routes are still present in the annotation, we just need to update the resource.
-	if len(am.GetRoutesWithKind(fresh, "HTTPRoute")) > 0 {
-		log.Debug(logger, "Updating hybrid-routes annotation", "kind", fresh.GetKind(), "obj", key)
-		if err := c.Patch(ctx, fresh, client.MergeFromWithOptions(base, client.MergeFromWithOptimisticLock{})); err != nil {
-			if apierrors.IsNotFound(err) {
-				return true, nil
-			}
-			return true, fmt.Errorf("failed to update resource: %w", err)
-		}
-		// Reflect the persisted state back onto the caller's resource.
-		resource.SetAnnotations(fresh.GetAnnotations())
-		resource.SetResourceVersion(fresh.GetResourceVersion())
-		return true, nil
-	}
-
-	// No other routes remain. Surface the validated resourceVersion (and the annotation
-	// removal) on the caller's resource so the orphan deletion uses it as an optimistic-lock
-	// precondition, and don't skip deletion.
-	resource.SetAnnotations(fresh.GetAnnotations())
-	resource.SetResourceVersion(fresh.GetResourceVersion())
-	return false, nil
+	return handleOrphanedResourceForRoute(ctx, logger, c.Client, c.route, "HTTPRoute", resource)
 }
 
 // translate converts the HTTPRoute to Kong resources and stores them in outputStore.

--- a/controller/hybridgateway/converter/tcp_route.go
+++ b/controller/hybridgateway/converter/tcp_route.go
@@ -6,14 +6,12 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	configurationv1alpha1 "github.com/kong/kong-operator/v2/api/configuration/v1alpha1"
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/kongroute"
-	"github.com/kong/kong-operator/v2/controller/hybridgateway/metadata"
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/route"
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/service"
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/target"
@@ -79,43 +77,7 @@ func (c *tcpRouteConverter) GetOutputStore(_ context.Context, logger logr.Logger
 // HandleOrphanedResource implements OrphanedResourceHandler.
 // It removes the TCPRoute reference from shared resources before orphan deletion.
 func (c *tcpRouteConverter) HandleOrphanedResource(ctx context.Context, logger logr.Logger, resource *unstructured.Unstructured) (skipDelete bool, err error) {
-	am := metadata.NewAnnotationManager(logger)
-	key := client.ObjectKeyFromObject(resource)
-	gvk := resource.GroupVersionKind()
-
-	fresh := &unstructured.Unstructured{}
-	fresh.SetGroupVersionKind(gvk)
-	if err := c.Get(ctx, key, fresh); err != nil {
-		if apierrors.IsNotFound(err) {
-			return true, nil
-		}
-		return true, fmt.Errorf("failed to get resource: %w", err)
-	}
-
-	if !am.ContainsRoute(fresh, c.route) {
-		log.Trace(logger, "Route annotation not found, skipping resource", "kind", fresh.GetKind(), "obj", key)
-		return true, nil
-	}
-
-	base := fresh.DeepCopy()
-	am.RemoveRouteFromAnnotation(fresh, c.route)
-
-	if len(am.GetRoutesWithKind(fresh, "TCPRoute")) > 0 {
-		log.Debug(logger, "Updating hybrid-routes annotation", "kind", fresh.GetKind(), "obj", key)
-		if err := c.Patch(ctx, fresh, client.MergeFromWithOptions(base, client.MergeFromWithOptimisticLock{})); err != nil {
-			if apierrors.IsNotFound(err) {
-				return true, nil
-			}
-			return true, fmt.Errorf("failed to update resource: %w", err)
-		}
-		resource.SetAnnotations(fresh.GetAnnotations())
-		resource.SetResourceVersion(fresh.GetResourceVersion())
-		return true, nil
-	}
-
-	resource.SetAnnotations(fresh.GetAnnotations())
-	resource.SetResourceVersion(fresh.GetResourceVersion())
-	return false, nil
+	return handleOrphanedResourceForRoute(ctx, logger, c.Client, c.route, tcpRouteKind, resource)
 }
 
 // Translate implements the APIConverter interface.

--- a/controller/hybridgateway/converter/tls_route.go
+++ b/controller/hybridgateway/converter/tls_route.go
@@ -6,14 +6,12 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	configurationv1alpha1 "github.com/kong/kong-operator/v2/api/configuration/v1alpha1"
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/kongroute"
-	"github.com/kong/kong-operator/v2/controller/hybridgateway/metadata"
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/route"
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/service"
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/target"
@@ -94,55 +92,7 @@ func (c *tlsRouteConverter) GetOutputStore(_ context.Context, logger logr.Logger
 //   - skipDelete: true if the resource should NOT be deleted (skip deletion), false if it should be deleted
 //   - err: any error that occurred during processing
 func (c *tlsRouteConverter) HandleOrphanedResource(ctx context.Context, logger logr.Logger, resource *unstructured.Unstructured) (skipDelete bool, err error) {
-	am := metadata.NewAnnotationManager(logger)
-	key := client.ObjectKeyFromObject(resource)
-	gvk := resource.GroupVersionKind()
-
-	// Remove this Route from the shared hybrid-routes annotation atomically. Multiple Routes (or
-	// rules) can share the same Kong resource, so a concurrent Route adding itself must not be lost
-	// and the resource must not be deleted while still referenced. We re-read the live object, drop
-	// our entry, and either patch with an optimistic lock (when other Routes remain) or surface the
-	// validated resourceVersion so the caller can delete with an optimistic-lock precondition.
-	fresh := &unstructured.Unstructured{}
-	fresh.SetGroupVersionKind(gvk)
-	if err := c.Get(ctx, key, fresh); err != nil {
-		if apierrors.IsNotFound(err) {
-			// Already gone; nothing to delete.
-			return true, nil
-		}
-		return true, fmt.Errorf("failed to get resource: %w", err)
-	}
-
-	// If the route is not present in the hybrid-routes annotation of the Kong resource, don't touch it.
-	if !am.ContainsRoute(fresh, c.route) {
-		log.Trace(logger, "Route annotation not found, skipping resource", "kind", fresh.GetKind(), "obj", key)
-		return true, nil
-	}
-
-	base := fresh.DeepCopy()
-	am.RemoveRouteFromAnnotation(fresh, c.route)
-
-	// If other Routes are still present in the annotation, we just need to update the resource.
-	if len(am.GetRoutesWithKind(fresh, "TLSRoute")) > 0 {
-		log.Debug(logger, "Updating hybrid-routes annotation", "kind", fresh.GetKind(), "obj", key)
-		if err := c.Patch(ctx, fresh, client.MergeFromWithOptions(base, client.MergeFromWithOptimisticLock{})); err != nil {
-			if apierrors.IsNotFound(err) {
-				return true, nil
-			}
-			return true, fmt.Errorf("failed to update resource: %w", err)
-		}
-		// Reflect the persisted state back onto the caller's resource.
-		resource.SetAnnotations(fresh.GetAnnotations())
-		resource.SetResourceVersion(fresh.GetResourceVersion())
-		return true, nil
-	}
-
-	// No other routes remain. Surface the validated resourceVersion (and the annotation
-	// removal) on the caller's resource so the orphan deletion uses it as an optimistic-lock
-	// precondition, and don't skip deletion.
-	resource.SetAnnotations(fresh.GetAnnotations())
-	resource.SetResourceVersion(fresh.GetResourceVersion())
-	return false, nil
+	return handleOrphanedResourceForRoute(ctx, logger, c.Client, c.route, "TLSRoute", resource)
 }
 
 // Translate implements APIConverter.

--- a/controller/hybridgateway/converter/udp_route.go
+++ b/controller/hybridgateway/converter/udp_route.go
@@ -6,14 +6,12 @@ import (
 	"fmt"
 
 	"github.com/go-logr/logr"
-	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	configurationv1alpha1 "github.com/kong/kong-operator/v2/api/configuration/v1alpha1"
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/kongroute"
-	"github.com/kong/kong-operator/v2/controller/hybridgateway/metadata"
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/route"
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/service"
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/target"
@@ -79,43 +77,7 @@ func (c *udpRouteConverter) GetOutputStore(_ context.Context, logger logr.Logger
 // HandleOrphanedResource implements OrphanedResourceHandler.
 // It removes the UDPRoute reference from shared resources before orphan deletion.
 func (c *udpRouteConverter) HandleOrphanedResource(ctx context.Context, logger logr.Logger, resource *unstructured.Unstructured) (skipDelete bool, err error) {
-	am := metadata.NewAnnotationManager(logger)
-	key := client.ObjectKeyFromObject(resource)
-	gvk := resource.GroupVersionKind()
-
-	fresh := &unstructured.Unstructured{}
-	fresh.SetGroupVersionKind(gvk)
-	if err := c.Get(ctx, key, fresh); err != nil {
-		if apierrors.IsNotFound(err) {
-			return true, nil
-		}
-		return true, fmt.Errorf("failed to get resource: %w", err)
-	}
-
-	if !am.ContainsRoute(fresh, c.route) {
-		log.Trace(logger, "Route annotation not found, skipping resource", "kind", fresh.GetKind(), "obj", key)
-		return true, nil
-	}
-
-	base := fresh.DeepCopy()
-	am.RemoveRouteFromAnnotation(fresh, c.route)
-
-	if len(am.GetRoutesWithKind(fresh, "UDPRoute")) > 0 {
-		log.Debug(logger, "Updating hybrid-routes annotation", "kind", fresh.GetKind(), "obj", key)
-		if err := c.Patch(ctx, fresh, client.MergeFromWithOptions(base, client.MergeFromWithOptimisticLock{})); err != nil {
-			if apierrors.IsNotFound(err) {
-				return true, nil
-			}
-			return true, fmt.Errorf("failed to update resource: %w", err)
-		}
-		resource.SetAnnotations(fresh.GetAnnotations())
-		resource.SetResourceVersion(fresh.GetResourceVersion())
-		return true, nil
-	}
-
-	resource.SetAnnotations(fresh.GetAnnotations())
-	resource.SetResourceVersion(fresh.GetResourceVersion())
-	return false, nil
+	return handleOrphanedResourceForRoute(ctx, logger, c.Client, c.route, udpRouteKind, resource)
 }
 
 // Translate implements the APIConverter interface.


### PR DESCRIPTION
**What this PR does / why we need it**:

`HandleOrphanedResource` is implemented by all kinds of Routes, but almost byte-identical.
This PR refactored it, added a common `handleOrphanedResourceForRoute`, which is shared by every Route's `OrphanedResourceHandler.HandleOrphanedResource` implementation.

**Which issue this PR fixes**

Part of #5099

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
