### PR TITLE
tests(crdsvalidation): share envtest setup to prevent resource contention and spawning too many etcd and kubeapiserver instances

### DIFF
--- a/test/crdsvalidation/aigateway.konghq.com/main_test.go
+++ b/test/crdsvalidation/aigateway.konghq.com/main_test.go
@@ -1,0 +1,15 @@
+package crdsvalidation_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/kong/kong-operator/v2/test/envtest"
+)
+
+// TestMain shares a single envtest environment across every test in this
+// package instead of starting a fresh etcd+API server pair (and reinstalling
+// every CRD) per test. See envtest.RunWithSharedEnvironment.
+func TestMain(m *testing.M) {
+	os.Exit(envtest.RunWithSharedEnvironment(m))
+}

--- a/test/crdsvalidation/common/testcase.go
+++ b/test/crdsvalidation/common/testcase.go
@@ -38,7 +38,7 @@ func (g TestCasesGroup[T]) Run(t *testing.T) {
 
 const (
 	// DefaultEventuallyTimeout is the default timeout for EventuallyConfig.
-	DefaultEventuallyTimeout = 5 * time.Second
+	DefaultEventuallyTimeout = 30 * time.Second
 	// DefaultEventuallyPeriod is the default period for EventuallyConfig.
 	DefaultEventuallyPeriod = 10 * time.Millisecond
 )
@@ -223,15 +223,27 @@ func (tc *TestCase[T]) RunWithConfig(t *testing.T, cfg *rest.Config, scheme *run
 			desiredObj.SetName(tc.TestObject.GetName())
 			desiredObj.SetResourceVersion(tc.TestObject.GetResourceVersion())
 
-			err = cl.Status().Update(ctx, desiredObj)
-			require.NoError(t, err)
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				// Refresh the resource version on every attempt: if a prior update
+				// actually landed server-side but the client just timed out waiting
+				// for the response, reusing the stale resource version would turn
+				// the retry into a spurious conflict.
+				if !assert.NoError(c, cl.Get(ctx, client.ObjectKeyFromObject(tc.TestObject), tc.TestObject)) {
+					return
+				}
+				desiredObj.SetResourceVersion(tc.TestObject.GetResourceVersion())
+				assert.NoError(c, cl.Status().Update(ctx, desiredObj))
+			}, timeout, period)
 
-			err = cl.Get(ctx, client.ObjectKeyFromObject(tc.TestObject), tc.TestObject)
-			require.NoError(t, err)
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				assert.NoError(c, cl.Get(ctx, client.ObjectKeyFromObject(tc.TestObject), tc.TestObject))
+			}, timeout, period)
 		}
 
 		if tc.Assert != nil {
-			require.NoError(t, cl.Get(ctx, client.ObjectKeyFromObject(tc.TestObject), tc.TestObject))
+			require.EventuallyWithT(t, func(c *assert.CollectT) {
+				assert.NoError(c, cl.Get(ctx, client.ObjectKeyFromObject(tc.TestObject), tc.TestObject))
+			}, timeout, period)
 			tc.Assert(t, tc.TestObject)
 		}
 

--- a/test/crdsvalidation/configuration.konghq.com/main_test.go
+++ b/test/crdsvalidation/configuration.konghq.com/main_test.go
@@ -1,0 +1,15 @@
+package configuration_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/kong/kong-operator/v2/test/envtest"
+)
+
+// TestMain shares a single envtest environment across every test in this
+// package instead of starting a fresh etcd+API server pair (and reinstalling
+// every CRD) per test. See envtest.RunWithSharedEnvironment.
+func TestMain(m *testing.M) {
+	os.Exit(envtest.RunWithSharedEnvironment(m))
+}

--- a/test/crdsvalidation/gateway-operator.konghq.com/main_test.go
+++ b/test/crdsvalidation/gateway-operator.konghq.com/main_test.go
@@ -1,0 +1,15 @@
+package crdsvalidation_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/kong/kong-operator/v2/test/envtest"
+)
+
+// TestMain shares a single envtest environment across every test in this
+// package instead of starting a fresh etcd+API server pair (and reinstalling
+// every CRD) per test. See envtest.RunWithSharedEnvironment.
+func TestMain(m *testing.M) {
+	os.Exit(envtest.RunWithSharedEnvironment(m))
+}

