### PR TITLE
fix(hybridgateway): propagate konghq.com/tags to generated KongPlugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,9 +123,9 @@
 - Konnect entities: Fix truncating of tags to cut at 128 unicode runes
   (UTF8 code points).
   [#5306](https://github.com/Kong/kong-operator/pull/5306)
-- Hybrid gateway: Propogate tags in the annotation `konghq.com/tags` in `KongPlugin`s
-  to the copies when attached to `HTTPRoute`s and `GRPCRoute`s to propogate the
-  tags to plugins in Konnect.
+- Hybrid gateway: Propagate tags in the annotation `konghq.com/tags` in `KongPlugin`s
+  to the copies when attached to `HTTPRoute`s and `GRPCRoute`s to propagate the
+  tags in `KongPlugin`s' annotation to plugins in Konnect.
   [#5280](https://github.com/Kong/kong-operator/pull/5280)
   [#5284](https://github.com/Kong/kong-operator/pull/5284)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -127,7 +127,7 @@
   to the copies when attached to `HTTPRoute`s and `GRPCRoute`s to propogate the
   tags to plugins in Konnect.
   [#5280](https://github.com/Kong/kong-operator/pull/5280)
-  [#5284])https://github.com/Kong/kong-operator/pull/5284
+  [#5284](https://github.com/Kong/kong-operator/pull/5284)
 
 ## [v2.3.0-rc.3]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -123,6 +123,11 @@
 - Konnect entities: Fix truncating of tags to cut at 128 unicode runes
   (UTF8 code points).
   [#5306](https://github.com/Kong/kong-operator/pull/5306)
+- Hybrid gateway: Propogate tags in the annotation `konghq.com/tags` in `KongPlugin`s
+  to the copies when attached to `HTTPRoute`s and `GRPCRoute`s to propogate the
+  tags to plugins in Konnect.
+  [#5280](https://github.com/Kong/kong-operator/pull/5280)
+  [#5284])https://github.com/Kong/kong-operator/pull/5284
 
 ## [v2.3.0-rc.3]
 

--- a/controller/hybridgateway/builder/kongplugin.go
+++ b/controller/hybridgateway/builder/kongplugin.go
@@ -104,11 +104,11 @@ func (b *KongPluginBuilder) MustBuild() configurationv1.KongPlugin {
 	return plugin
 }
 
-// WithTagsAnnotation merges the konghq.com/tags annotation value from the given
+// WithTagsFromAnnotations merges the konghq.com/tags annotation value from the given
 // sources into the KongPlugin being built. This ensures that when the generated
 // KongPlugin copy is later read by the Konnect ops layer (via metadata.ExtractTags),
 // the user-supplied tags are present. Multiple sources are merged and deduplicated.
-func (b *KongPluginBuilder) WithTagsAnnotation(sources ...pkgmetadata.ObjectWithAnnotations) *KongPluginBuilder {
+func (b *KongPluginBuilder) WithTagsFromAnnotations(sources ...pkgmetadata.ObjectWithAnnotations) *KongPluginBuilder {
 	var allTags []string
 	for _, src := range sources {
 		if src == nil {

--- a/controller/hybridgateway/builder/kongplugin.go
+++ b/controller/hybridgateway/builder/kongplugin.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"sort"
 	"strings"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -130,6 +131,7 @@ func (b *KongPluginBuilder) WithTagsAnnotation(sources ...pkgmetadata.ObjectWith
 	if b.plugin.Annotations == nil {
 		b.plugin.Annotations = make(map[string]string)
 	}
+	sort.Strings(deduped)
 	b.plugin.Annotations[pkgmetadata.AnnotationKeyTags] = strings.Join(deduped, ",")
 	return b
 }

--- a/controller/hybridgateway/builder/kongplugin.go
+++ b/controller/hybridgateway/builder/kongplugin.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"strings"
 
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -13,6 +14,7 @@ import (
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/metadata"
 	gwtypes "github.com/kong/kong-operator/v2/internal/types"
 	"github.com/kong/kong-operator/v2/modules/manager/scheme"
+	pkgmetadata "github.com/kong/kong-operator/v2/pkg/metadata"
 )
 
 // KongPluginBuilder is a builder for configurationv1.KongPlugin resources.
@@ -99,6 +101,37 @@ func (b *KongPluginBuilder) MustBuild() configurationv1.KongPlugin {
 		panic(fmt.Errorf("failed to build KongPlugin: %w", err))
 	}
 	return plugin
+}
+
+// WithTagsAnnotation merges the konghq.com/tags annotation value from the given
+// sources into the KongPlugin being built. This ensures that when the generated
+// KongPlugin copy is later read by the Konnect ops layer (via metadata.ExtractTags),
+// the user-supplied tags are present. Multiple sources are merged and deduplicated.
+func (b *KongPluginBuilder) WithTagsAnnotation(sources ...pkgmetadata.ObjectWithAnnotations) *KongPluginBuilder {
+	var allTags []string
+	for _, src := range sources {
+		if src == nil {
+			continue
+		}
+		allTags = append(allTags, pkgmetadata.ExtractTags(src)...)
+	}
+	if len(allTags) == 0 {
+		return b
+	}
+	// Deduplicate while preserving order.
+	seen := make(map[string]struct{}, len(allTags))
+	deduped := make([]string, 0, len(allTags))
+	for _, t := range allTags {
+		if _, ok := seen[t]; !ok {
+			seen[t] = struct{}{}
+			deduped = append(deduped, t)
+		}
+	}
+	if b.plugin.Annotations == nil {
+		b.plugin.Annotations = make(map[string]string)
+	}
+	b.plugin.Annotations[pkgmetadata.AnnotationKeyTags] = strings.Join(deduped, ",")
+	return b
 }
 
 // WithPluginName sets the plugin name for the KongPlugin being built.

--- a/controller/hybridgateway/builder/kongplugin.go
+++ b/controller/hybridgateway/builder/kongplugin.go
@@ -123,11 +123,20 @@ func (b *KongPluginBuilder) WithTagsAnnotation(sources ...pkgmetadata.ObjectWith
 	seen := make(map[string]struct{}, len(allTags))
 	deduped := make([]string, 0, len(allTags))
 	for _, t := range allTags {
+		// Trim trailing and leading whitespace from each tag to avoid duplicates that differ only by whitespace.
+		t = strings.TrimSpace(t)
+		if t == "" {
+			continue
+		}
 		if _, ok := seen[t]; !ok {
 			seen[t] = struct{}{}
 			deduped = append(deduped, t)
 		}
 	}
+	if len(deduped) == 0 {
+		return b
+	}
+
 	if b.plugin.Annotations == nil {
 		b.plugin.Annotations = make(map[string]string)
 	}

--- a/controller/hybridgateway/builder/kongplugin_test.go
+++ b/controller/hybridgateway/builder/kongplugin_test.go
@@ -219,7 +219,7 @@ func TestKongPluginBuilder_WithTagsAnnotation(t *testing.T) {
 
 		plugin, err := NewKongPlugin().
 			WithName("test-plugin").
-			WithTagsAnnotation(route).
+			WithTagsFromAnnotations(route).
 			Build()
 		require.NoError(t, err)
 		assert.Equal(t, "env-prod,team-payments", plugin.Annotations["konghq.com/tags"])
@@ -247,7 +247,7 @@ func TestKongPluginBuilder_WithTagsAnnotation(t *testing.T) {
 
 		plugin, err := NewKongPlugin().
 			WithName("test-plugin").
-			WithTagsAnnotation(route, sourcePlugin).
+			WithTagsFromAnnotations(route, sourcePlugin).
 			Build()
 		require.NoError(t, err)
 		assert.Equal(t, "plugin-tag,route-tag,shared-tag", plugin.Annotations["konghq.com/tags"])
@@ -263,7 +263,7 @@ func TestKongPluginBuilder_WithTagsAnnotation(t *testing.T) {
 
 		plugin, err := NewKongPlugin().
 			WithName("test-plugin").
-			WithTagsAnnotation(route).
+			WithTagsFromAnnotations(route).
 			Build()
 		require.NoError(t, err)
 		assert.Empty(t, plugin.Annotations["konghq.com/tags"])
@@ -282,7 +282,7 @@ func TestKongPluginBuilder_WithTagsAnnotation(t *testing.T) {
 
 		plugin, err := NewKongPlugin().
 			WithName("test-plugin").
-			WithTagsAnnotation(route, nil).
+			WithTagsFromAnnotations(route, nil).
 			Build()
 		require.NoError(t, err)
 		assert.Equal(t, "my-tag", plugin.Annotations["konghq.com/tags"])
@@ -305,7 +305,7 @@ func TestKongPluginBuilder_WithTagsAnnotation(t *testing.T) {
 		plugin, err := NewKongPlugin().
 			WithName("test-plugin").
 			WithAnnotations(route, parentRef).
-			WithTagsAnnotation(route).
+			WithTagsFromAnnotations(route).
 			Build()
 		require.NoError(t, err)
 		// Tags annotation should be present
@@ -327,7 +327,7 @@ func TestKongPluginBuilder_WithTagsAnnotation(t *testing.T) {
 
 		plugin, err := NewKongPlugin().
 			WithName("test-plugin").
-			WithTagsAnnotation(route).
+			WithTagsFromAnnotations(route).
 			Build()
 		require.NoError(t, err)
 		assert.Equal(t, "env-prod,shared-tag,team-payments", plugin.Annotations["konghq.com/tags"])

--- a/controller/hybridgateway/builder/kongplugin_test.go
+++ b/controller/hybridgateway/builder/kongplugin_test.go
@@ -204,3 +204,113 @@ func TestKongPluginBuilder_ChainedCalls(t *testing.T) {
 	assert.NotNil(t, plugin.Annotations)
 	assert.JSONEq(t, string(config), string(plugin.Config.Raw))
 }
+
+func TestKongPluginBuilder_WithTagsAnnotation(t *testing.T) {
+	t.Run("tags from single source", func(t *testing.T) {
+		route := &gwtypes.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-route",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"konghq.com/tags": "team-payments,env-prod",
+				},
+			},
+		}
+
+		plugin, err := NewKongPlugin().
+			WithName("test-plugin").
+			WithTagsAnnotation(route).
+			Build()
+		require.NoError(t, err)
+		assert.Equal(t, "env-prod,team-payments", plugin.Annotations["konghq.com/tags"])
+	})
+
+	t.Run("tags from multiple sources are merged and deduplicated", func(t *testing.T) {
+		route := &gwtypes.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-route",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"konghq.com/tags": "shared-tag,route-tag",
+				},
+			},
+		}
+		sourcePlugin := &configurationv1.KongPlugin{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "user-plugin",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"konghq.com/tags": "shared-tag,plugin-tag",
+				},
+			},
+		}
+
+		plugin, err := NewKongPlugin().
+			WithName("test-plugin").
+			WithTagsAnnotation(route, sourcePlugin).
+			Build()
+		require.NoError(t, err)
+		assert.Equal(t, "plugin-tag,route-tag,shared-tag", plugin.Annotations["konghq.com/tags"])
+	})
+
+	t.Run("no tags annotation when sources have no tags", func(t *testing.T) {
+		route := &gwtypes.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-route",
+				Namespace: "default",
+			},
+		}
+
+		plugin, err := NewKongPlugin().
+			WithName("test-plugin").
+			WithTagsAnnotation(route).
+			Build()
+		require.NoError(t, err)
+		assert.Empty(t, plugin.Annotations["konghq.com/tags"])
+	})
+
+	t.Run("nil source is safely skipped", func(t *testing.T) {
+		route := &gwtypes.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-route",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"konghq.com/tags": "my-tag",
+				},
+			},
+		}
+
+		plugin, err := NewKongPlugin().
+			WithName("test-plugin").
+			WithTagsAnnotation(route, nil).
+			Build()
+		require.NoError(t, err)
+		assert.Equal(t, "my-tag", plugin.Annotations["konghq.com/tags"])
+	})
+
+	t.Run("tags annotation preserved alongside tracking annotations", func(t *testing.T) {
+		route := &gwtypes.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-route",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"konghq.com/tags": "my-tag",
+				},
+			},
+		}
+		parentRef := &gwtypes.ParentReference{
+			Name: "test-gateway",
+		}
+
+		plugin, err := NewKongPlugin().
+			WithName("test-plugin").
+			WithAnnotations(route, parentRef).
+			WithTagsAnnotation(route).
+			Build()
+		require.NoError(t, err)
+		// Tags annotation should be present
+		assert.Equal(t, "my-tag", plugin.Annotations["konghq.com/tags"])
+		// Tracking annotations from BuildAnnotations should also be present
+		assert.NotEmpty(t, plugin.Annotations["gateway-operator.konghq.com/hybrid-gateways"])
+	})
+}

--- a/controller/hybridgateway/builder/kongplugin_test.go
+++ b/controller/hybridgateway/builder/kongplugin_test.go
@@ -313,4 +313,23 @@ func TestKongPluginBuilder_WithTagsAnnotation(t *testing.T) {
 		// Tracking annotations from BuildAnnotations should also be present
 		assert.NotEmpty(t, plugin.Annotations["gateway-operator.konghq.com/hybrid-gateways"])
 	})
+
+	t.Run("tags with spaces are trimmed", func(t *testing.T) {
+		route := &gwtypes.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-route",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"konghq.com/tags": "team-payments , env-prod,env-prod, ,  shared-tag  ",
+				},
+			},
+		}
+
+		plugin, err := NewKongPlugin().
+			WithName("test-plugin").
+			WithTagsAnnotation(route).
+			Build()
+		require.NoError(t, err)
+		assert.Equal(t, "env-prod,shared-tag,team-payments", plugin.Annotations["konghq.com/tags"])
+	})
 }

