### PR TITLE
feat(crd-from-oas)Add SupportCrossNamespaceReference in ReferenceConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -99,6 +99,9 @@
   [#5269](https://github.com/Kong/kong-operator/pull/5269)
 - AIGateway: enable AIGatewayAgent and AIGatewayModel to reference IdentityProvider
   [#5265](https://github.com/Kong/kong-operator/pull/5265)
+- CRD-from-OAS: enable resources to reference other resources from different
+  namespaces by setting `supportCrossNamespaceReference` in `ReferenceConfig`.
+  [#5263](https://github.com/Kong/kong-operator/pull/5263)
 
 ### Fixes
 

--- a/api/configuration/v1alpha1/zz_generated_eventgatewayvirtualclusterconsumepolicy_sdkops.go
+++ b/api/configuration/v1alpha1/zz_generated_eventgatewayvirtualclusterconsumepolicy_sdkops.go
@@ -472,6 +472,15 @@ func (obj *EventGatewayVirtualClusterConsumePolicy) ResolveKonnectReferences(ctx
 	return errors.Join(errs...)
 }
 
+// CrossNamespaceSiblingReferences returns every cross-namespace sibling
+// reference declared on obj's spec whose SupportCrossNamespaceReference is
+// enabled, for callers to authorize against KongReferenceGrant before
+// calling ResolveKonnectReferences.
+func (obj *EventGatewayVirtualClusterConsumePolicy) CrossNamespaceSiblingReferences() []CrossNamespaceReferenceCheck {
+	var checks []CrossNamespaceReferenceCheck
+	return checks
+}
+
 // ToCreateEventGatewayVirtualClusterConsumePolicyRequest converts the EventGatewayVirtualClusterConsumePolicy to the SDK type
 // sdkkonnectoper.CreateEventGatewayVirtualClusterConsumePolicyRequest, resolving referenced CRs via the provided client.
 func (obj *EventGatewayVirtualClusterConsumePolicy) ToCreateEventGatewayVirtualClusterConsumePolicyRequest(ctx context.Context, cl client.Client) (*sdkkonnectoper.CreateEventGatewayVirtualClusterConsumePolicyRequest, error) {

--- a/api/configuration/v1alpha1/zz_generated_references.go
+++ b/api/configuration/v1alpha1/zz_generated_references.go
@@ -2,7 +2,11 @@
 
 package v1alpha1
 
-import "fmt"
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
 
 const (
 	// KonnectReferencesResolvedConditionType indicates whether all CR references
@@ -19,10 +23,28 @@ const (
 	// KonnectReferencesResolvedReasonInvalid indicates a reference is invalid
 	// and cannot be resolved by waiting for the referenced CR to be programmed.
 	KonnectReferencesResolvedReasonInvalid = "ReferenceInvalid"
+	// KonnectReferencesResolvedReasonNotPermitted indicates a cross-namespace
+	// reference is not permitted by any KongReferenceGrant in the referenced
+	// namespace.
+	KonnectReferencesResolvedReasonNotPermitted = "ReferenceNotPermitted"
 	// KonnectReferencesResolvedReasonResolutionFailed indicates references failed
 	// for multiple reasons. The condition message contains per-reference details.
 	KonnectReferencesResolvedReasonResolutionFailed = "ReferenceResolutionFailed"
 )
+
+// CrossNamespaceReferenceCheck describes one cross-namespace sibling
+// reference (a ReferenceConfig entry with SupportCrossNamespaceReference:
+// true whose target namespace differs from the referrer's) that must be
+// authorized by a KongReferenceGrant before it is resolved. Entities that
+// declare such references expose them via CrossNamespaceSiblingReferences,
+// for callers outside this package to check against KongReferenceGrant
+// before calling ResolveKonnectReferences.
+//
+// +kubebuilder:object:generate=false
+type CrossNamespaceReferenceCheck struct {
+	FromGVK, ToGVK                     metav1.GroupVersionKind
+	FromNamespace, ToNamespace, ToName string
+}
 
 // ReferenceNotFoundError is returned when a referenced CR does not exist.
 //

--- a/api/konnect/v1alpha1/zz_generated_aigatewayagent_sdkops.go
+++ b/api/konnect/v1alpha1/zz_generated_aigatewayagent_sdkops.go
@@ -422,6 +422,15 @@ func (obj *AIGatewayAgent) ResolveKonnectReferences(ctx context.Context, cl clie
 	return errors.Join(errs...)
 }
 
+// CrossNamespaceSiblingReferences returns every cross-namespace sibling
+// reference declared on obj's spec whose SupportCrossNamespaceReference is
+// enabled, for callers to authorize against KongReferenceGrant before
+// calling ResolveKonnectReferences.
+func (obj *AIGatewayAgent) CrossNamespaceSiblingReferences() []CrossNamespaceReferenceCheck {
+	var checks []CrossNamespaceReferenceCheck
+	return checks
+}
+
 // ToCreateAIGatewayAgentRequest converts the AIGatewayAgent to the SDK type
 // sdkkonnectcomp.CreateAIGatewayAgentRequest, resolving referenced CRs to Konnect IDs via the provided client.
 func (obj *AIGatewayAgent) ToCreateAIGatewayAgentRequest(ctx context.Context, cl client.Client) (*sdkkonnectcomp.CreateAIGatewayAgentRequest, error) {

--- a/api/konnect/v1alpha1/zz_generated_aigatewayconsumer_sdkops.go
+++ b/api/konnect/v1alpha1/zz_generated_aigatewayconsumer_sdkops.go
@@ -103,6 +103,15 @@ func (obj *AIGatewayConsumer) ResolveKonnectReferences(ctx context.Context, cl c
 	return errors.Join(errs...)
 }
 
+// CrossNamespaceSiblingReferences returns every cross-namespace sibling
+// reference declared on obj's spec whose SupportCrossNamespaceReference is
+// enabled, for callers to authorize against KongReferenceGrant before
+// calling ResolveKonnectReferences.
+func (obj *AIGatewayConsumer) CrossNamespaceSiblingReferences() []CrossNamespaceReferenceCheck {
+	var checks []CrossNamespaceReferenceCheck
+	return checks
+}
+
 // ToCreateAIGatewayConsumerRequest converts the AIGatewayConsumer to the SDK type
 // sdkkonnectcomp.CreateAIGatewayConsumerRequest, resolving referenced CRs to Konnect IDs via the provided client.
 func (obj *AIGatewayConsumer) ToCreateAIGatewayConsumerRequest(ctx context.Context, cl client.Client) (*sdkkonnectcomp.CreateAIGatewayConsumerRequest, error) {

--- a/api/konnect/v1alpha1/zz_generated_aigatewayconsumergroup_sdkops.go
+++ b/api/konnect/v1alpha1/zz_generated_aigatewayconsumergroup_sdkops.go
@@ -103,6 +103,15 @@ func (obj *AIGatewayConsumerGroup) ResolveKonnectReferences(ctx context.Context,
 	return errors.Join(errs...)
 }
 
+// CrossNamespaceSiblingReferences returns every cross-namespace sibling
+// reference declared on obj's spec whose SupportCrossNamespaceReference is
+// enabled, for callers to authorize against KongReferenceGrant before
+// calling ResolveKonnectReferences.
+func (obj *AIGatewayConsumerGroup) CrossNamespaceSiblingReferences() []CrossNamespaceReferenceCheck {
+	var checks []CrossNamespaceReferenceCheck
+	return checks
+}
+
 // ToCreateAIGatewayConsumerGroupRequest converts the AIGatewayConsumerGroup to the SDK type
 // sdkkonnectcomp.CreateAIGatewayConsumerGroupRequest, resolving referenced CRs to Konnect IDs via the provided client.
 func (obj *AIGatewayConsumerGroup) ToCreateAIGatewayConsumerGroupRequest(ctx context.Context, cl client.Client) (*sdkkonnectcomp.CreateAIGatewayConsumerGroupRequest, error) {

--- a/api/konnect/v1alpha1/zz_generated_aigatewaymcpserver_sdkops.go
+++ b/api/konnect/v1alpha1/zz_generated_aigatewaymcpserver_sdkops.go
@@ -1697,6 +1697,15 @@ func (obj *AIGatewayMCPServer) ResolveKonnectReferences(ctx context.Context, cl 
 	return errors.Join(errs...)
 }
 
+// CrossNamespaceSiblingReferences returns every cross-namespace sibling
+// reference declared on obj's spec whose SupportCrossNamespaceReference is
+// enabled, for callers to authorize against KongReferenceGrant before
+// calling ResolveKonnectReferences.
+func (obj *AIGatewayMCPServer) CrossNamespaceSiblingReferences() []CrossNamespaceReferenceCheck {
+	var checks []CrossNamespaceReferenceCheck
+	return checks
+}
+
 // ToCreateAIGatewayMCPServerRequest converts the AIGatewayMCPServer to the SDK type
 // sdkkonnectcomp.CreateAIGatewayMCPServerRequest, resolving referenced CRs via the provided client.
 func (obj *AIGatewayMCPServer) ToCreateAIGatewayMCPServerRequest(ctx context.Context, cl client.Client) (*sdkkonnectcomp.CreateAIGatewayMCPServerRequest, error) {

--- a/api/konnect/v1alpha1/zz_generated_aigatewaymodel_sdkops.go
+++ b/api/konnect/v1alpha1/zz_generated_aigatewaymodel_sdkops.go
@@ -911,6 +911,15 @@ func (obj *AIGatewayModel) ResolveKonnectReferences(ctx context.Context, cl clie
 	return errors.Join(errs...)
 }
 
+// CrossNamespaceSiblingReferences returns every cross-namespace sibling
+// reference declared on obj's spec whose SupportCrossNamespaceReference is
+// enabled, for callers to authorize against KongReferenceGrant before
+// calling ResolveKonnectReferences.
+func (obj *AIGatewayModel) CrossNamespaceSiblingReferences() []CrossNamespaceReferenceCheck {
+	var checks []CrossNamespaceReferenceCheck
+	return checks
+}
+
 // ToCreateAIGatewayModelRequest converts the AIGatewayModel to the SDK type
 // sdkkonnectcomp.CreateAIGatewayModelRequest, resolving referenced CRs via the provided client.
 func (obj *AIGatewayModel) ToCreateAIGatewayModelRequest(ctx context.Context, cl client.Client) (*sdkkonnectcomp.CreateAIGatewayModelRequest, error) {

--- a/api/konnect/v1alpha1/zz_generated_references.go
+++ b/api/konnect/v1alpha1/zz_generated_references.go
@@ -2,7 +2,11 @@
 
 package v1alpha1
 
-import "fmt"
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
 
 const (
 	// KonnectReferencesResolvedConditionType indicates whether all CR references
@@ -19,10 +23,28 @@ const (
 	// KonnectReferencesResolvedReasonInvalid indicates a reference is invalid
 	// and cannot be resolved by waiting for the referenced CR to be programmed.
 	KonnectReferencesResolvedReasonInvalid = "ReferenceInvalid"
+	// KonnectReferencesResolvedReasonNotPermitted indicates a cross-namespace
+	// reference is not permitted by any KongReferenceGrant in the referenced
+	// namespace.
+	KonnectReferencesResolvedReasonNotPermitted = "ReferenceNotPermitted"
 	// KonnectReferencesResolvedReasonResolutionFailed indicates references failed
 	// for multiple reasons. The condition message contains per-reference details.
 	KonnectReferencesResolvedReasonResolutionFailed = "ReferenceResolutionFailed"
 )
+
+// CrossNamespaceReferenceCheck describes one cross-namespace sibling
+// reference (a ReferenceConfig entry with SupportCrossNamespaceReference:
+// true whose target namespace differs from the referrer's) that must be
+// authorized by a KongReferenceGrant before it is resolved. Entities that
+// declare such references expose them via CrossNamespaceSiblingReferences,
+// for callers outside this package to check against KongReferenceGrant
+// before calling ResolveKonnectReferences.
+//
+// +kubebuilder:object:generate=false
+type CrossNamespaceReferenceCheck struct {
+	FromGVK, ToGVK                     metav1.GroupVersionKind
+	FromNamespace, ToNamespace, ToName string
+}
 
 // ReferenceNotFoundError is returned when a referenced CR does not exist.
 //

--- a/controller/konnect/reconciler_generic_type_specific.go
+++ b/controller/konnect/reconciler_generic_type_specific.go
@@ -19,6 +19,7 @@ import (
 	"github.com/kong/kong-operator/v2/controller/konnect/ops"
 	sdkops "github.com/kong/kong-operator/v2/controller/konnect/ops/sdk"
 	"github.com/kong/kong-operator/v2/controller/pkg/patch"
+	"github.com/kong/kong-operator/v2/internal/utils/crossnamespace"
 )
 
 // handleTypeSpecific handles type-specific logic for Konnect entities.
@@ -140,12 +141,19 @@ func handleKongConsumerSpecific(
 // that declare CR references on their spec (see crd-from-oas `references` config).
 type konnectReferenceResolver interface {
 	ResolveKonnectReferences(ctx context.Context, cl client.Client) error
+	// CrossNamespaceSiblingReferences returns every cross-namespace sibling
+	// reference declared on the entity's spec (references with
+	// SupportCrossNamespaceReference: true whose target namespace differs
+	// from the entity's own) that must be authorized by a KongReferenceGrant
+	// before ResolveKonnectReferences is called.
+	CrossNamespaceSiblingReferences() []konnectv1alpha1.CrossNamespaceReferenceCheck
 }
 
-// handleKonnectReferences resolves the CR references declared on ent's spec (if
-// any) and reflects the outcome in the KonnectReferencesResolved condition.
-// Reconciliation must stop (isProblem=true) before any SDK calls when
-// references fail to resolve.
+// handleKonnectReferences authorizes any cross-namespace sibling references
+// declared on ent's spec against KongReferenceGrant, then resolves the CR
+// references declared on ent's spec (if any), and reflects the outcome in the
+// KonnectReferencesResolved condition. Reconciliation must stop
+// (isProblem=true) before any SDK calls when references fail to resolve.
 func handleKonnectReferences[
 	T constraints.SupportedKonnectEntityType,
 	TEnt constraints.EntityType[T],
@@ -155,7 +163,34 @@ func handleKonnectReferences[
 	ent TEnt,
 	resolver konnectReferenceResolver,
 ) (updated bool, isProblem bool, err error) {
-	err = resolver.ResolveKonnectReferences(ctx, cl)
+	if grantErr := checkCrossNamespaceSiblingReferences(ctx, cl, resolver.CrossNamespaceSiblingReferences()); grantErr != nil {
+		return setKonnectReferencesResolvedCondition(ent, grantErr)
+	}
+	return setKonnectReferencesResolvedCondition(ent, resolver.ResolveKonnectReferences(ctx, cl))
+}
+
+// checkCrossNamespaceSiblingReferences authorizes every check against
+// KongReferenceGrant, reusing the same authorization mechanism the parent-ref
+// handler uses (see ensureKongReferenceGrantForParentRef). Returns nil when
+// checks is empty (the common case today, since no ReferenceConfig entry sets
+// SupportCrossNamespaceReference yet) without listing any KongReferenceGrant.
+func checkCrossNamespaceSiblingReferences(ctx context.Context, cl client.Client, checks []konnectv1alpha1.CrossNamespaceReferenceCheck) error {
+	var errs []error
+	for _, c := range checks {
+		if err := crossnamespace.CheckKongReferenceGrantForResource(ctx, cl, c.FromNamespace, c.ToNamespace, c.ToName, c.FromGVK, c.ToGVK); err != nil {
+			errs = append(errs, err)
+		}
+	}
+	return errors.Join(errs...)
+}
+
+// setKonnectReferencesResolvedCondition reflects a reference-resolution
+// outcome (from either checkCrossNamespaceSiblingReferences or
+// ResolveKonnectReferences) in the KonnectReferencesResolved condition.
+func setKonnectReferencesResolvedCondition[
+	T constraints.SupportedKonnectEntityType,
+	TEnt constraints.EntityType[T],
+](ent TEnt, err error) (updated bool, isProblem bool, retErr error) {
 	if err == nil {
 		updated = patch.SetStatusWithConditionIfDifferent(
 			ent,
@@ -190,6 +225,9 @@ func konnectReferenceResolutionReason(err error) string {
 	if reasons[referenceResolutionReasonInvalid] {
 		return konnectv1alpha1.KonnectReferencesResolvedReasonInvalid
 	}
+	if reasons[referenceResolutionReasonNotPermitted] {
+		return konnectv1alpha1.KonnectReferencesResolvedReasonNotPermitted
+	}
 	if reasons[referenceResolutionReasonNotFound] {
 		return konnectv1alpha1.KonnectReferencesResolvedReasonNotFound
 	}
@@ -200,6 +238,7 @@ type referenceResolutionReasonCategory string
 
 const (
 	referenceResolutionReasonInvalid       referenceResolutionReasonCategory = "invalid"
+	referenceResolutionReasonNotPermitted  referenceResolutionReasonCategory = "not-permitted"
 	referenceResolutionReasonNotFound      referenceResolutionReasonCategory = "not-found"
 	referenceResolutionReasonNotProgrammed referenceResolutionReasonCategory = "not-programmed"
 )
@@ -226,6 +265,8 @@ func collectKonnectReferenceResolutionReasons(err error, reasons map[referenceRe
 	switch {
 	case hasInvalidKonnectReferenceResolutionError(err):
 		reasons[referenceResolutionReasonInvalid] = true
+	case hasNotPermittedKonnectReferenceResolutionError(err):
+		reasons[referenceResolutionReasonNotPermitted] = true
 	case hasNotFoundKonnectReferenceResolutionError(err):
 		reasons[referenceResolutionReasonNotFound] = true
 	case hasNotProgrammedKonnectReferenceResolutionError(err):
@@ -260,6 +301,9 @@ func isExpectedKonnectReferenceResolutionError(err error) bool {
 	if _, ok := errors.AsType[konnectv1alpha1.ReferenceDifferentGatewayError](err); ok {
 		return true
 	}
+	if crossnamespace.IsReferenceNotGranted(err) {
+		return true
+	}
 	return false
 }
 
@@ -271,6 +315,10 @@ func hasInvalidKonnectReferenceResolutionError(err error) bool {
 		return true
 	}
 	return false
+}
+
+func hasNotPermittedKonnectReferenceResolutionError(err error) bool {
+	return crossnamespace.IsReferenceNotGranted(err)
 }
 
 func hasNotFoundKonnectReferenceResolutionError(err error) bool {

--- a/controller/konnect/reconciler_generic_type_specific_test.go
+++ b/controller/konnect/reconciler_generic_type_specific_test.go
@@ -13,16 +13,22 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
 	configurationv1 "github.com/kong/kong-operator/v2/api/configuration/v1"
+	configurationv1alpha1 "github.com/kong/kong-operator/v2/api/configuration/v1alpha1"
 	konnectv1alpha1 "github.com/kong/kong-operator/v2/api/konnect/v1alpha1"
 	"github.com/kong/kong-operator/v2/modules/manager/scheme"
 )
 
 type failingKonnectReferenceResolver struct {
-	err error
+	err                             error
+	crossNamespaceSiblingReferences []konnectv1alpha1.CrossNamespaceReferenceCheck
 }
 
 func (r failingKonnectReferenceResolver) ResolveKonnectReferences(context.Context, client.Client) error {
 	return r.err
+}
+
+func (r failingKonnectReferenceResolver) CrossNamespaceSiblingReferences() []konnectv1alpha1.CrossNamespaceReferenceCheck {
+	return r.crossNamespaceSiblingReferences
 }
 
 func TestHandleKongConsumerSpecific(t *testing.T) {
@@ -382,6 +388,75 @@ func TestHandleKonnectReferencesResolution(t *testing.T) {
 		require.ErrorIs(t, err, resolverErr)
 		require.False(t, isProblem)
 		require.False(t, updated)
+	})
+
+	crossNamespaceCheck := konnectv1alpha1.CrossNamespaceReferenceCheck{
+		FromGVK:       metav1.GroupVersionKind{Group: konnectv1alpha1.GroupVersion.Group, Version: konnectv1alpha1.GroupVersion.Version, Kind: "AIGatewayAgent"},
+		ToGVK:         metav1.GroupVersionKind{Group: konnectv1alpha1.GroupVersion.Group, Version: konnectv1alpha1.GroupVersion.Version, Kind: "AIGatewayPolicy"},
+		FromNamespace: "ns",
+		ToNamespace:   "other-ns",
+		ToName:        "policy",
+	}
+
+	t.Run("cross-namespace sibling reference without a KongReferenceGrant sets condition False with NotPermitted, without calling the resolver", func(t *testing.T) {
+		cl := fake.NewClientBuilder().WithScheme(scheme.Get()).Build()
+		ent := agent.DeepCopy()
+
+		updated, isProblem, err := handleKonnectReferences(
+			t.Context(),
+			cl,
+			ent,
+			failingKonnectReferenceResolver{
+				err:                             errors.New("resolver should not be called"),
+				crossNamespaceSiblingReferences: []konnectv1alpha1.CrossNamespaceReferenceCheck{crossNamespaceCheck},
+			},
+		)
+		require.NoError(t, err)
+		require.True(t, isProblem)
+		require.True(t, updated)
+
+		cond, ok := getKonnectReferencesResolvedCondition(ent.Status.Conditions)
+		require.True(t, ok, "expected KonnectReferencesResolved condition to be set")
+		assert.Equal(t, metav1.ConditionFalse, cond.Status)
+		assert.Equal(t, konnectv1alpha1.KonnectReferencesResolvedReasonNotPermitted, cond.Reason)
+	})
+
+	t.Run("cross-namespace sibling reference permitted by a KongReferenceGrant proceeds to resolve", func(t *testing.T) {
+		grant := &configurationv1alpha1.KongReferenceGrant{
+			ObjectMeta: metav1.ObjectMeta{Name: "allow-agent", Namespace: "other-ns"},
+			Spec: configurationv1alpha1.KongReferenceGrantSpec{
+				From: []configurationv1alpha1.ReferenceGrantFrom{{
+					Group:     configurationv1alpha1.Group(konnectv1alpha1.GroupVersion.Group),
+					Kind:      configurationv1alpha1.Kind("AIGatewayAgent"),
+					Namespace: configurationv1alpha1.Namespace("ns"),
+				}},
+				To: []configurationv1alpha1.ReferenceGrantTo{{
+					Group: configurationv1alpha1.Group(konnectv1alpha1.GroupVersion.Group),
+					Kind:  configurationv1alpha1.Kind("AIGatewayPolicy"),
+				}},
+			},
+		}
+		cl := fake.NewClientBuilder().WithScheme(scheme.Get()).WithObjects(grant).Build()
+		ent := agent.DeepCopy()
+		resolverErr := konnectv1alpha1.ReferenceNotFoundError{Kind: "AIGatewayPolicy", Namespace: "other-ns", Name: "policy", Err: errors.New("not found")}
+
+		updated, isProblem, err := handleKonnectReferences(
+			t.Context(),
+			cl,
+			ent,
+			failingKonnectReferenceResolver{
+				err:                             resolverErr,
+				crossNamespaceSiblingReferences: []konnectv1alpha1.CrossNamespaceReferenceCheck{crossNamespaceCheck},
+			},
+		)
+		require.NoError(t, err)
+		require.True(t, isProblem)
+		require.True(t, updated)
+
+		cond, ok := getKonnectReferencesResolvedCondition(ent.Status.Conditions)
+		require.True(t, ok, "expected KonnectReferencesResolved condition to be set")
+		assert.Equal(t, metav1.ConditionFalse, cond.Status)
+		assert.Equal(t, konnectv1alpha1.KonnectReferencesResolvedReasonNotFound, cond.Reason, "grant check passed, so the resolver's own error must surface")
 	})
 }
 

--- a/crd-from-oas/pkg/config/config.go
+++ b/crd-from-oas/pkg/config/config.go
@@ -98,6 +98,12 @@ type ReferenceConfig struct {
 	// than one entry (the name cannot be derived); must be empty otherwise
 	// (single-kind names derive as "<Kind>Ref").
 	RefTypeName string `yaml:"refTypeName,omitempty"`
+	// SupportCrossNamespaceReference indicates whether this reference may
+	// point at a CR in a different namespace than the referrer's, subject to
+	// an authorizing KongReferenceGrant in the target namespace. Defaults to
+	// false: a mismatched namespace is rejected with
+	// ReferenceCrossNamespaceError, exactly as today.
+	SupportCrossNamespaceReference bool `yaml:"supportCrossNamespaceReference,omitempty"`
 }
 
 // TypeName returns the Go type name of the generated ref struct.
@@ -875,7 +881,7 @@ func (c *APIGroupVersionConfig) validate() error {
 // validateReferenceTypeConsistency ensures that every generated ref struct type
 // name (see ReferenceConfig.TypeName) is declared consistently across all types
 // in the API group-version: two references that share a type name must agree on
-// their Kinds (order-insensitive) and ResolvesTo.
+// their Kinds (order-insensitive), ResolvesTo, and SupportCrossNamespaceReference.
 func (c *APIGroupVersionConfig) validateReferenceTypeConsistency() error {
 	seen := make(map[string]ReferenceConfig)
 	for _, tc := range c.Types {
@@ -889,8 +895,10 @@ func (c *APIGroupVersionConfig) validateReferenceTypeConsistency() error {
 				seen[name] = ref
 				continue
 			}
-			if !equalKinds(prev.Kinds, ref.Kinds) || prev.ResolvesTo != ref.ResolvesTo {
-				return fmt.Errorf("reference type %q declared with conflicting kinds or resolvesTo", name)
+			if !equalKinds(prev.Kinds, ref.Kinds) ||
+				prev.ResolvesTo != ref.ResolvesTo ||
+				prev.SupportCrossNamespaceReference != ref.SupportCrossNamespaceReference {
+				return fmt.Errorf("reference type %q declared with conflicting kinds, resolvesTo, or supportCrossNamespaceReference", name)
 			}
 		}
 	}

--- a/crd-from-oas/pkg/config/config_test.go
+++ b/crd-from-oas/pkg/config/config_test.go
@@ -1272,6 +1272,41 @@ func TestReferenceConfigValidation(t *testing.T) {
 	}
 }
 
+func TestValidateReferenceTypeConsistency_SupportCrossNamespaceReference(t *testing.T) {
+	mk := func(firstFlag, secondFlag bool) *APIGroupVersionConfig {
+		return &APIGroupVersionConfig{
+			Types: []*TypeConfig{
+				{
+					Path: "/v1/ai-gateways/{gatewayId}/agents",
+					Name: "AIGatewayAgent",
+					References: []ReferenceConfig{{
+						Path:                           "spec.apiSpec.access.acls.allow.allow",
+						Kinds:                          []string{"AIGatewayConsumerGroup"},
+						RefTypeName:                    "AIGatewayACLRef",
+						ResolvesTo:                     "name",
+						SupportCrossNamespaceReference: firstFlag,
+					}},
+				},
+				{
+					Path: "/v1/ai-gateways/{gatewayId}/models",
+					Name: "AIGatewayModel",
+					References: []ReferenceConfig{{
+						Path:                           "spec.apiSpec.api.access.acls.allow.allow",
+						Kinds:                          []string{"AIGatewayConsumerGroup"},
+						RefTypeName:                    "AIGatewayACLRef",
+						ResolvesTo:                     "name",
+						SupportCrossNamespaceReference: secondFlag,
+					}},
+				},
+			},
+		}
+	}
+
+	require.NoError(t, mk(true, true).validate())
+	require.NoError(t, mk(false, false).validate())
+	require.ErrorContains(t, mk(true, false).validate(), "conflicting kinds, resolvesTo, or supportCrossNamespaceReference")
+}
+
 func TestReferenceConfigTypeName(t *testing.T) {
 	require.Equal(t, "AIGatewayPolicyRef", ReferenceConfig{Kinds: []string{"AIGatewayPolicy"}}.TypeName())
 	require.Equal(t, "AIGatewayACLRef", ReferenceConfig{

--- a/crd-from-oas/pkg/generator/generator.go
+++ b/crd-from-oas/pkg/generator/generator.go
@@ -1705,13 +1705,14 @@ func (g *Generator) generateSharedFiles(parsed *parser.ParsedSpec, referencedSch
 
 // refTypeTemplateData is the per-ref-struct data for referencesFileTemplate.
 type refTypeTemplateData struct {
-	TypeName      string
-	Kinds         []string
-	SingleKind    bool
-	DefaultKind   string
-	KindsEnum     string // "A;B"
-	KindsSentence string // "an AIGatewayPolicy" / "an AIGatewayConsumer or AIGatewayConsumerGroup"
-	ResolvesTo    string
+	TypeName                       string
+	Kinds                          []string
+	SingleKind                     bool
+	DefaultKind                    string
+	KindsEnum                      string // "A;B"
+	KindsSentence                  string // "an AIGatewayPolicy" / "an AIGatewayConsumer or AIGatewayConsumerGroup"
+	ResolvesTo                     string
+	SupportCrossNamespaceReference bool
 }
 
 // GenerateReferencesFile emits the shared zz_generated_references.go content,
@@ -1727,13 +1728,14 @@ func (g *Generator) GenerateReferencesFile() (string, error) {
 			}
 			names = append(names, name)
 			byName[name] = refTypeTemplateData{
-				TypeName:      name,
-				Kinds:         ref.Kinds,
-				SingleKind:    len(ref.Kinds) == 1,
-				DefaultKind:   ref.Kinds[0],
-				KindsEnum:     strings.Join(ref.Kinds, ";"),
-				KindsSentence: kindsSentence(ref.Kinds),
-				ResolvesTo:    ref.ResolvesTo,
+				TypeName:                       name,
+				Kinds:                          ref.Kinds,
+				SingleKind:                     len(ref.Kinds) == 1,
+				DefaultKind:                    ref.Kinds[0],
+				KindsEnum:                      strings.Join(ref.Kinds, ";"),
+				KindsSentence:                  kindsSentence(ref.Kinds),
+				ResolvesTo:                     ref.ResolvesTo,
+				SupportCrossNamespaceReference: ref.SupportCrossNamespaceReference,
 			}
 		}
 	}
@@ -4526,6 +4528,18 @@ func (g *Generator) templateReferences(entityName string) []TemplateReferenceCon
 	return result
 }
 
+// referencesNeedCrossNamespaceCheck reports whether any reference opts into
+// cross-namespace resolution, which requires the metav1 import in the
+// generated sdkops file for the CrossNamespaceSiblingReferences method.
+func referencesNeedCrossNamespaceCheck(refs []TemplateReferenceConfig) bool {
+	for _, r := range refs {
+		if r.SupportCrossNamespaceReference {
+			return true
+		}
+	}
+	return false
+}
+
 // TemplateRefParentNav is one sibling-preserving navigation hop from the SDK
 // payload root down to the map holding the value being written.
 type TemplateRefParentNav struct {
@@ -5723,39 +5737,41 @@ func (g *Generator) generateSDKOps(entityName string, schema *parser.Schema, ops
 
 	secretReferences := g.templateSecretReferences(entityName)
 	data := struct {
-		APIVersion              string
-		EntityName              string
-		Imports                 []*sdkOpsImport
-		BoolFields              []sdkOpsBoolField
-		ConstFields             []sdkOpsConstField
-		FreeformKeyFields       []sdkOpsFreeformKeyField
-		Methods                 []sdkOpsMethod
-		NeedsClient             bool
-		SecretReferences        []SecretReferenceForTemplate
-		NeedsSecretFetchImport  bool
-		HasReferences           bool
-		References              []TemplateReferenceConfig
-		RefInjections           []TemplateRefInjection
-		HasParentRefReplacement bool
-		ParentRefReplacesField  string
-		ParentStatusEntityName  string
+		APIVersion               string
+		EntityName               string
+		Imports                  []*sdkOpsImport
+		BoolFields               []sdkOpsBoolField
+		ConstFields              []sdkOpsConstField
+		FreeformKeyFields        []sdkOpsFreeformKeyField
+		Methods                  []sdkOpsMethod
+		NeedsClient              bool
+		SecretReferences         []SecretReferenceForTemplate
+		NeedsSecretFetchImport   bool
+		HasReferences            bool
+		References               []TemplateReferenceConfig
+		NeedsCrossNamespaceCheck bool
+		RefInjections            []TemplateRefInjection
+		HasParentRefReplacement  bool
+		ParentRefReplacesField   string
+		ParentStatusEntityName   string
 	}{
-		APIVersion:              g.config.APIVersion,
-		EntityName:              entityName,
-		Imports:                 imports,
-		BoolFields:              boolFields,
-		ConstFields:             constFields,
-		FreeformKeyFields:       freeformKeyFields,
-		Methods:                 standardMethods,
-		NeedsClient:             opsConfig.RequireClient || g.entityHasReferences(entityName),
-		SecretReferences:        secretReferences,
-		NeedsSecretFetchImport:  secretReferencesNeedCoreV1Import(secretReferences),
-		HasReferences:           g.entityHasReferences(entityName),
-		References:              references,
-		RefInjections:           injections,
-		HasParentRefReplacement: hasParentRefReplacement,
-		ParentRefReplacesField:  parentRefReplacesField,
-		ParentStatusEntityName:  parentStatusEntityName,
+		APIVersion:               g.config.APIVersion,
+		EntityName:               entityName,
+		Imports:                  imports,
+		BoolFields:               boolFields,
+		ConstFields:              constFields,
+		FreeformKeyFields:        freeformKeyFields,
+		Methods:                  standardMethods,
+		NeedsClient:              opsConfig.RequireClient || g.entityHasReferences(entityName),
+		SecretReferences:         secretReferences,
+		NeedsSecretFetchImport:   secretReferencesNeedCoreV1Import(secretReferences),
+		HasReferences:            g.entityHasReferences(entityName),
+		References:               references,
+		NeedsCrossNamespaceCheck: referencesNeedCrossNamespaceCheck(references),
+		RefInjections:            injections,
+		HasParentRefReplacement:  hasParentRefReplacement,
+		ParentRefReplacesField:   parentRefReplacesField,
+		ParentStatusEntityName:   parentStatusEntityName,
 	}
 
 	if err := tmpl.Execute(&buf, data); err != nil {
@@ -6026,37 +6042,39 @@ func (g *Generator) generateRootUnionSDKOps(
 	var buf strings.Builder
 	secretReferences := g.templateSecretReferences(entityName)
 	data := struct {
-		APIVersion             string
-		EntityName             string
-		UnionTypeName          string
-		Imports                []*sdkOpsImport
-		BoolFields             []sdkOpsBoolField
-		ConstFields            []sdkOpsConstField
-		UnionUnwrapFields      []sdkOpsUnionUnwrapField
-		FreeformKeyFields      []sdkOpsFreeformKeyField
-		Methods                []sdkOpsRootUnionMethod
-		Variants               []sdkOpsRootUnionVariant
-		NeedsClient            bool
-		SecretReferences       []SecretReferenceForTemplate
-		NeedsSecretFetchImport bool
-		References             []TemplateReferenceConfig
-		RefInjections          []TemplateRefInjection
+		APIVersion               string
+		EntityName               string
+		UnionTypeName            string
+		Imports                  []*sdkOpsImport
+		BoolFields               []sdkOpsBoolField
+		ConstFields              []sdkOpsConstField
+		UnionUnwrapFields        []sdkOpsUnionUnwrapField
+		FreeformKeyFields        []sdkOpsFreeformKeyField
+		Methods                  []sdkOpsRootUnionMethod
+		Variants                 []sdkOpsRootUnionVariant
+		NeedsClient              bool
+		SecretReferences         []SecretReferenceForTemplate
+		NeedsSecretFetchImport   bool
+		References               []TemplateReferenceConfig
+		NeedsCrossNamespaceCheck bool
+		RefInjections            []TemplateRefInjection
 	}{
-		APIVersion:             g.config.APIVersion,
-		EntityName:             entityName,
-		UnionTypeName:          rootUnionTypeName,
-		Imports:                imports,
-		BoolFields:             boolFields,
-		ConstFields:            constFields,
-		UnionUnwrapFields:      unionUnwrapFields,
-		FreeformKeyFields:      freeformKeyFields,
-		Methods:                rootUnionMethods,
-		Variants:               variants,
-		NeedsClient:            opsConfig.RequireClient || g.entityHasReferences(entityName),
-		SecretReferences:       secretReferences,
-		NeedsSecretFetchImport: secretReferencesNeedCoreV1Import(secretReferences),
-		References:             references,
-		RefInjections:          injections,
+		APIVersion:               g.config.APIVersion,
+		EntityName:               entityName,
+		UnionTypeName:            rootUnionTypeName,
+		Imports:                  imports,
+		BoolFields:               boolFields,
+		ConstFields:              constFields,
+		UnionUnwrapFields:        unionUnwrapFields,
+		FreeformKeyFields:        freeformKeyFields,
+		Methods:                  rootUnionMethods,
+		Variants:                 variants,
+		NeedsClient:              opsConfig.RequireClient || g.entityHasReferences(entityName),
+		SecretReferences:         secretReferences,
+		NeedsSecretFetchImport:   secretReferencesNeedCoreV1Import(secretReferences),
+		References:               references,
+		NeedsCrossNamespaceCheck: referencesNeedCrossNamespaceCheck(references),
+		RefInjections:            injections,
 	}
 	if err := tmpl.Execute(&buf, data); err != nil {
 		return "", err

--- a/crd-from-oas/pkg/generator/generator_test.go
+++ b/crd-from-oas/pkg/generator/generator_test.go
@@ -5620,6 +5620,90 @@ func TestGenerateSDKOps_EmitsResolveKonnectReferences(t *testing.T) {
 	require.Contains(t, content, "return errors.Join(errs...)")
 }
 
+func TestGenerateSDKOps_CrossNamespaceSiblingReferences(t *testing.T) {
+	g := NewGenerator(Config{
+		APIVersion: "v1alpha1",
+		References: map[string][]config.ReferenceConfig{
+			"AIGatewayAgent": {
+				{Path: "spec.apiSpec.policies", Kinds: []string{"AIGatewayPolicy"}, ResolvesTo: "id", SupportCrossNamespaceReference: true},
+				{Path: "spec.apiSpec.consumerGroups", Kinds: []string{"AIGatewayConsumerGroup"}, ResolvesTo: "id"},
+			},
+		},
+	})
+	schema := &parser.Schema{
+		Properties: []*parser.Property{
+			{Name: "policies", Type: "array"},
+			{Name: "consumerGroups", Type: "array"},
+			{Name: "name", Type: "string"},
+		},
+	}
+	opsConfig := &config.EntityOpsConfig{
+		Ops: map[string]*config.OpConfig{
+			"create": {Path: "github.com/Kong/sdk-konnect-go/models/components.CreateAIGatewayAgentRequest"},
+			"update": {Path: "github.com/Kong/sdk-konnect-go/models/components.UpdateAIGatewayAgentRequest"},
+		},
+	}
+
+	content, err := g.generateSDKOps("AIGatewayAgent", schema, opsConfig)
+	require.NoError(t, err)
+
+	// The opted-in field's resolver no longer rejects cross-namespace refs.
+	idxPolicies := strings.Index(content, "func resolveAIGatewayAgentPolicies(ctx context.Context, cl client.Client, obj *AIGatewayAgent) ([]string, error) {")
+	idxConsumerGroups := strings.Index(content, "func resolveAIGatewayAgentConsumerGroups(ctx context.Context, cl client.Client, obj *AIGatewayAgent) ([]string, error) {")
+	idxResolveKonnectReferences := strings.Index(content, "func (obj *AIGatewayAgent) ResolveKonnectReferences(")
+	idxCrossNamespaceSiblingReferences := strings.Index(content, "func (obj *AIGatewayAgent) CrossNamespaceSiblingReferences() []CrossNamespaceReferenceCheck {")
+	require.GreaterOrEqual(t, idxPolicies, 0)
+	require.GreaterOrEqual(t, idxConsumerGroups, 0)
+	require.GreaterOrEqual(t, idxResolveKonnectReferences, 0)
+	require.GreaterOrEqual(t, idxCrossNamespaceSiblingReferences, 0)
+
+	policiesResolver := content[idxPolicies:idxConsumerGroups]
+	require.NotContains(t, policiesResolver, "ReferenceCrossNamespaceError{")
+
+	// The non-opted-in field's resolver still rejects cross-namespace refs.
+	consumerGroupsResolver := content[idxConsumerGroups:idxResolveKonnectReferences]
+	require.Contains(t, consumerGroupsResolver, "ReferenceCrossNamespaceError{Kind: kind, Namespace: ns, Name: ref.Name, ReferrerNamespace: obj.GetNamespace()}")
+
+	// CrossNamespaceSiblingReferences only collects checks for the opted-in field.
+	crossNamespaceMethod := content[idxCrossNamespaceSiblingReferences:]
+	require.Contains(t, crossNamespaceMethod, "for _, ref := range obj.Spec.APISpec.Policies {")
+	require.NotContains(t, crossNamespaceMethod, "obj.Spec.APISpec.ConsumerGroups")
+	require.Contains(t, crossNamespaceMethod, `FromGVK:       metav1.GroupVersionKind{Group: GroupVersion.Group, Version: GroupVersion.Version, Kind: "AIGatewayAgent"},`)
+	require.Contains(t, crossNamespaceMethod, "ToGVK:         metav1.GroupVersionKind{Group: GroupVersion.Group, Version: GroupVersion.Version, Kind: kind},")
+
+	// metav1 import is pulled in because at least one reference needs it.
+	require.Contains(t, content, `metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"`)
+}
+
+func TestGenerateSDKOps_NoCrossNamespaceReferences_OmitsMetav1Import(t *testing.T) {
+	g := NewGenerator(Config{
+		APIVersion: "v1alpha1",
+		References: map[string][]config.ReferenceConfig{
+			"AIGatewayAgent": {
+				{Path: "spec.apiSpec.policies", Kinds: []string{"AIGatewayPolicy"}, ResolvesTo: "id"},
+			},
+		},
+	})
+	schema := &parser.Schema{
+		Properties: []*parser.Property{
+			{Name: "policies", Type: "array"},
+			{Name: "name", Type: "string"},
+		},
+	}
+	opsConfig := &config.EntityOpsConfig{
+		Ops: map[string]*config.OpConfig{
+			"create": {Path: "github.com/Kong/sdk-konnect-go/models/components.CreateAIGatewayAgentRequest"},
+			"update": {Path: "github.com/Kong/sdk-konnect-go/models/components.UpdateAIGatewayAgentRequest"},
+		},
+	}
+
+	content, err := g.generateSDKOps("AIGatewayAgent", schema, opsConfig)
+	require.NoError(t, err)
+
+	require.NotContains(t, content, "k8s.io/apimachinery/pkg/apis/meta/v1")
+	require.Contains(t, content, "func (obj *AIGatewayAgent) CrossNamespaceSiblingReferences() []CrossNamespaceReferenceCheck {\n\tvar checks []CrossNamespaceReferenceCheck\n\treturn checks\n}")
+}
+
 func TestGenerateOpsUpdate_PointerBody(t *testing.T) {
 	g := NewGenerator(Config{
 		APIGroupPackagePath:  "github.com/kong/kong-operator/v2/api/konnect/v1alpha1",

--- a/crd-from-oas/pkg/generator/templates.go
+++ b/crd-from-oas/pkg/generator/templates.go
@@ -545,6 +545,7 @@ import (
 {{- if .NeedsClient}}
 
 {{if .NeedsSecretFetchImport}}	corev1 "k8s.io/api/core/v1"
+{{end}}{{if .NeedsCrossNamespaceCheck}}	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 {{end}}{{if .References}}	apierrors "k8s.io/apimachinery/pkg/api/errors"
 {{end}}	"sigs.k8s.io/controller-runtime/pkg/client"
 {{- end}}
@@ -1034,10 +1035,12 @@ func resolve{{$.EntityName}}{{.GoResolverName}}(ctx context.Context, cl client.C
 		if kind == "" {
 			kind = "{{.DefaultKind}}"
 		}
+{{- if not .SupportCrossNamespaceReference}}
 		if ns != obj.GetNamespace() {
 			errs = append(errs, ReferenceCrossNamespaceError{Kind: kind, Namespace: ns, Name: ref.Name, ReferrerNamespace: obj.GetNamespace()})
 			continue
 		}
+{{- end}}
 {{- if .MultiKind}}
 		var resolvedValue, konnectID string
 		switch kind {
@@ -1120,6 +1123,39 @@ func (obj *{{$.EntityName}}) ResolveKonnectReferences(ctx context.Context, cl cl
 	}
 	{{- end}}
 	return errors.Join(errs...)
+}
+
+// CrossNamespaceSiblingReferences returns every cross-namespace sibling
+// reference declared on obj's spec whose SupportCrossNamespaceReference is
+// enabled, for callers to authorize against KongReferenceGrant before
+// calling ResolveKonnectReferences.
+func (obj *{{$.EntityName}}) CrossNamespaceSiblingReferences() []CrossNamespaceReferenceCheck {
+	var checks []CrossNamespaceReferenceCheck
+	{{- range $.References}}
+	{{- if .SupportCrossNamespaceReference}}
+	for _, ref := range {{.RefsExpr}} {
+		ns := ref.Namespace
+		if ns == "" {
+			ns = obj.GetNamespace()
+		}
+		if ns == obj.GetNamespace() {
+			continue
+		}
+		kind := ref.Kind
+		if kind == "" {
+			kind = "{{.DefaultKind}}"
+		}
+		checks = append(checks, CrossNamespaceReferenceCheck{
+			FromGVK:       metav1.GroupVersionKind{Group: GroupVersion.Group, Version: GroupVersion.Version, Kind: "{{$.EntityName}}"},
+			ToGVK:         metav1.GroupVersionKind{Group: GroupVersion.Group, Version: GroupVersion.Version, Kind: kind},
+			FromNamespace: obj.GetNamespace(),
+			ToNamespace:   ns,
+			ToName:        ref.Name,
+		})
+	}
+	{{- end}}
+	{{- end}}
+	return checks
 }
 {{- end}}
 {{- end}}
@@ -1237,6 +1273,7 @@ import (
 {{- if .NeedsClient}}
 
 {{if .NeedsSecretFetchImport}}	corev1 "k8s.io/api/core/v1"
+{{end}}{{if .NeedsCrossNamespaceCheck}}	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 {{end}}{{if .References}}	apierrors "k8s.io/apimachinery/pkg/api/errors"
 {{end}}	"sigs.k8s.io/controller-runtime/pkg/client"
 {{- end}}
@@ -3461,7 +3498,11 @@ const referencesFileTemplate = sharedGeneratedFilePreamble + `
 
 package {{.PackageName}}
 
-import "fmt"
+import (
+	"fmt"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
 
 const (
 	// KonnectReferencesResolvedConditionType indicates whether all CR references
@@ -3478,10 +3519,28 @@ const (
 	// KonnectReferencesResolvedReasonInvalid indicates a reference is invalid
 	// and cannot be resolved by waiting for the referenced CR to be programmed.
 	KonnectReferencesResolvedReasonInvalid = "ReferenceInvalid"
+	// KonnectReferencesResolvedReasonNotPermitted indicates a cross-namespace
+	// reference is not permitted by any KongReferenceGrant in the referenced
+	// namespace.
+	KonnectReferencesResolvedReasonNotPermitted = "ReferenceNotPermitted"
 	// KonnectReferencesResolvedReasonResolutionFailed indicates references failed
 	// for multiple reasons. The condition message contains per-reference details.
 	KonnectReferencesResolvedReasonResolutionFailed = "ReferenceResolutionFailed"
 )
+
+// CrossNamespaceReferenceCheck describes one cross-namespace sibling
+// reference (a ReferenceConfig entry with SupportCrossNamespaceReference:
+// true whose target namespace differs from the referrer's) that must be
+// authorized by a KongReferenceGrant before it is resolved. Entities that
+// declare such references expose them via CrossNamespaceSiblingReferences,
+// for callers outside this package to check against KongReferenceGrant
+// before calling ResolveKonnectReferences.
+//
+// +kubebuilder:object:generate=false
+type CrossNamespaceReferenceCheck struct {
+	FromGVK, ToGVK                     metav1.GroupVersionKind
+	FromNamespace, ToNamespace, ToName string
+}
 
 // ReferenceNotFoundError is returned when a referenced CR does not exist.
 //
@@ -3569,9 +3628,13 @@ type {{.TypeName}} struct {
 	// +kubebuilder:validation:MinLength=1
 	Name string ` + "`" + `json:"name"` + "`" + `
 
-	// Namespace is reserved for future cross-namespace support.
+{{if .SupportCrossNamespaceReference}}	// Namespace, if set to a namespace other than the referrer's, must be
+	// permitted by a KongReferenceGrant in that namespace.
 	//
 	// +optional
-	Namespace string ` + "`" + `json:"namespace,omitempty"` + "`" + `
+{{else}}	// Namespace is reserved for future cross-namespace support.
+	//
+	// +optional
+{{end}}	Namespace string ` + "`" + `json:"namespace,omitempty"` + "`" + `
 }
 {{end}}`

--- a/docs/all-api-reference.md
+++ b/docs/all-api-reference.md
@@ -1321,6 +1321,8 @@ _Appears in:_
 
 - [KongLicenseControllerStatus](#configuration-konghq-com-v1alpha1-types-konglicensecontrollerstatus)
 
+
+
 #### DecryptionRecordPart
 
 _Underlying type:_ `string`
@@ -15503,6 +15505,8 @@ CreatePortalCustomDomainSSLWithCustomCertificate is a type alias.
 _Appears in:_
 
 - [PortalCustomDomainSSL](#konnect-konghq-com-v1alpha1-types-portalcustomdomainssl)
+
+
 
 #### DataPlaneClientAuthStatus
 

--- a/docs/configuration-api-reference.md
+++ b/docs/configuration-api-reference.md
@@ -1052,6 +1052,8 @@ _Appears in:_
 
 - [KongLicenseControllerStatus](#configuration-konghq-com-v1alpha1-types-konglicensecontrollerstatus)
 
+
+
 #### DecryptionRecordPart
 
 _Underlying type:_ `string`

--- a/docs/konnect-api-reference.md
+++ b/docs/konnect-api-reference.md
@@ -6445,6 +6445,8 @@ _Appears in:_
 
 - [PortalCustomDomainSSL](#konnect-konghq-com-v1alpha1-types-portalcustomdomainssl)
 
+
+
 #### DataPlaneClientAuthStatus
 
 


### PR DESCRIPTION
**What this PR does / why we need it**:

Add `SupportCrossNamespaceReference` to support referencing resources in other namespaces.

When it is set to true, it generates code for the CRDs to check and resolve references to resources in other namespaces and watching `KongReferenceGrant`s in the controllers.

**Which issue this PR fixes**

Fixes #5258

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