--- a/test/crdsvalidation/konnect.konghq.com/main_test.go
+++ b/test/crdsvalidation/konnect.konghq.com/main_test.go
@@ -1,0 +1,15 @@
+package crdsvalidation_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/kong/kong-operator/v2/test/envtest"
+)
+
+// TestMain shares a single envtest environment across every test in this
+// package instead of starting a fresh etcd+API server pair (and reinstalling
+// every CRD) per test. See envtest.RunWithSharedEnvironment.
+func TestMain(m *testing.M) {
+	os.Exit(envtest.RunWithSharedEnvironment(m))
+}

--- a/test/envtest/setup.go
+++ b/test/envtest/setup.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"os/signal"
+	"slices"
 	"strings"
 	"sync"
 	"syscall"
@@ -42,6 +43,12 @@ var DefaultEnvTestOpts = Options{
 	InstallKongCRDs:    true,
 }
 
+func optionsEqual(a, b Options) bool {
+	return a.InstallGatewayCRDs == b.InstallGatewayCRDs &&
+		a.InstallKongCRDs == b.InstallKongCRDs &&
+		slices.Equal(a.AdditionalCRDPaths, b.AdditionalCRDPaths)
+}
+
 type OptionModifier func(Options) Options
 
 func WithInstallKongCRDs(install bool) OptionModifier {
@@ -67,15 +74,85 @@ func WithAdditionalCRDPaths(paths []string) OptionModifier {
 
 const (
 	// maxEnvtestStartAttempts bounds how many times we rebuild testEnv when the
-	// webhook server's port was stolen between allocation and bind (EADDRINUSE).
+	// control plane fails to start in time (e.g. the API server times out while
+	// installing CRDs under load) or the webhook server's port was stolen between
+	// allocation and bind (EADDRINUSE).
 	maxEnvtestStartAttempts = 10
 	// webhookBindProbe is how long we wait for ws.Start to surface a bind error
 	// before treating the server as successfully serving. Binding is synchronous
 	// and near-instant, so this only adds latency on the (common) success path.
 	webhookBindProbe = 500 * time.Millisecond
+	// controlPlaneStartTimeout bounds how long we wait for the API server/etcd to
+	// come up and, when CRDs are configured, for them to be installed. The
+	// controller-runtime default (20s) is too tight when many envtest environments
+	// start concurrently in CI, so this is set generously.
+	controlPlaneStartTimeout = 2 * time.Minute
+	// crdInstallMaxTime bounds how long envtest waits for installed CRDs to become
+	// established. Kept in step with controlPlaneStartTimeout for the same reason.
+	crdInstallMaxTime = 2 * time.Minute
 )
 
 var once sync.Once = sync.Once{}
+
+// Shared envtest environment support: opt-in via RunWithSharedEnvironment,
+// used by packages (e.g. test/crdsvalidation/*) that only need installed CRDs
+// and a fresh namespace per test, to avoid starting one etcd+API server pair
+// per test. Guarded by sharedEnvMu rather than [sync.Once] so a failed
+// creation attempt can be retried by the next test instead of poisoning the
+// package.
+var (
+	sharedEnvMu      sync.Mutex
+	sharedEnvEnabled bool
+	sharedEnvOpts    Options
+	sharedEnvCfg     *rest.Config
+	sharedEnvStop    func()
+)
+
+// RunWithSharedEnvironment runs m.Run() against a single envtest environment
+// shared by every test in the package, instead of starting a fresh
+// etcd+API server pair (and reinstalling all CRDs) per test.
+//
+// Only use this for packages whose tests need nothing beyond installed CRDs
+// and their own namespace (e.g. test/crdsvalidation/*): the environment and
+// its installed CRDs are never reset between tests, and every Setup call in
+// the package must request the same Options.
+func RunWithSharedEnvironment(m *testing.M) int {
+	sharedEnvEnabled = true
+	code := m.Run()
+
+	sharedEnvMu.Lock()
+	stop := sharedEnvStop
+	sharedEnvMu.Unlock()
+	if stop != nil {
+		stop()
+	}
+
+	return code
+}
+
+// makeStopper starts a goroutine that stops testEnv either when the process
+// receives SIGINT/SIGTERM or when the returned stop func is called, and
+// returns that stop func.
+func makeStopper(testEnv *envtest.Environment) func() {
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	done := make(chan struct{})
+	ch := make(chan os.Signal, 1)
+	signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
+	go func() {
+		defer wg.Done()
+		select {
+		case <-ch:
+			_ = testEnv.Stop()
+		case <-done:
+			_ = testEnv.Stop()
+		}
+	}()
+	return func() {
+		close(done)
+		wg.Wait()
+	}
+}
 
 func createWebhookServer(scheme *runtime.Scheme, webhookOpts envtest.WebhookInstallOptions) webhook.Server {
 	ws := webhook.NewServer(webhook.Options{
@@ -89,15 +166,16 @@ func createWebhookServer(scheme *runtime.Scheme, webhookOpts envtest.WebhookInst
 
 func createTestEnv(scheme *runtime.Scheme, crdPaths []string) *envtest.Environment {
 	testEnv := &envtest.Environment{
-		ControlPlaneStopTimeout: time.Second * 60,
-		Scheme:                  scheme,
+		ControlPlaneStartTimeout: controlPlaneStartTimeout,
+		ControlPlaneStopTimeout:  time.Second * 60,
+		Scheme:                   scheme,
 	}
 	if len(crdPaths) > 0 {
 		testEnv.CRDInstallOptions = envtest.CRDInstallOptions{
 			Paths:              crdPaths,
 			Scheme:             scheme,
 			ErrorIfPathMissing: true,
-			MaxTime:            30 * time.Second,
+			MaxTime:            crdInstallMaxTime,
 		}
 	}
 
@@ -119,34 +197,30 @@ func generateCRDPaths(opts Options) []string {
 	return crdPaths
 }
 
-// Setup sets up a test k8s API server environment and returned the configuration.
-func Setup(t *testing.T, ctx context.Context, scheme *runtime.Scheme, optModifiers ...OptionModifier) (*rest.Config, *corev1.Namespace) {
-	once.Do(func() {
-		f, err := testutil.SetupControllerLogger("stdout")
-		require.NoError(t, err)
-		t.Cleanup(func() {
-			require.NoError(t, f())
-		})
-	})
-
+// startEnv starts a fresh envtest environment (control plane + conversion
+// webhook server), retrying the whole environment when the control plane
+// fails to start in time or the webhook server's allocated port gets stolen.
+func startEnv(t *testing.T, ctx context.Context, scheme *runtime.Scheme, crdPaths []string) (*envtest.Environment, *rest.Config) {
 	t.Helper()
 
-	opts := DefaultEnvTestOpts
-	for _, mod := range optModifiers {
-		opts = mod(opts)
-	}
-
 	var (
-		crdPaths = generateCRDPaths(opts)
-		testEnv  *envtest.Environment
-		cfg      *rest.Config
+		testEnv *envtest.Environment
+		cfg     *rest.Config
 	)
 	for attempt := 1; ; attempt++ {
 		testEnv = createTestEnv(scheme, crdPaths)
 		t.Logf("starting envtest environment for test %s (attempt %d)...", t.Name(), attempt)
 		var err error
 		cfg, err = testEnv.Start()
-		require.NoError(t, err)
+		if err != nil {
+			if attempt < maxEnvtestStartAttempts {
+				t.Logf("envtest environment failed to start (%v); retrying with a fresh environment (attempt %d/%d)...", err, attempt+1, maxEnvtestStartAttempts)
+				_ = testEnv.Stop()
+				time.Sleep(time.Duration(attempt) * time.Second)
+				continue
+			}
+			require.NoError(t, err)
+		}
 
 		errCh := make(chan error, 1)
 		go func() {
@@ -179,20 +253,66 @@ func Setup(t *testing.T, ctx context.Context, scheme *runtime.Scheme, optModifie
 		break
 	}
 
-	wg := sync.WaitGroup{}
-	wg.Add(1)
-	done := make(chan struct{})
-	ch := make(chan os.Signal, 1)
-	signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
-	go func() {
-		defer wg.Done()
-		select {
-		case <-ch:
-			_ = testEnv.Stop()
-		case <-done:
-			_ = testEnv.Stop()
+	return testEnv, cfg
+}
+
+// getSharedEnvConfig returns the package's shared envtest environment's
+// rest.Config, creating it on first use. Guarded by sharedEnvMu so concurrent
+// (t.Parallel()) callers don't race to create it, and so a failed creation
+// attempt can be retried by whichever caller acquires the lock next.
+func getSharedEnvConfig(t *testing.T, scheme *runtime.Scheme, opts Options) *rest.Config {
+	t.Helper()
+
+	sharedEnvMu.Lock()
+	defer sharedEnvMu.Unlock()
+
+	if sharedEnvCfg != nil {
+		if !optionsEqual(opts, sharedEnvOpts) {
+			t.Fatalf("envtest: shared environment was created with Options %+v, but this test requested %+v; "+
+				"all tests in a package using RunWithSharedEnvironment must request the same Options", sharedEnvOpts, opts)
 		}
-	}()
+		return sharedEnvCfg
+	}
+
+	// The shared webhook server must outlive the test that happens to create it,
+	// so it can't be tied to that test's (cancelled-on-completion) context.
+	testEnv, cfg := startEnv(t, context.Background(), scheme, generateCRDPaths(opts))
+	sharedEnvStop = makeStopper(testEnv)
+	sharedEnvOpts = opts
+	sharedEnvCfg = cfg
+	return cfg
+}
+
+// Setup sets up a test k8s API server environment and returned the configuration.
+func Setup(t *testing.T, ctx context.Context, scheme *runtime.Scheme, optModifiers ...OptionModifier) (*rest.Config, *corev1.Namespace) {
+	once.Do(func() {
+		f, err := testutil.SetupControllerLogger("stdout")
+		require.NoError(t, err)
+		t.Cleanup(func() {
+			require.NoError(t, f())
+		})
+	})
+
+	t.Helper()
+
+	opts := DefaultEnvTestOpts
+	for _, mod := range optModifiers {
+		opts = mod(opts)
+	}
+
+	var cfg *rest.Config
+	if sharedEnvEnabled {
+		cfg = rest.CopyConfig(getSharedEnvConfig(t, scheme, opts))
+	} else {
+		testEnv, envCfg := startEnv(t, ctx, scheme, generateCRDPaths(opts))
+		stop := makeStopper(testEnv)
+		t.Cleanup(func() {
+			t.Helper()
+			t.Logf("stopping envtest environment for test %s", t.Name())
+			stop()
+		})
+		cfg = envCfg
+	}
 
 	config, err := clientcmd.BuildConfigFromFlags(cfg.Host, "")
 	require.NoError(t, err)
@@ -220,14 +340,9 @@ func Setup(t *testing.T, ctx context.Context, scheme *runtime.Scheme, optModifie
 			},
 		},
 	}
-	require.NoError(t, cl.Create(ctx, ns))
-
-	t.Cleanup(func() {
-		t.Helper()
-		t.Logf("stopping envtest environment for test %s", t.Name())
-		close(done)
-		wg.Wait()
-	})
+	require.EventuallyWithT(t, func(c *assert.CollectT) {
+		assert.NoError(c, cl.Create(ctx, ns))
+	}, 30*time.Second, time.Second, "failed to create test namespace")
 
 	return cfg, ns
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Prevent errors like:

https://github.com/Kong/kong-operator/actions/runs/31593139426/job/94102496385?pr=5009

```
    kongcredentialhmac_test.go:23: 
        	Error Trace:	/home/runner/work/kong-operator/kong-operator/test/envtest/setup.go:149
        	            				/home/runner/work/kong-operator/kong-operator/test/crdsvalidation/configuration.konghq.com/kongcredentialhmac_test.go:23
        	Error:      	Received unexpected error:
        	            	unable to install CRDs onto control plane: unable to create CRD instances: unable to create CRD "dataplanes.gateway-operator.konghq.com": the server was unable to return a response in the time allotted, but may still be processing the request (post customresourcedefinitions.apiextensions.k8s.io)
        	Test:       	TestKongCredentialHMAC
    testcase.go:152: 
        	Error Trace:	/home/runner/work/kong-operator/kong-operator/test/crdsvalidation/common/testcase.go:152
        	            				/home/runner/work/kong-operator/kong-operator/test/crdsvalidation/common/testcase.go:177
        	Error:      	create condition not satisfied before timeout
        	Test:       	TestKongConsumerGroup/cp_ref/cpRef_change_(type=konnectNamespacedRef)_is_allowed_when_object_is_Programmed=False
        	Messages:   	Create error: the server was unable to return a response in the time allotted, but may still be processing the request (post kongconsumergroups.configuration.konghq.com)
```

by sharing the envtest setup. This will cause the envtest suite to spawn envtest components per test package not per test.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
