### PR TITLE
chore(workflows): Do not use variables directly in commands and add a linter script to enforcce it

### DIFF
--- a/.github/workflows/__integration_tests.yaml
+++ b/.github/workflows/__integration_tests.yaml
@@ -83,14 +83,19 @@ jobs:
 
     - name: set kong image override
       if: ${{ inputs.kong-image-repo != '' }}
+      env:
+        KONG_IMAGE_REPO: ${{ inputs.kong-image-repo }}
+        KONG_IMAGE_TAG: ${{ inputs.kong-image-tag }}
       run: |
-        echo "TEST_KONG_IMAGE=${{ inputs.kong-image-repo }}" >> $GITHUB_ENV
-        echo "TEST_KONG_TAG=${{ inputs.kong-image-tag }}" >> $GITHUB_ENV
+        echo "TEST_KONG_IMAGE=$KONG_IMAGE_REPO" >> $GITHUB_ENV
+        echo "TEST_KONG_TAG=$KONG_IMAGE_TAG" >> $GITHUB_ENV
 
     - name: set kong effective version
       if: ${{ inputs.kong-effective-version != '' }}
+      env:
+        KONG_EFFECTIVE_VERSION: ${{ inputs.kong-effective-version }}
       run: |
-        echo "TEST_KONG_EFFECTIVE_VERSION=${{ inputs.kong-effective-version }}" >> $GITHUB_ENV
+        echo "TEST_KONG_EFFECTIVE_VERSION=$KONG_EFFECTIVE_VERSION" >> $GITHUB_ENV
 
     - run: echo "GO_MOD_CACHE=$(go env GOMODCACHE)" >> $GITHUB_ENV
     - run: echo "GO_BUILD_CACHE=$(go env GOCACHE)" >> $GITHUB_ENV

--- a/Makefile
+++ b/Makefile
@@ -295,6 +295,7 @@ lint.actions: download.actionlint download.shellcheck
 	SHELLCHECK_OPTS='--exclude=SC2086,SC2155,SC2046' \
 	$(ACTIONLINT) -shellcheck $(SHELLCHECK) \
 		./.github/workflows/*
+	YQ_BIN=$(YQ) $(PROJECT_DIR)/scripts/verify-no-run-expressions.sh
 
 .PHONY: lint.markdownlint
 lint.markdownlint: download.markdownlint-cli2

--- a/scripts/verify-no-run-expressions.sh
+++ b/scripts/verify-no-run-expressions.sh
@@ -1,0 +1,65 @@
+#!/bin/bash
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+SCRIPT_ROOT="$(cd -- "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+readonly SCRIPT_ROOT
+
+WORKFLOWS_DIR="${SCRIPT_ROOT}/.github/workflows"
+readonly WORKFLOWS_DIR
+
+YQ_BIN="${YQ_BIN:-yq}"
+readonly YQ_BIN
+
+# Pulls every step's `run:` script body out of a workflow file, each one
+# preceded by a marker line identifying its job and step name. This
+# deliberately excludes `env:`, `with:`, `if:`, `name:`, cache `key:`/`path:`,
+# etc. so only the actual shell script text run by the runner is checked.
+extract_run_bodies() {
+	local file="${1}"
+
+	"${YQ_BIN}" eval '
+		(.jobs // {}) as $jobs
+		| ($jobs | keys)[] as $job_id
+		| ($jobs[$job_id].steps // [])[]
+		| select(has("run"))
+		| "===STEP:job=" + $job_id + " step=\"" + (.name // "<unnamed>") + "\"===\n" + .run
+	' "${file}" 2>/dev/null || true
+}
+
+status=0
+
+for file in "${WORKFLOWS_DIR}"/*; do
+	[[ -f "${file}" ]] || continue
+
+	current_step=""
+	while IFS= read -r line; do
+		if [[ "${line}" == ===STEP:*=== ]]; then
+			current_step="${line#===STEP:}"
+			current_step="${current_step%===}"
+			continue
+		fi
+
+		if [[ "${line}" == *'${{'* ]]; then
+			echo "Script-injection risk: a '\${{ }}' expression is used directly in a run: script."
+			echo "  File: ${file#"${SCRIPT_ROOT}"/}"
+			echo "  ${current_step}"
+			echo "  Line: ${line}"
+			echo
+			status=1
+		fi
+	done < <(extract_run_bodies "${file}")
+done
+
+if [[ "${status}" -ne 0 ]]; then
+	echo "One or more 'run:' steps interpolate a '\${{ ... }}' expression directly into"
+	echo "the shell script text. GitHub Actions splices the expression's value into the"
+	echo "script before the shell parses it, so values with shell metacharacters can"
+	echo "inject arbitrary commands. Fix: move the value into a step- or job-level"
+	echo "'env:' block and reference it as a shell variable (e.g. \"\$VAR\") instead."
+	echo "See: https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#understanding-the-risk-of-script-injections"
+fi
+
+exit "${status}"


### PR DESCRIPTION
**What this PR does / why we need it**:

- Fix the usage of variables directly used in commands
- Add a linter script to enforce it

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
