### PR TITLE
fix(hybridgateway): propagate konghq.com/tags to generated KongPlugin…

### DIFF
--- a/controller/hybridgateway/builder/kongplugin.go
+++ b/controller/hybridgateway/builder/kongplugin.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"sort"
 	"strings"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -130,6 +131,7 @@ func (b *KongPluginBuilder) WithTagsAnnotation(sources ...pkgmetadata.ObjectWith
 	if b.plugin.Annotations == nil {
 		b.plugin.Annotations = make(map[string]string)
 	}
+	sort.Strings(deduped)
 	b.plugin.Annotations[pkgmetadata.AnnotationKeyTags] = strings.Join(deduped, ",")
 	return b
 }

--- a/controller/hybridgateway/builder/kongplugin.go
+++ b/controller/hybridgateway/builder/kongplugin.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"strings"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -13,6 +14,7 @@ import (
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/metadata"
 	gwtypes "github.com/kong/kong-operator/v2/internal/types"
 	"github.com/kong/kong-operator/v2/modules/manager/scheme"
+	pkgmetadata "github.com/kong/kong-operator/v2/pkg/metadata"
 )
 
 // KongPluginBuilder is a builder for configurationv1.KongPlugin resources.
@@ -99,6 +101,37 @@ func (b *KongPluginBuilder) MustBuild() configurationv1.KongPlugin {
 		panic(fmt.Errorf("failed to build KongPlugin: %w", err))
 	}
 	return plugin
+}
+
+// WithTagsAnnotation merges the konghq.com/tags annotation value from the given
+// sources into the KongPlugin being built. This ensures that when the generated
+// KongPlugin copy is later read by the Konnect ops layer (via metadata.ExtractTags),
+// the user-supplied tags are present. Multiple sources are merged and deduplicated.
+func (b *KongPluginBuilder) WithTagsAnnotation(sources ...pkgmetadata.ObjectWithAnnotations) *KongPluginBuilder {
+	var allTags []string
+	for _, src := range sources {
+		if src == nil {
+			continue
+		}
+		allTags = append(allTags, pkgmetadata.ExtractTags(src)...)
+	}
+	if len(allTags) == 0 {
+		return b
+	}
+	// Deduplicate while preserving order.
+	seen := make(map[string]struct{}, len(allTags))
+	deduped := make([]string, 0, len(allTags))
+	for _, t := range allTags {
+		if _, ok := seen[t]; !ok {
+			seen[t] = struct{}{}
+			deduped = append(deduped, t)
+		}
+	}
+	if b.plugin.Annotations == nil {
+		b.plugin.Annotations = make(map[string]string)
+	}
+	b.plugin.Annotations[pkgmetadata.AnnotationKeyTags] = strings.Join(deduped, ",")
+	return b
 }
 
 // WithPluginName sets the plugin name for the KongPlugin being built.

--- a/controller/hybridgateway/builder/kongplugin_test.go
+++ b/controller/hybridgateway/builder/kongplugin_test.go
@@ -204,3 +204,113 @@ func TestKongPluginBuilder_ChainedCalls(t *testing.T) {
 	assert.NotNil(t, plugin.Annotations)
 	assert.JSONEq(t, string(config), string(plugin.Config.Raw))
 }
+
+func TestKongPluginBuilder_WithTagsAnnotation(t *testing.T) {
+	t.Run("tags from single source", func(t *testing.T) {
+		route := &gwtypes.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-route",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"konghq.com/tags": "team-payments,env-prod",
+				},
+			},
+		}
+
+		plugin, err := NewKongPlugin().
+			WithName("test-plugin").
+			WithTagsAnnotation(route).
+			Build()
+		require.NoError(t, err)
+		assert.Equal(t, "env-prod,team-payments", plugin.Annotations["konghq.com/tags"])
+	})
+
+	t.Run("tags from multiple sources are merged and deduplicated", func(t *testing.T) {
+		route := &gwtypes.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-route",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"konghq.com/tags": "shared-tag,route-tag",
+				},
+			},
+		}
+		sourcePlugin := &configurationv1.KongPlugin{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "user-plugin",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"konghq.com/tags": "shared-tag,plugin-tag",
+				},
+			},
+		}
+
+		plugin, err := NewKongPlugin().
+			WithName("test-plugin").
+			WithTagsAnnotation(route, sourcePlugin).
+			Build()
+		require.NoError(t, err)
+		assert.Equal(t, "plugin-tag,route-tag,shared-tag", plugin.Annotations["konghq.com/tags"])
+	})
+
+	t.Run("no tags annotation when sources have no tags", func(t *testing.T) {
+		route := &gwtypes.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-route",
+				Namespace: "default",
+			},
+		}
+
+		plugin, err := NewKongPlugin().
+			WithName("test-plugin").
+			WithTagsAnnotation(route).
+			Build()
+		require.NoError(t, err)
+		assert.Empty(t, plugin.Annotations["konghq.com/tags"])
+	})
+
+	t.Run("nil source is safely skipped", func(t *testing.T) {
+		route := &gwtypes.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-route",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"konghq.com/tags": "my-tag",
+				},
+			},
+		}
+
+		plugin, err := NewKongPlugin().
+			WithName("test-plugin").
+			WithTagsAnnotation(route, nil).
+			Build()
+		require.NoError(t, err)
+		assert.Equal(t, "my-tag", plugin.Annotations["konghq.com/tags"])
+	})
+
+	t.Run("tags annotation preserved alongside tracking annotations", func(t *testing.T) {
+		route := &gwtypes.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-route",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"konghq.com/tags": "my-tag",
+				},
+			},
+		}
+		parentRef := &gwtypes.ParentReference{
+			Name: "test-gateway",
+		}
+
+		plugin, err := NewKongPlugin().
+			WithName("test-plugin").
+			WithAnnotations(route, parentRef).
+			WithTagsAnnotation(route).
+			Build()
+		require.NoError(t, err)
+		// Tags annotation should be present
+		assert.Equal(t, "my-tag", plugin.Annotations["konghq.com/tags"])
+		// Tracking annotations from BuildAnnotations should also be present
+		assert.NotEmpty(t, plugin.Annotations["gateway-operator.konghq.com/hybrid-gateways"])
+	})
+}