--- a/controller/hybridgateway/plugin/grpc_plugin.go
+++ b/controller/hybridgateway/plugin/grpc_plugin.go
@@ -59,7 +59,6 @@ func GRPCPluginsForRule(
 				WithPluginName(conf.name).
 				WithPluginConfig(conf.config).
 				WithAnnotations(grpcRoute, pRef).
-				WithTagsAnnotation(grpcRoute).
 				Build()
 			if err != nil {
 				return nil, fmt.Errorf("failed to build KongPlugin %s: %w", pluginName, err)
@@ -97,7 +96,8 @@ func GRPCPluginsForRule(
 			WithPluginName(plugin.PluginName).
 			WithPluginConfig(plugin.Config.Raw).
 			WithAnnotations(grpcRoute, pRef).
-			WithTagsAnnotation(grpcRoute, plugin).
+			// Since plugins are shared across multiple routes, we don't want to overwrite the tags annotation from the GRPCRoute on the original plugin.
+			WithTagsAnnotation(plugin).
 			Build()
 		if err != nil {
 			return nil, fmt.Errorf("failed to build KongPlugin %s: %w", pluginName, err)

--- a/controller/hybridgateway/plugin/grpc_plugin.go
+++ b/controller/hybridgateway/plugin/grpc_plugin.go
@@ -59,6 +59,7 @@ func GRPCPluginsForRule(
 				WithPluginName(conf.name).
 				WithPluginConfig(conf.config).
 				WithAnnotations(grpcRoute, pRef).
+				WithTagsAnnotation(grpcRoute).
 				Build()
 			if err != nil {
 				return nil, fmt.Errorf("failed to build KongPlugin %s: %w", pluginName, err)
@@ -96,6 +97,7 @@ func GRPCPluginsForRule(
 			WithPluginName(plugin.PluginName).
 			WithPluginConfig(plugin.Config.Raw).
 			WithAnnotations(grpcRoute, pRef).
+			WithTagsAnnotation(grpcRoute, plugin).
 			Build()
 		if err != nil {
 			return nil, fmt.Errorf("failed to build KongPlugin %s: %w", pluginName, err)

--- a/controller/hybridgateway/plugin/grpc_plugin.go
+++ b/controller/hybridgateway/plugin/grpc_plugin.go
@@ -96,8 +96,8 @@ func GRPCPluginsForRule(
 			WithPluginName(plugin.PluginName).
 			WithPluginConfig(plugin.Config.Raw).
 			WithAnnotations(grpcRoute, pRef).
-			// Since plugins are shared across multiple routes, we don't want to overwrite the tags annotation from the GRPCRoute on the original plugin.
-			WithTagsAnnotation(plugin).
+			// Copy the tags annotation from the original plugin to the new plugin copy.
+			WithTagsFromAnnotations(plugin).
 			Build()
 		if err != nil {
 			return nil, fmt.Errorf("failed to build KongPlugin %s: %w", pluginName, err)

--- a/controller/hybridgateway/plugin/grpc_plugin_test.go
+++ b/controller/hybridgateway/plugin/grpc_plugin_test.go
@@ -70,7 +70,8 @@ func TestGRPCPluginsForRule(t *testing.T) {
 	assert.Equal(t, "request-transformer", plugin.PluginName)
 	assert.Contains(t, plugin.Annotations, consts.GatewayOperatorHybridRoutesGRPCRouteAnnotation)
 	assert.Equal(t, "test-namespace/test-route", plugin.Annotations[consts.GatewayOperatorHybridRoutesGRPCRouteAnnotation])
-	assert.Equal(t, "grpc-tag,shared-tag", plugin.Annotations[pkgmetadata.AnnotationKeyTags])
+	// tags in GRPCRoute should not be merged into the tags annotation of the KongPlugin, since plugins are shared across multiple routes.
+	assert.Empty(t, plugin.Annotations[pkgmetadata.AnnotationKeyTags])
 }
 
 func TestGRPCPluginsForRule_UnsupportedFilterErrors(t *testing.T) {
@@ -266,7 +267,7 @@ func TestGRPCPluginsForRule_ExtensionRef_TagsAnnotation(t *testing.T) {
 			Name:      "referenced-plugin",
 			Namespace: "test-namespace",
 			Annotations: map[string]string{
-				pkgmetadata.AnnotationKeyTags: "plugin-tag,route-tag",
+				pkgmetadata.AnnotationKeyTags: "plugin-tag",
 			},
 		},
 		PluginName: "rate-limiting",
@@ -293,6 +294,6 @@ func TestGRPCPluginsForRule_ExtensionRef_TagsAnnotation(t *testing.T) {
 	plugins, err := GRPCPluginsForRule(ctx, logger, fakeClient, grpcRoute, rule, parentRef)
 	require.NoError(t, err)
 	require.Len(t, plugins, 1)
-
-	assert.Equal(t, "plugin-tag,route-tag", plugins[0].Annotations[pkgmetadata.AnnotationKeyTags])
+	// Should only include the tags from the referenced plugin, not the route.
+	assert.Equal(t, "plugin-tag", plugins[0].Annotations[pkgmetadata.AnnotationKeyTags])
 }

--- a/controller/hybridgateway/plugin/grpc_plugin_test.go
+++ b/controller/hybridgateway/plugin/grpc_plugin_test.go
@@ -17,6 +17,7 @@ import (
 	gwtypes "github.com/kong/kong-operator/v2/internal/types"
 	"github.com/kong/kong-operator/v2/modules/manager/scheme"
 	"github.com/kong/kong-operator/v2/pkg/consts"
+	pkgmetadata "github.com/kong/kong-operator/v2/pkg/metadata"
 )
 
 var grpcRouteTypeMeta = metav1.TypeMeta{
@@ -34,6 +35,9 @@ func TestGRPCPluginsForRule(t *testing.T) {
 			Name:      "test-route",
 			Namespace: "test-namespace",
 			UID:       "test-uid",
+			Annotations: map[string]string{
+				pkgmetadata.AnnotationKeyTags: "grpc-tag, shared-tag",
+			},
 		},
 	}
 	parentRef := &gwtypes.ParentReference{
@@ -66,6 +70,7 @@ func TestGRPCPluginsForRule(t *testing.T) {
 	assert.Equal(t, "request-transformer", plugin.PluginName)
 	assert.Contains(t, plugin.Annotations, consts.GatewayOperatorHybridRoutesGRPCRouteAnnotation)
 	assert.Equal(t, "test-namespace/test-route", plugin.Annotations[consts.GatewayOperatorHybridRoutesGRPCRouteAnnotation])
+	assert.Equal(t, "grpc-tag,shared-tag", plugin.Annotations[pkgmetadata.AnnotationKeyTags])
 }
 
 func TestGRPCPluginsForRule_UnsupportedFilterErrors(t *testing.T) {
@@ -235,4 +240,59 @@ func TestGetReferencedKongPluginForGRPCFilter(t *testing.T) {
 			assert.Equal(t, tt.expectedPlugin.Config.Raw, plugin.Config.Raw)
 		})
 	}
+}
+
+func TestGRPCPluginsForRule_ExtensionRef_TagsAnnotation(t *testing.T) {
+	logger := logr.Discard()
+	ctx := context.Background()
+
+	grpcRoute := &gwtypes.GRPCRoute{
+		TypeMeta: grpcRouteTypeMeta,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "test-namespace",
+			UID:       "test-uid",
+			Annotations: map[string]string{
+				pkgmetadata.AnnotationKeyTags: "route-tag",
+			},
+		},
+	}
+	parentRef := &gwtypes.ParentReference{
+		Name: "test-gateway",
+	}
+
+	referencedPlugin := &configurationv1.KongPlugin{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "referenced-plugin",
+			Namespace: "test-namespace",
+			Annotations: map[string]string{
+				pkgmetadata.AnnotationKeyTags: "plugin-tag,route-tag",
+			},
+		},
+		PluginName: "rate-limiting",
+	}
+
+	rule := gwtypes.GRPCRouteRule{
+		Filters: []gatewayv1.GRPCRouteFilter{
+			{
+				Type: gatewayv1.GRPCRouteFilterExtensionRef,
+				ExtensionRef: &gatewayv1.LocalObjectReference{
+					Group: gatewayv1.Group(configurationv1.GroupVersion.Group),
+					Kind:  "KongPlugin",
+					Name:  "referenced-plugin",
+				},
+			},
+		},
+	}
+
+	fakeClient := fakectrlruntimeclient.NewClientBuilder().
+		WithScheme(scheme.Get()).
+		WithObjects(referencedPlugin).
+		Build()
+
+	plugins, err := GRPCPluginsForRule(ctx, logger, fakeClient, grpcRoute, rule, parentRef)
+	require.NoError(t, err)
+	require.Len(t, plugins, 1)
+
+	assert.Equal(t, "plugin-tag,route-tag", plugins[0].Annotations[pkgmetadata.AnnotationKeyTags])
 }

--- a/controller/hybridgateway/plugin/grpc_request_termination.go
+++ b/controller/hybridgateway/plugin/grpc_request_termination.go
@@ -48,6 +48,7 @@ func GRPCRequestTerminationForBackendNotFound(
 		WithNamespace(metadata.NamespaceFromParentRef(grpcRoute, pRef)).
 		WithLabels(grpcRoute, pRef).
 		WithAnnotations(grpcRoute, pRef).
+		WithTagsAnnotation(grpcRoute).
 		WithPluginName("request-termination").
 		WithPluginConfig(config).
 		Build()

--- a/controller/hybridgateway/plugin/grpc_request_termination.go
+++ b/controller/hybridgateway/plugin/grpc_request_termination.go
@@ -48,7 +48,7 @@ func GRPCRequestTerminationForBackendNotFound(
 		WithNamespace(metadata.NamespaceFromParentRef(grpcRoute, pRef)).
 		WithLabels(grpcRoute, pRef).
 		WithAnnotations(grpcRoute, pRef).
-		WithTagsAnnotation(grpcRoute).
+		WithTagsFromAnnotations(grpcRoute).
 		WithPluginName("request-termination").
 		WithPluginConfig(config).
 		Build()

--- a/controller/hybridgateway/plugin/plugin.go
+++ b/controller/hybridgateway/plugin/plugin.go
@@ -80,6 +80,7 @@ func PluginsForRule(
 			WithPluginName(pConf.name).
 			WithPluginConfig(pConf.config).
 			WithAnnotations(httpRoute, pRef).
+			WithTagsAnnotation(httpRoute).
 			Build()
 		if err != nil {
 			return nil, fmt.Errorf("failed to build KongPlugin %s: %w", pluginName, err)
@@ -116,6 +117,7 @@ func PluginsForRule(
 			WithPluginName(plugin.PluginName).
 			WithPluginConfig(plugin.Config.Raw).
 			WithAnnotations(httpRoute, pRef).
+			WithTagsAnnotation(httpRoute, plugin).
 			Build()
 		if err != nil {
 			return nil, fmt.Errorf("failed to build KongPlugin %s: %w", pluginName, err)

--- a/controller/hybridgateway/plugin/plugin.go
+++ b/controller/hybridgateway/plugin/plugin.go
@@ -80,7 +80,6 @@ func PluginsForRule(
 			WithPluginName(pConf.name).
 			WithPluginConfig(pConf.config).
 			WithAnnotations(httpRoute, pRef).
-			WithTagsAnnotation(httpRoute).
 			Build()
 		if err != nil {
 			return nil, fmt.Errorf("failed to build KongPlugin %s: %w", pluginName, err)
@@ -117,7 +116,8 @@ func PluginsForRule(
 			WithPluginName(plugin.PluginName).
 			WithPluginConfig(plugin.Config.Raw).
 			WithAnnotations(httpRoute, pRef).
-			WithTagsAnnotation(httpRoute, plugin).
+			// Since plugins are shared across multiple routes, we don't want to overwrite the tags annotation from the HTTPRoute on the original plugin.
+			WithTagsAnnotation(plugin).
 			Build()
 		if err != nil {
 			return nil, fmt.Errorf("failed to build KongPlugin %s: %w", pluginName, err)

--- a/controller/hybridgateway/plugin/plugin.go
+++ b/controller/hybridgateway/plugin/plugin.go
@@ -116,8 +116,8 @@ func PluginsForRule(
 			WithPluginName(plugin.PluginName).
 			WithPluginConfig(plugin.Config.Raw).
 			WithAnnotations(httpRoute, pRef).
-			// Since plugins are shared across multiple routes, we don't want to overwrite the tags annotation from the HTTPRoute on the original plugin.
-			WithTagsAnnotation(plugin).
+			// Copy the tags annotation from the original plugin to the new plugin copy.
+			WithTagsFromAnnotations(plugin).
 			Build()
 		if err != nil {
 			return nil, fmt.Errorf("failed to build KongPlugin %s: %w", pluginName, err)

--- a/controller/hybridgateway/plugin/plugin_test.go
+++ b/controller/hybridgateway/plugin/plugin_test.go
@@ -19,6 +19,7 @@ import (
 	gwtypes "github.com/kong/kong-operator/v2/internal/types"
 	"github.com/kong/kong-operator/v2/modules/manager/scheme"
 	"github.com/kong/kong-operator/v2/pkg/consts"
+	pkgmetadata "github.com/kong/kong-operator/v2/pkg/metadata"
 )
 
 var (
@@ -184,6 +185,47 @@ func TestPluginForFilter(t *testing.T) {
 				assert.Equal(t, "request-transformer", plugin.PluginName)
 				assert.Contains(t, plugin.Annotations, consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation)
 				assert.Equal(t, "test-namespace/test-route", plugin.Annotations[consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation])
+			},
+		},
+		{
+			name: "route tags are merged into the tags annotation",
+			filter: gwtypes.HTTPRouteFilter{
+				Type: gatewayv1.HTTPRouteFilterRequestHeaderModifier,
+				RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+					Set: []gatewayv1.HTTPHeader{
+						{Name: "X-Custom-Header", Value: "custom-value"},
+					},
+				},
+			},
+			rule: gwtypes.HTTPRouteRule{
+				Matches: []gatewayv1.HTTPRouteMatch{
+					{
+						Path: &gatewayv1.HTTPPathMatch{
+							Type:  new(gatewayv1.PathMatchPathPrefix),
+							Value: new("/test"),
+						},
+					},
+				},
+			},
+			existingPlugin: nil,
+			httpRoute: &gwtypes.HTTPRoute{
+				TypeMeta: httpRouteTypeMeta,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+					UID:       "test-uid",
+					Annotations: map[string]string{
+						pkgmetadata.AnnotationKeyTags: "team-b, team-a",
+					},
+				},
+			},
+			parentRef: &gwtypes.ParentReference{
+				Name: "test-gateway",
+			},
+			expectedError: false,
+			validatePlugin: func(t *testing.T, plugin *configurationv1.KongPlugin) {
+				require.NotNil(t, plugin)
+				assert.Equal(t, "team-a,team-b", plugin.Annotations[pkgmetadata.AnnotationKeyTags])
 			},
 		},
 	}
@@ -366,4 +408,59 @@ func TestGetReferencedKongPlugin(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPluginsForRule_ExtensionRef_TagsAnnotation(t *testing.T) {
+	logger := logr.Discard()
+	ctx := context.Background()
+
+	httpRoute := &gwtypes.HTTPRoute{
+		TypeMeta: httpRouteTypeMeta,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "test-namespace",
+			UID:       "test-uid",
+			Annotations: map[string]string{
+				pkgmetadata.AnnotationKeyTags: "route-tag",
+			},
+		},
+	}
+	parentRef := &gwtypes.ParentReference{
+		Name: "test-gateway",
+	}
+
+	referencedPlugin := &configurationv1.KongPlugin{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "referenced-plugin",
+			Namespace: "test-namespace",
+			Annotations: map[string]string{
+				pkgmetadata.AnnotationKeyTags: "plugin-tag,route-tag",
+			},
+		},
+		PluginName: "rate-limiting",
+	}
+
+	rule := gwtypes.HTTPRouteRule{
+		Filters: []gwtypes.HTTPRouteFilter{
+			{
+				Type: gatewayv1.HTTPRouteFilterExtensionRef,
+				ExtensionRef: &gatewayv1.LocalObjectReference{
+					Group: gatewayv1.Group(configurationv1.GroupVersion.Group),
+					Kind:  "KongPlugin",
+					Name:  "referenced-plugin",
+				},
+			},
+		},
+	}
+
+	fakeClient := fakectrlruntimeclient.NewClientBuilder().
+		WithScheme(scheme.Get()).
+		WithObjects(referencedPlugin).
+		Build()
+
+	plugins, err := PluginsForRule(ctx, logger, fakeClient, httpRoute, rule, parentRef)
+	require.NoError(t, err)
+	require.Len(t, plugins, 1)
+
+	assert.Equal(t, "plugin-tag,route-tag", plugins[0].Annotations[pkgmetadata.AnnotationKeyTags])
 }

--- a/controller/hybridgateway/plugin/plugin_test.go
+++ b/controller/hybridgateway/plugin/plugin_test.go
@@ -188,7 +188,7 @@ func TestPluginForFilter(t *testing.T) {
 			},
 		},
 		{
-			name: "route tags are merged into the tags annotation",
+			name: "route tags are not merged into the tags annotation",
 			filter: gwtypes.HTTPRouteFilter{
 				Type: gatewayv1.HTTPRouteFilterRequestHeaderModifier,
 				RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
@@ -225,7 +225,7 @@ func TestPluginForFilter(t *testing.T) {
 			expectedError: false,
 			validatePlugin: func(t *testing.T, plugin *configurationv1.KongPlugin) {
 				require.NotNil(t, plugin)
-				assert.Equal(t, "team-a,team-b", plugin.Annotations[pkgmetadata.AnnotationKeyTags])
+				assert.Empty(t, plugin.Annotations[pkgmetadata.AnnotationKeyTags])
 			},
 		},
 	}

--- a/controller/hybridgateway/plugin/request_termination.go
+++ b/controller/hybridgateway/plugin/request_termination.go
@@ -40,7 +40,7 @@ func RequestTerminationForBackendNotFound(
 		WithNamespace(metadata.NamespaceFromParentRef(httpRoute, pRef)).
 		WithLabels(httpRoute, pRef).
 		WithAnnotations(httpRoute, pRef).
-		WithTagsAnnotation(httpRoute).
+		WithTagsFromAnnotations(httpRoute).
 		WithPluginName("request-termination").
 		WithPluginConfig(config).
 		Build()

--- a/controller/hybridgateway/plugin/request_termination.go
+++ b/controller/hybridgateway/plugin/request_termination.go
@@ -40,6 +40,7 @@ func RequestTerminationForBackendNotFound(
 		WithNamespace(metadata.NamespaceFromParentRef(httpRoute, pRef)).
 		WithLabels(httpRoute, pRef).
 		WithAnnotations(httpRoute, pRef).
+		WithTagsAnnotation(httpRoute).
 		WithPluginName("request-termination").
 		WithPluginConfig(config).
 		Build()

--- a/controller/konnect/ops/objects_metadata.go
+++ b/controller/konnect/ops/objects_metadata.go
@@ -67,12 +67,17 @@ func GenerateTagsForObject(obj ObjectWithMetadata, additionalTags ...string) []s
 		annotationTags = append(annotationTags, truncate(tag, maxAllowedTagLength))
 	}
 
+	// Truncate the additional tags to ensure they are within the maximum allowed tag length.
+	truncatedAdditional := make([]string, 0, len(additionalTags))
+	for _, tag := range additionalTags {
+		truncatedAdditional = append(truncatedAdditional, truncate(tag, maxAllowedTagLength))
+	}
 	k8sMetaTags := generateKubernetesMetadataTags(obj)
 
-	// We concatenate the tags in this order to ensure that the k8sMetaTags and additionalTags (from spec) are never
-	// truncated below. CEL rules ensure that the total length of k8sMetaTags and additionalTags never exceeds
-	// the maximum allowed tags count. That means we will only discard tags from annotations.
-	allTags := lo.Uniq(slices.Concat(k8sMetaTags, additionalTags, annotationTags))
+	// We concatenate the tags in this order to ensure that the k8sMetaTags and additionalTags
+	// (from spec or annotation of `KongPlugin` to create plugins for `HTTPRoute` or `GRPCRoute`) are always preserved.
+	// That means we will only discard tags from annotations.
+	allTags := lo.Uniq(slices.Concat(k8sMetaTags, truncatedAdditional, annotationTags))
 
 	// If the total number of tags exceeds the maximum allowed tags counts, we limit the number of tags to the maximum
 	// allowed tags count, discarding the tags from annotations.

--- a/controller/konnect/ops/objects_metadata.go
+++ b/controller/konnect/ops/objects_metadata.go
@@ -60,6 +60,8 @@ func GenerateTagsForObject(obj ObjectWithMetadata, additionalTags ...string) []s
 		// The maximum number of tags that can be attached to a Konnect entity.
 		maxAllowedTagsCount = 20
 	)
+	// TODO: truncate by unicode code points instead of bytes to avoid cutting off a multi-byte character in the middle:
+	// https://github.com/Kong/kong-operator/issues/5305
 
 	// Truncate the tags from annotations as we do not validate their length in CEL validations rules.
 	var annotationTags []string

--- a/controller/konnect/ops/objects_metadata.go
+++ b/controller/konnect/ops/objects_metadata.go
@@ -60,8 +60,6 @@ func GenerateTagsForObject(obj ObjectWithMetadata, additionalTags ...string) []s
 		// The maximum number of tags that can be attached to a Konnect entity.
 		maxAllowedTagsCount = 20
 	)
-	// TODO: truncate by unicode code points instead of bytes to avoid cutting off a multi-byte character in the middle:
-	// https://github.com/Kong/kong-operator/issues/5305
 
 	// Truncate the tags from annotations as we do not validate their length in CEL validations rules.
 	var annotationTags []string

--- a/controller/konnect/ops/objects_metadata_test.go
+++ b/controller/konnect/ops/objects_metadata_test.go
@@ -294,6 +294,28 @@ func TestGenerateTagsForObject(t *testing.T) {
 			},
 		},
 		{
+			name: "too long tags in additional tags are truncated",
+			obj:  namespacedObject(),
+			additionalTags: []string{
+				"tag1",
+				"tag2",
+				"long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-tag-that-would-end-here-and-no-more-things-should-be-preserved",
+			},
+			expectedTags: []string{
+				"k8s-generation:2",
+				"k8s-group:test.objects.io",
+				"k8s-kind:TestObjectKind",
+				"k8s-name:test-object",
+				"k8s-namespace:test-namespace",
+				"k8s-uid:test-uid",
+				"k8s-version:v1",
+				"long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-tag-that-would-end-here",
+				"managed-by:kong-operator",
+				"tag1",
+				"tag2",
+			},
+		},
+		{
 			name: "when too many tags in total, last from annotations are discarded",
 			obj: func() testObjectKind {
 				obj := namespacedObject()

--- a/pkg/metadata/tags.go
+++ b/pkg/metadata/tags.go
@@ -1,6 +1,7 @@
 package metadata
 
 import (
+	"reflect"
 	"strings"
 )
 
@@ -9,6 +10,14 @@ import (
 //
 //godoclint:disable max-len
 func ExtractTags(obj ObjectWithAnnotations) []string {
+	if obj == nil {
+		return nil
+	}
+	// If the object is a nil pointer, return nil to avoid panics when calling GetAnnotations().
+	if v := reflect.ValueOf(obj); v.Kind() == reflect.Pointer && v.IsNil() {
+		return nil
+	}
+
 	ann, ok := obj.GetAnnotations()[AnnotationKeyTags]
 	if !ok || len(ann) == 0 {
 		return nil

--- a/pkg/metadata/tags_test.go
+++ b/pkg/metadata/tags_test.go
@@ -48,6 +48,16 @@ func TestExtractTags(t *testing.T) {
 			},
 			expected: nil,
 		},
+		{
+			name:     "Nil object",
+			obj:      nil,
+			expected: nil,
+		},
+		{
+			name:     "Nil pointer object",
+			obj:      (*configurationv1.KongConsumer)(nil),
+			expected: nil,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
**What this PR does / why we need it**:

Re-submit of #5280 from the contributor @bowale01.

> 
> ## Summary
> 
> Fixes https://github.com/Kong/kong-operator/issues/5277
> 
> When the hybrid gateway controller creates operator-managed KongPlugin copies (for both built-in
> filter plugins and ExtensionRef-referenced user plugins), it only set internal tracking annotations
> via `metadata.BuildAnnotations()`. The `konghq.com/tags` annotation from the source
> HTTPRoute/GRPCRoute or user-managed KongPlugin was never forwarded to the generated copy.
> 
> This caused the Konnect ops layer to produce Plugin entities without the user-specified tags,
> since `metadata.ExtractTags()` on the generated copy returned nothing.
> 
> ## Changes
> 
> - Added `WithTagsAnnotation()` to `KongPluginBuilder` that merges `konghq.com/tags` from source
>   objects (route and/or original plugin) onto the generated copy's annotations. Tags from multiple
>   sources are deduplicated.
> - Applied it in all plugin generation paths:
>   - Built-in filter plugins (tags from HTTPRoute/GRPCRoute)
>   - ExtensionRef plugins (tags from both route and original KongPlugin)
>   - Request-termination plugins (tags from route)
> 
> ## How it works
> 
> The Konnect ops layer already handles tag extraction correctly in `kongPluginBindingToSDKPluginInput`:
> 
> tags := GenerateTagsForObject(pluginBinding, metadata.ExtractTags(plugin)...)
> 
> It fetches the referenced KongPlugin and extracts tags from its annotations. The problem was that
> the generated copy never had the annotation set. This fix ensures it does.
> 
> ## Testing
> 
> - All existing unit tests pass for `controller/hybridgateway/builder/` and `controller/hybridgateway/plugin/`
> - Follows the same pattern used for KongRoute/KongService/KongUpstream tag propagation (from #4554)
> 

**Which issue this PR fixes**

Fixes #5277 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
