### PR TITLE
fix(konnect): Truncate tags and label values by unicode runes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -120,6 +120,9 @@
 - Fix Gateway API routes becoming transiently unaccepted and removed from dataplane
   when listener is intermittently marked as Programmed=False.
   [#5237](https://github.com/Kong/kong-operator/pull/5237)
+- Konnect entities: Fix truncating of tags to cut at 128 unicode runes
+  (UTF8 code points).
+  [#5306](https://github.com/Kong/kong-operator/pull/5306)
 
 ## [v2.3.0-rc.3]
 

--- a/controller/konnect/ops/objects_metadata.go
+++ b/controller/konnect/ops/objects_metadata.go
@@ -5,6 +5,7 @@ import (
 	"maps"
 	"slices"
 	"sort"
+	"unicode/utf8"
 
 	"github.com/samber/lo"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -158,9 +159,11 @@ func WithKubernetesMetadataLabelsPtr(obj ObjectWithMetadata, userSetLabels map[s
 	return out
 }
 
+// truncate truncates a string to the specified limit in runes, since tags supports unicode runes.
+// If the string is shorter than or equal to the limit, it returns the original string.
 func truncate(s string, limit int) string {
-	if len(s) <= limit {
+	if utf8.RuneCountInString(s) <= limit {
 		return s
 	}
-	return s[:limit]
+	return string([]rune(s)[:limit])
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Truncate tags and label values by unicode runes (code points) instead of by bytes to avoid cutting in the middle that causes tags containing non-ASCII characters fails to apply in Konnect.

**Which issue this PR fixes**

Fixes #5305

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
