### PR TITLE
fix(ci): add missing Kong license to conformance tests report workflow

### DIFF
--- a/.github/workflows/conformance_tests_report.yaml
+++ b/.github/workflows/conformance_tests_report.yaml
@@ -54,12 +54,18 @@ jobs:
         with:
           go-version-file: go.mod
 
+      - uses: Kong/kong-license@ddccb487a0b319cef85f348b16a1ad2b6d9c1df7 # master @ 20260529
+        id: license
+        with:
+          op-token: ${{ secrets.OP_SERVICE_ACCOUNT_TOKEN }}
+
       - name: Run conformance tests
         env:
           TEST_KONG_ROUTER_FLAVOR: ${{ matrix.router-flavor }}
           KONG_TEST_CONFORMANCE_GATEWAY_TYPE: ${{ matrix.gateway-type }}
           KONG_TEST_KONNECT_ACCESS_TOKEN: ${{ matrix.gateway-type == 'hybrid' && secrets.KONG_TEST_KONNECT_ACCESS_TOKEN || '' }}
           KONG_TEST_KONNECT_SERVER_URL: ${{ matrix.gateway-type == 'hybrid' && 'us.api.konghq.tech' || '' }}
+          KONG_LICENSE_DATA: ${{ steps.license.outputs.license }}
           # Add GITHUB_TOKEN env so that mise plugins can can access GitHub's API
           # authenticated and thus not get rate-limited (which causes failures).
           # Source ref: https://github.com/pirackr/asdf-telepresence/blob/c9eeab4d28b9851bb904c4c67239a118c8dd384d/bin/list-all#L7-L9


### PR DESCRIPTION
**What this PR does / why we need it**:


failed job: https://github.com/Kong/kong-operator/actions/runs/31703621520/job/94458565711#step:7:296

```
=== Failed
=== FAIL: test/conformance TestGatewayConformance (0.01s)
INFO: running in CI: true
    conformance_test.go:85: 
        	Error Trace:	/home/runner/work/kong-operator/kong-operator/test/helpers/license.go:67
        	            				/home/runner/work/kong-operator/kong-operator/test/conformance/conformance_test.go:100
        	            				/home/runner/work/kong-operator/kong-operator/test/conformance/conformance_test.go:85
        	Error:      	Received unexpected error:
        	            	KONG_LICENSE_DATA not set
        	Test:       	TestGatewayConformance
```

**Which issue this PR fixes**



**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
