### PR TITLE
tests: fix TestSynchronizer

### DIFF
--- a/ingress-controller/internal/dataplane/synchronizer_test.go
+++ b/ingress-controller/internal/dataplane/synchronizer_test.go
@@ -62,12 +62,12 @@ func TestSynchronizer(t *testing.T) {
 	assert.Equal(t, "server is already running", err.Error())
 
 	t.Log("verifying that eventually the synchronizer reports as ready for a dbless dataplane")
-	assert.Eventually(t, func() bool { return sync.IsReady() }, testSynchronizerTick*3, testSynchronizerTick)
+	assert.Eventually(t, func() bool { return sync.IsReady() }, time.Second, testSynchronizerTick)
 
 	t.Log("verifying that the dataplane eventually receives several successful updates from the synchronizer")
-	assert.Eventually(t, func() bool {
-		return c.totalUpdates() >= 5
-	}, 10*testSynchronizerTick, testSynchronizerTick, "got %d updates, expected 5 or more", c.totalUpdates())
+	assert.EventuallyWithT(t, func(ct *assert.CollectT) {
+		assert.GreaterOrEqual(ct, c.totalUpdates(), 5)
+	}, time.Second, testSynchronizerTick)
 
 	t.Log("verifying that the server shuts down when the context is cancelled")
 	cancel()
@@ -114,16 +114,15 @@ func TestSynchronizer_IsReadyDoesntBlockWhenDataPlaneIsBlocked(t *testing.T) {
 			require.NoError(t, s.Start(ctx))
 
 			t.Log("verifying the first update happened and the synchronizer is ready")
-			require.Eventually(t, func() bool { return s.IsReady() }, testSynchronizerTick*10, testSynchronizerTick)
+			require.Eventually(t, func() bool { return s.IsReady() }, time.Second, testSynchronizerTick)
 
 			const clientBlockTime = time.Second * 10
 
 			t.Log("making the data plane calls block for significantly longer than the synchronizer tick")
 			c.clientShouldBlockFor(clientBlockTime)
-			updateCount := c.totalUpdates()
 
 			t.Log("waiting for a blocking update to happen")
-			require.Eventually(t, func() bool { return c.totalUpdates() > updateCount }, testSynchronizerTick*10, testSynchronizerTick)
+			require.Eventually(t, func() bool { return c.totalBlockingUpdates() > 0 }, time.Second, testSynchronizerTick)
 
 			t.Log("verifying that IsReady is not blocking even though the client is blocked")
 			// NOTE: Allow a little extra time for the synchronizer to return from IsReady() as
@@ -139,6 +138,7 @@ func TestSynchronizer_IsReadyDoesntBlockWhenDataPlaneIsBlocked(t *testing.T) {
 type fakeDataplaneClient struct {
 	dbmode                  dpconf.DBMode
 	updateCount             atomic.Uint64
+	blockingUpdateCount     atomic.Uint64
 	lock                    sync.RWMutex
 	clientCallBlockDuration time.Duration
 	t                       *testing.T
@@ -161,19 +161,20 @@ func (c *fakeDataplaneClient) DBMode() dpconf.DBMode {
 }
 
 func (c *fakeDataplaneClient) Update(ctx context.Context) error {
-	c.updateCount.Add(1)
 	c.lock.RLock()
-	defer c.lock.RUnlock()
-	if c.clientCallBlockDuration > 0 {
-		ch := time.After(c.clientCallBlockDuration)
+	blockFor := c.clientCallBlockDuration
+	c.lock.RUnlock()
 
-		select {
-		case <-c.t.Context().Done():
-			return c.t.Context().Err()
-		case <-ctx.Done():
-			return ctx.Err()
-		case <-ch:
-		}
+	c.updateCount.Add(1)
+	if blockFor <= 0 {
+		return nil
+	}
+
+	c.blockingUpdateCount.Add(1)
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(blockFor):
 	}
 	return nil
 }
@@ -190,4 +191,8 @@ func (c *fakeDataplaneClient) clientShouldBlockFor(d time.Duration) {
 
 func (c *fakeDataplaneClient) totalUpdates() int {
 	return int(c.updateCount.Load())
+}
+
+func (c *fakeDataplaneClient) totalBlockingUpdates() int {
+	return int(c.blockingUpdateCount.Load())
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Noticed in https://github.com/Kong/kong-operator/actions/runs/31788445999/job/94729682369?pr=5291#step:12:21226

```
=== Failed
=== FAIL: ingress-controller/internal/dataplane TestSynchronizer_IsReadyDoesntBlockWhenDataPlaneIsBlocked/dbmode=off (0.17s)
    synchronizer_test.go:116: verifying the first update happened and the synchronizer is ready
    synchronizer_test.go:121: making the data plane calls block for significantly longer than the synchronizer tick
    synchronizer_test.go:125: waiting for a blocking update to happen
    synchronizer_test.go:126: 
        	Error Trace:	/home/runner/work/kong-operator/kong-operator/ingress-controller/internal/dataplane/synchronizer_test.go:126
        	Error:      	Condition never satisfied
        	Test:       	TestSynchronizer_IsReadyDoesntBlockWhenDataPlaneIsBlocked/dbmode=off
2026-08-14T09:40:24.614Z	INFO	dataplane/synchronizer.go:168	Context done: shutting down the proxy update server

=== FAIL: ingress-controller/internal/dataplane TestSynchronizer_IsReadyDoesntBlockWhenDataPlaneIsBlocked (0.19s)
```

Root cause: `fakeDataplaneClient.Update` in `synchronizer_test.go` incremented `updateCount` before acquiring the lock that guards clientCallBlockDuration. The test read updateCount as a baseline right after calling
  clientShouldBlockFor(10s). If the in-flight Update call's increment landed in that gap, the baseline already included it — the subsequent Eventually then waited for a new update that couldn't happen (the synchronizer is
  single-goroutine and the current call was about to block for 10s).

Fix (`ingress-controller/internal/dataplane/synchronizer_test.go`):
  - Update now reads the block duration under the lock, releases it, then increments a counter — a separate blockingUpdateCount incremented only when it's actually about to block.
  - The test waits on `totalBlockingUpdates() > 0` instead of a stale `totalUpdates()` snapshot, so the wait condition can only be satisfied by an update that has genuinely started blocking.
  - Widened several tight Eventually budgets (was 30–100ms) to 1s for CI headroom; no effect on the passing-fast path.


**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
