### PR TITLE
bump AIGateway dataplane to 2.0.2-rc.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -94,8 +94,9 @@
   the behavior that already applied to every other Konnect entity.
   [#5207](https://github.com/Kong/kong-operator/pull/5207)
 - AIGateway: update the default AI Gateway DataPlane image to
-  `kong/kong-ai-gateway-dev:2.0.2-rc.1`.
+  `kong/kong-ai-gateway-dev:2.0.2-rc.2`.
   [#5231](https://github.com/Kong/kong-operator/pull/5231)
+  [#5269](https://github.com/Kong/kong-operator/pull/5269)
 - AIGateway: enable AIGatewayAgent and AIGatewayModel to reference IdentityProvider
   [#5265](https://github.com/Kong/kong-operator/pull/5265)
 

--- a/pkg/consts/aigateway.go
+++ b/pkg/consts/aigateway.go
@@ -49,7 +49,7 @@ const (
 	// DefaultAIGatewayDataPlaneBaseImage is the base image name for the AI Gateway container.
 	DefaultAIGatewayDataPlaneBaseImage = "kong/kong-ai-gateway-dev"
 	// DefaultAIGatewayDataPlaneTag is the default image tag for the AI Gateway container.
-	DefaultAIGatewayDataPlaneTag = "2.0.2-rc.1" // renovate: datasource=docker depName=kong/kong-ai-gateway-dev
+	DefaultAIGatewayDataPlaneTag = "2.0.2-rc.2" // renovate: datasource=docker depName=kong/kong-ai-gateway-dev
 	// DefaultAIGatewayDataPlaneImage is the full default image reference for the AI Gateway container.
 	DefaultAIGatewayDataPlaneImage = DefaultAIGatewayDataPlaneBaseImage + ":" + DefaultAIGatewayDataPlaneTag
 )

--- a/test/test_dependencies.yaml
+++ b/test/test_dependencies.yaml
@@ -33,4 +33,4 @@ chainsaw:
   aigw-dp:
     image: kong/kong-ai-gateway-dev
     # renovate: datasource=docker depName=kong/kong-ai-gateway-dev versioning=docker
-    tag: '2.0.2-rc.1'
+    tag: '2.0.2-rc.2'


### PR DESCRIPTION
**What this PR does / why we need it**:

Update default AIGateway DP image to `2.0.2-rc.2`.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