--- a/controller/hybridgateway/plugin/grpc_plugin.go
+++ b/controller/hybridgateway/plugin/grpc_plugin.go
@@ -59,6 +59,7 @@ func GRPCPluginsForRule(
 				WithPluginName(conf.name).
 				WithPluginConfig(conf.config).
 				WithAnnotations(grpcRoute, pRef).
+				WithTagsAnnotation(grpcRoute).
 				Build()
 			if err != nil {
 				return nil, fmt.Errorf("failed to build KongPlugin %s: %w", pluginName, err)
@@ -96,6 +97,7 @@ func GRPCPluginsForRule(
 			WithPluginName(plugin.PluginName).
 			WithPluginConfig(plugin.Config.Raw).
 			WithAnnotations(grpcRoute, pRef).
+			WithTagsAnnotation(grpcRoute, plugin).
 			Build()
 		if err != nil {
 			return nil, fmt.Errorf("failed to build KongPlugin %s: %w", pluginName, err)

--- a/controller/hybridgateway/plugin/grpc_request_termination.go
+++ b/controller/hybridgateway/plugin/grpc_request_termination.go
@@ -48,6 +48,7 @@ func GRPCRequestTerminationForBackendNotFound(
 		WithNamespace(metadata.NamespaceFromParentRef(grpcRoute, pRef)).
 		WithLabels(grpcRoute, pRef).
 		WithAnnotations(grpcRoute, pRef).
+		WithTagsAnnotation(grpcRoute).
 		WithPluginName("request-termination").
 		WithPluginConfig(config).
 		Build()

--- a/controller/hybridgateway/plugin/plugin.go
+++ b/controller/hybridgateway/plugin/plugin.go
@@ -80,6 +80,7 @@ func PluginsForRule(
 			WithPluginName(pConf.name).
 			WithPluginConfig(pConf.config).
 			WithAnnotations(httpRoute, pRef).
+			WithTagsAnnotation(httpRoute).
 			Build()
 		if err != nil {
 			return nil, fmt.Errorf("failed to build KongPlugin %s: %w", pluginName, err)
@@ -116,6 +117,7 @@ func PluginsForRule(
 			WithPluginName(plugin.PluginName).
 			WithPluginConfig(plugin.Config.Raw).
 			WithAnnotations(httpRoute, pRef).
+			WithTagsAnnotation(httpRoute, plugin).
 			Build()
 		if err != nil {
 			return nil, fmt.Errorf("failed to build KongPlugin %s: %w", pluginName, err)

--- a/controller/hybridgateway/plugin/request_termination.go
+++ b/controller/hybridgateway/plugin/request_termination.go
@@ -40,6 +40,7 @@ func RequestTerminationForBackendNotFound(
 		WithNamespace(metadata.NamespaceFromParentRef(httpRoute, pRef)).
 		WithLabels(httpRoute, pRef).
 		WithAnnotations(httpRoute, pRef).
+		WithTagsAnnotation(httpRoute).
 		WithPluginName("request-termination").
 		WithPluginConfig(config).
 		Build()


### PR DESCRIPTION
## Summary

Fixes https://github.com/Kong/kong-operator/issues/5277

When the hybrid gateway controller creates operator-managed KongPlugin copies (for both built-in
filter plugins and ExtensionRef-referenced user plugins), it only set internal tracking annotations
via `metadata.BuildAnnotations()`. The `konghq.com/tags` annotation from the source
HTTPRoute/GRPCRoute or user-managed KongPlugin was never forwarded to the generated copy.

This caused the Konnect ops layer to produce Plugin entities without the user-specified tags,
since `metadata.ExtractTags()` on the generated copy returned nothing.

## Changes

- Added `WithTagsAnnotation()` to `KongPluginBuilder` that merges `konghq.com/tags` from source
  objects (route and/or original plugin) onto the generated copy's annotations. Tags from multiple
  sources are deduplicated.
- Applied it in all plugin generation paths:
  - Built-in filter plugins (tags from HTTPRoute/GRPCRoute)
  - ExtensionRef plugins (tags from both route and original KongPlugin)
  - Request-termination plugins (tags from route)

## How it works

The Konnect ops layer already handles tag extraction correctly in `kongPluginBindingToSDKPluginInput`:

tags := GenerateTagsForObject(pluginBinding, metadata.ExtractTags(plugin)...)

It fetches the referenced KongPlugin and extracts tags from its annotations. The problem was that
the generated copy never had the annotation set. This fix ensures it does.

## Testing

- All existing unit tests pass for `controller/hybridgateway/builder/` and `controller/hybridgateway/plugin/`
- Follows the same pattern used for KongRoute/KongService/KongUpstream tag propagation (from #4554)
