### PR TITLE
test/e2e: fix masked path-selector coverage in model-route-selectors

### DIFF
--- a/test/e2e/chainsaw/aigateway/ai-proxy-mirror/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/aigateway/ai-proxy-mirror/chainsaw-test.yaml
@@ -130,7 +130,7 @@ spec:
               - name: EXPECT_HEADER
                 value: X-Kong-LLM-Model
             content: |
-              bash ../../common/scripts/aigw_chat_completion.sh
+              bash ../../common/scripts/aigw_chat_completion_from_cluster.sh
   catch:
     - description: Capture debug snapshot on test failure.
       script:

--- a/test/e2e/chainsaw/aigateway/ai-proxy/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/aigateway/ai-proxy/chainsaw-test.yaml
@@ -71,7 +71,7 @@ spec:
               - name: EXPECT_HEADER
                 value: X-Kong-LLM-Model
             content: |
-              bash ../../common/scripts/aigw_chat_completion.sh
+              bash ../../common/scripts/aigw_chat_completion_from_cluster.sh
   catch:
     - description: Capture debug snapshot on test failure.
       script:

--- a/test/e2e/chainsaw/aigateway/aigateway-policy/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/aigateway/aigateway-policy/chainsaw-test.yaml
@@ -83,7 +83,7 @@ spec:
               - name: EXPECT_HEADER
                 value: "Modified-By-Policy-Inline"
             content: |
-              bash ../../common/scripts/aigw_chat_completion.sh
+              bash ../../common/scripts/aigw_chat_completion_from_cluster.sh
     - name: Create-aigateway-policy-secretRef-config
       description: Create an AIGatewayPolicy resource with secretRef config that adds a custom header to the response of an API.
       bindings:
@@ -119,7 +119,7 @@ spec:
               - name: EXPECT_HEADER
                 value: "Modified-By-Policy-Secretref"
             content: |
-              bash ../../common/scripts/aigw_chat_completion.sh
+              bash ../../common/scripts/aigw_chat_completion_from_cluster.sh
     - name: Update-secret-to-change-the-policy-config
       description: Update the secret referenced by the AIGatewayPolicy with secretRef config to change the custom header value in the response of an API.
       bindings:
@@ -144,7 +144,7 @@ spec:
               - name: EXPECT_HEADER
                 value: "Modified-By-Policy-Secretref-Updated"
             content: |
-              bash ../../common/scripts/aigw_chat_completion.sh
+              bash ../../common/scripts/aigw_chat_completion_from_cluster.sh
     - name: Delete-aigateway-model-and-policies-and-wait-for-konnect-cleanup
       description: |
         Explicitly delete the AIGatewayModel first (it references both policies

--- a/test/e2e/chainsaw/aigateway/model-route-selectors/01-assert-programmed.yaml
+++ b/test/e2e/chainsaw/aigateway/model-route-selectors/01-assert-programmed.yaml
@@ -37,3 +37,13 @@ status:
   (conditions[?type == 'Programmed']):
     - status: 'True'
   (id != null): true
+---
+apiVersion: aiconfiguration.konghq.com/v1alpha1
+kind: AIGatewayModel
+metadata:
+  name: model-no-selector
+  namespace: ($namespace)
+status:
+  (conditions[?type == 'Programmed']):
+    - status: 'True'
+  (id != null): true

--- a/test/e2e/chainsaw/aigateway/model-route-selectors/01-provider-and-models.yaml
+++ b/test/e2e/chainsaw/aigateway/model-route-selectors/01-provider-and-models.yaml
@@ -153,3 +153,42 @@ spec:
             type: openai
             openai:
               upstreamURL: http://kong-mock.kong-aigateway-mock.svc.cluster.local:8000/provider-a
+---
+# no selector: `config.route.model` is left unset entirely. Per the schema's
+# doc comment, this should fall back to the format's default selector
+# (for `openai`, the request body's "model" field) with the target name
+# itself as the implicit selector value.
+apiVersion: aiconfiguration.konghq.com/v1alpha1
+kind: AIGatewayModel
+metadata:
+  name: model-no-selector
+  namespace: ($namespace)
+spec:
+  aiGatewayRef:
+    type: namespacedRef
+    namespacedRef:
+      name: ($aigw_cp_name)
+  apiSpec:
+    type: model
+    model:
+      name: model-no-selector
+      displayName: Model routed via no selector (format default)
+      enabled: Enabled
+      formats:
+        - type: openai
+      capabilities:
+        - generate
+      config:
+        model:
+          nameHeader: Enabled
+        route:
+          paths:
+            - /model-route/no-selector/chat
+      targets:
+        - name: qwen2.5:0.5b
+          provider:
+            name: openai-provider
+          config:
+            type: openai
+            openai:
+              upstreamURL: http://kong-mock.kong-aigateway-mock.svc.cluster.local:8000/provider-a

--- a/test/e2e/chainsaw/aigateway/model-route-selectors/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/aigateway/model-route-selectors/chainsaw-test.yaml
@@ -3,15 +3,17 @@ kind: Test
 metadata:
   name: aigateway-model-route-selectors
 spec:
-  # Skipping this test: the path-selector case fails server-side.
-  skip: true
   description: |
     AIGatewayModel route selectors. Stands up a Konnect AIGateway
-    control plane, a shared OpenAI-compatible provider, and three AIGatewayModel
-    resources - one per `config.route.model` selector type (headers, body, path) -
-    then drives real chat-completions traffic to verify each selector type routes
-    requests to the correct target based on its configured alias `values`, and
-    that a non-matching alias is consistently rejected.
+    control plane, a shared OpenAI-compatible provider, and four AIGatewayModel
+    resources - one per `config.route.model` selector type (headers, body, path)
+    plus one with no selector configured at all - then drives real
+    chat-completions traffic to verify each selector type routes requests to
+    the correct target based on its configured alias `values`, that a
+    non-matching alias is consistently rejected, and that the model with no
+    selector configured falls back to the format's default selector (the
+    request body's "model" field for `openai`) as documented on
+    `AIGatewayModelSelectorConfig`.
   bindings:
     - name: test_name
       value: ($namespace)
@@ -64,7 +66,12 @@ spec:
       use:
         template: ../../common/_step_templates/apply-assert-aigatewayDataPlane.yaml
     - name: 6-Verify-headers-selector-routes-matching-alias
-      description: A request carrying the configured header alias is routed to the model.
+      description: |
+        A request carrying the configured header alias is routed to the model.
+        The body's `model` field is deliberately omitted (INCLUDE_BODY_MODEL:
+        'false') so this exercises `headerParam` alone rather than the
+        OpenAI-format body fallback every model with any `route.model`
+        selector also accepts.
       try:
         - script:
             env:
@@ -76,10 +83,15 @@ spec:
                 value: /model-route/headers/chat
               - name: MODEL_ALIAS
                 value: qwen2.5:0.5b
+              - name: INCLUDE_BODY_MODEL
+                value: 'false'
             content: |
-              bash ../../common/scripts/aigw_chat_completion.sh
+              bash ../../common/scripts/aigw_chat_completion_from_cluster.sh
     - name: 7-Verify-headers-selector-rejects-non-matching-alias
-      description: A request carrying an alias absent from the selector's `values` never resolves to the model.
+      description: |
+        A request carrying an alias absent from the selector's `values` never
+        resolves to the model. Body `model` field omitted for the same reason
+        as step 6.
       try:
         - script:
             env:
@@ -91,12 +103,17 @@ spec:
                 value: /model-route/headers/chat
               - name: MODEL_ALIAS
                 value: headers-alias-wrong
-              - name: EXPECT_SUCCESS
+              - name: EXPECTED_SUCCESS
+                value: 'false'
+              - name: INCLUDE_BODY_MODEL
                 value: 'false'
             content: |
-              bash ../../common/scripts/aigw_chat_completion.sh
+              bash ../../common/scripts/aigw_chat_completion_from_cluster.sh
     - name: 8-Verify-body-selector-routes-matching-alias
-      description: A request carrying the configured body property alias is routed to the model.
+      description: |
+        A request carrying the configured body property alias is routed to
+        the model. The X-Kong-LLM-Model header is deliberately omitted
+        (INCLUDE_HEADER: 'false') so this exercises `bodyParam` alone.
       try:
         - script:
             env:
@@ -108,10 +125,46 @@ spec:
                 value: /model-route/body/chat
               - name: MODEL_ALIAS
                 value: gemma3:270m
+              - name: INCLUDE_HEADER
+                value: 'false'
             content: |
-              bash ../../common/scripts/aigw_chat_completion.sh
-    - name: 9-Verify-path-selector-routes-matching-alias
-      description: A request whose path segment matches the selector's `values` is routed to the model.
+              bash ../../common/scripts/aigw_chat_completion_from_cluster.sh
+    - name: 9-Verify-no-selector-model-routes-via-format-default
+      description: |
+        A model with no `route.model` selector configured falls back to the
+        format's default selector (the request body's "model" field for
+        `openai`), per the doc comment on `AIGatewayModelSelectorConfig`. Per
+        that same doc comment ("when values are not set, the model name is
+        used as the selector value"), the implicit selector value is the
+        AIGatewayModel resource's own `name` (`model-no-selector`), not any
+        target's name. The X-Kong-LLM-Model header is deliberately omitted
+        (INCLUDE_HEADER: 'false') so this exercises the format-default
+        fallback alone. Runs before the pathParam steps below so it still
+        executes even while pathParam routing is broken.
+      try:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+              - name: DP_SVC
+                value: (join('', [($aigw_dp_name), '-ingress']))
+              - name: ROUTE_PATH
+                value: /model-route/no-selector/chat
+              - name: MODEL_ALIAS
+                value: model-no-selector
+              - name: INCLUDE_HEADER
+                value: 'false'
+            content: |
+              bash ../../common/scripts/aigw_chat_completion_from_cluster.sh
+    - name: 10-Verify-path-selector-routes-matching-alias
+      description: |
+        A request whose path segment matches the selector's `values` is
+        routed to the model. Both the X-Kong-LLM-Model header and the body
+        `model` field are deliberately omitted (INCLUDE_HEADER,
+        INCLUDE_BODY_MODEL: 'false') so this exercises `pathParam` alone —
+        AI Gateway resolves the model alias from whichever of header, body,
+        or path carries it, so leaving either of the other two enabled would
+        let this step pass even if the path-based capture were broken.
       try:
         - script:
             env:
@@ -123,10 +176,17 @@ spec:
                 value: /model-route/path/qwen2.5:0.5b/chat
               - name: MODEL_ALIAS
                 value: qwen2.5:0.5b
+              - name: INCLUDE_HEADER
+                value: 'false'
+              - name: INCLUDE_BODY_MODEL
+                value: 'false'
             content: |
-              bash ../../common/scripts/aigw_chat_completion.sh
-    - name: 10-Verify-body-selector-rejects-non-matching-alias
-      description: A request carrying a body property alias absent from the selector's `values` never resolves to the model.
+              bash ../../common/scripts/aigw_chat_completion_from_cluster.sh
+    - name: 11-Verify-body-selector-rejects-non-matching-alias
+      description: |
+        A request carrying a body property alias absent from the selector's
+        `values` never resolves to the model. Header omitted for the same
+        reason as step 8.
       try:
         - script:
             env:
@@ -138,12 +198,17 @@ spec:
                 value: /model-route/body/chat
               - name: MODEL_ALIAS
                 value: body-alias-wrong
-              - name: EXPECT_SUCCESS
+              - name: EXPECTED_SUCCESS
+                value: 'false'
+              - name: INCLUDE_HEADER
                 value: 'false'
             content: |
-              bash ../../common/scripts/aigw_chat_completion.sh
-    - name: 11-Verify-path-selector-rejects-non-matching-alias
-      description: A request whose path segment is absent from the selector's `values` never resolves to the model.
+              bash ../../common/scripts/aigw_chat_completion_from_cluster.sh
+    - name: 12-Verify-path-selector-rejects-non-matching-alias
+      description: |
+        A request whose path segment is absent from the selector's `values`
+        never resolves to the model. Header and body `model` field omitted
+        for the same reason as step 10.
       try:
         - script:
             env:
@@ -155,10 +220,14 @@ spec:
                 value: /model-route/path/path-alias-wrong/chat
               - name: MODEL_ALIAS
                 value: path-alias-wrong
-              - name: EXPECT_SUCCESS
+              - name: EXPECTED_SUCCESS
+                value: 'false'
+              - name: INCLUDE_HEADER
+                value: 'false'
+              - name: INCLUDE_BODY_MODEL
                 value: 'false'
             content: |
-              bash ../../common/scripts/aigw_chat_completion.sh
+              bash ../../common/scripts/aigw_chat_completion_from_cluster.sh
   catch:
     - description: Capture debug snapshot on test failure.
       script:

--- a/test/e2e/chainsaw/common/scripts/aigw_chat_completion.sh
+++ b/test/e2e/chainsaw/common/scripts/aigw_chat_completion.sh
@@ -2,20 +2,24 @@
 # Drive a chat-completions request through an AIGatewayDataPlane and verify the
 # gateway processed it: HTTP 200 and the model header present.
 #
-# The request is issued from a short-lived curl Pod inside the cluster (the
-# AIGatewayDataPlane ingress is only reachable in-cluster), targeting the ingress
-# Service by DNS. Exits non-zero (failing the chainsaw step) unless a 200 with the
-# expected header is observed within the retry budget.
+# Assumes ADDRESS is directly reachable from wherever this script runs: either
+# the chainsaw test-runner host (e.g. an external LoadBalancer address), or an
+# in-cluster curl Pod when piped through aigw_chat_completion_from_cluster.sh
+# (e.g. the ingress Service's cluster-DNS name), mirroring
+# aigw_agent_request.sh / aigw_agent_request_from_cluster.sh. Emits a JSON
+# result object to stdout (success or failure) and exits non-zero (failing
+# the chainsaw step) unless a matching response is observed within the retry
+# budget.
 #
 # Required env:
-#   NAMESPACE     Namespace the AIGatewayDataPlane / ingress Service live in.
-#   DP_SVC        Ingress Service name (typically <aigw-dp-name>-ingress).
+#   ADDRESS       Host or IP to connect to (cluster-DNS name or external address).
 #   ROUTE_PATH    Route path configured on the model (e.g. /aigw11/chat).
-#   MODEL_ALIAS   Model alias to send in the request body.
+#   MODEL_ALIAS   Model alias to send.
+#
 # Optional env:
 #   EXPECT_HEADER Response header proving AI Gateway processed the request.
 #                 Default: X-Kong-LLM-Model.
-#   EXPECT_SUCCESS
+#   EXPECTED_SUCCESS
 #                 "true" (default): succeed once a 200 with EXPECT_HEADER is seen.
 #                 "false": the alias is expected to NOT resolve to a model
 #                 (e.g. a value absent from the selector's `values`). Succeeds
@@ -23,82 +27,168 @@
 #                 produce a 200-with-header, guarding against a transient
 #                 blip while the route is still propagating.
 #   REJECT_CONFIRMATIONS
-#                 Consecutive non-matches required when EXPECT_SUCCESS=false.
-#                 Default: 3.
+#                 Only used when EXPECTED_SUCCESS='false'. Number of
+#                 *consecutive* non-matches required before concluding the
+#                 alias is genuinely unmatched. Default: 3. Symmetric with the
+#                 stale-success protection in aigw_agent_request.sh: a lone
+#                 transient blip can't prematurely pass the check.
+#   INCLUDE_HEADER
+#                 "true" (default): send MODEL_ALIAS via the X-Kong-LLM-Model
+#                 request header. Set "false" to omit it. AI Gateway accepts
+#                 the model alias from more than one source at once (header,
+#                 body, path), so leaving an unrelated source enabled can mask
+#                 a broken selector under test with a false positive — set
+#                 this "false" when isolating a route.model selector that is
+#                 NOT `headerParam` (e.g. bodyParam, pathParam).
+#   INCLUDE_BODY_MODEL
+#                 "true" (default): send MODEL_ALIAS via the top-level "model"
+#                 field of the JSON request body (the OpenAI-format
+#                 convention). Set "false" to omit it for the same reason as
+#                 INCLUDE_HEADER — isolate a route.model selector that is NOT
+#                 `bodyParam` on the "model" field (e.g. headerParam, pathParam).
 #   PORT          Ingress Service port. Default: 443.
-#   CURL_IMAGE    Image for the in-cluster curl Pod. Default: curlimages/curl:latest.
-#   MAX_RETRIES   Retry attempts. Default: 60.
-#   RETRY_DELAY   Seconds between retries. Default: 5.
+#   MAX_RETRIES   Retry attempts. Default: 180.
+#   RETRY_DELAY   Seconds between retries. Default: 1.
 set -o errexit
 set -o nounset
 set -o pipefail
 
-NAMESPACE="${NAMESPACE}"
-DP_SVC="${DP_SVC}"
+ADDRESS="${ADDRESS}"
 ROUTE_PATH="${ROUTE_PATH}"
 MODEL_ALIAS="${MODEL_ALIAS}"
 EXPECT_HEADER="${EXPECT_HEADER:-X-Kong-LLM-Model}"
-EXPECT_SUCCESS="${EXPECT_SUCCESS:-true}"
+EXPECTED_SUCCESS="${EXPECTED_SUCCESS:-true}"
 REJECT_CONFIRMATIONS="${REJECT_CONFIRMATIONS:-3}"
+INCLUDE_HEADER="${INCLUDE_HEADER:-true}"
+INCLUDE_BODY_MODEL="${INCLUDE_BODY_MODEL:-true}"
 PORT="${PORT:-443}"
-CURL_IMAGE="${CURL_IMAGE:-curlimages/curl:latest}"
-MAX_RETRIES="${MAX_RETRIES:-60}"
-RETRY_DELAY="${RETRY_DELAY:-5}"
+MAX_RETRIES="${MAX_RETRIES:-180}"
+RETRY_DELAY="${RETRY_DELAY:-1}"
 
-POD="aigw-traffic-${RANDOM}"
-URL="https://${DP_SVC}.${NAMESPACE}.svc:${PORT}${ROUTE_PATH}/chat/completions"
-BODY="{\"model\":\"${MODEL_ALIAS}\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with exactly: Kong AI Gateway works.\"}]}"
-
-cleanup() {
-  kubectl -n "${NAMESPACE}" delete pod "${POD}" --ignore-not-found --grace-period=0 --force >/dev/null 2>&1 || true
-}
+URL="https://${ADDRESS}:${PORT}${ROUTE_PATH}/chat/completions"
+BODY_FILE=$(mktemp /tmp/aigw_chat_body.XXXXXX)
+HEADER_FILE=$(mktemp /tmp/aigw_chat_headers.XXXXXX)
+cleanup() { rm -f "${BODY_FILE}" "${HEADER_FILE}"; }
 trap cleanup EXIT
+# Set before print_result() is usable (curl_command is only known once build_curl_cmd runs).
+CURL_CMD=""
 
-kubectl -n "${NAMESPACE}" run "${POD}" \
-  --image="${CURL_IMAGE}" --image-pull-policy=IfNotPresent --restart=Never \
-  --command -- sleep 3600 >/dev/null
-kubectl -n "${NAMESPACE}" wait --for=condition=Ready "pod/${POD}" --timeout=120s >/dev/null
+if [ "${INCLUDE_BODY_MODEL}" = "true" ]; then
+  REQUEST_BODY="{\"model\":\"${MODEL_ALIAS}\",\"messages\":[{\"role\":\"user\",\"content\":\"Reply with exactly: Kong AI Gateway works.\"}]}"
+else
+  REQUEST_BODY="{\"messages\":[{\"role\":\"user\",\"content\":\"Reply with exactly: Kong AI Gateway works.\"}]}"
+fi
 
+# Pure shell JSON string escaping (backslashes, double quotes, newlines) since
+# jq isn't available in the curlimages/curl image this script runs in-cluster
+# under. Mirrors aigw_agent_request.sh's json_escape.
+json_escape() {
+  printf '%s' "$1" | awk '
+    {
+      line = $0
+      out = ""
+      n = length(line)
+      for (i = 1; i <= n; i++) {
+        c = substr(line, i, 1)
+        if (c == "\\") out = out "\\\\"
+        else if (c == "\"") out = out "\\\""
+        else out = out c
+      }
+      printf "%s%s", (NR > 1 ? "\\n" : ""), out
+    }
+  '
+}
+
+print_result() {
+  local success="$1"
+  local code="$2"
+  local body="$3"
+  local header_value="$4"
+  local attempt="$5"
+  local error="${6:-}"
+  cat <<EOF
+{
+  "success": ${success},
+  "http_status": "${code:-000}",
+  "expected_header": "${EXPECT_HEADER}",
+  "header_value": "$(json_escape "${header_value}")",
+  "expected_success": "${EXPECTED_SUCCESS}",
+  "model_alias": "${MODEL_ALIAS}",
+  "url": "${URL}",
+  "retry_attempt": ${attempt},
+  "max_retries": ${MAX_RETRIES},
+  "curl_command": "$(json_escape "${CURL_CMD}")",
+  "body": "$(json_escape "${body}")"$( [ -n "${error}" ] && printf ',\n  "error": "%s"' "$(json_escape "${error}")" )
+}
+EOF
+}
+
+# Build the curl command as a single string, both to execute (via eval, as
+# the other *_connectivity_test.sh scripts do) and to show verbatim in the
+# JSON result for debugging.
+build_curl_cmd() {
+  local CMD="curl -sk -m 60 -o ${BODY_FILE} -D ${HEADER_FILE} -w '%{http_code}' -X POST"
+  if [ "${INCLUDE_HEADER}" = "true" ]; then
+    CMD="${CMD} -H 'X-Kong-LLM-Model: ${MODEL_ALIAS}'"
+  fi
+  CMD="${CMD} -H 'Content-Type: application/json' --data '${REQUEST_BODY}' '${URL}'"
+  echo "${CMD}"
+}
+
+# Extracts the first value of a response header from HEADER_FILE (may contain
+# multiple header blocks across TLS/redirect round-trips; the last one wins).
+response_header_value() {
+  local name="$1"
+  grep -i "^${name}:" "${HEADER_FILE}" 2>/dev/null | tail -1 | cut -d' ' -f2- | tr -d '\r'
+}
+
+response_matches() {
+  local code="$1"
+  local header_value="$2"
+  [ "${code}" = "200" ] && [ -n "${header_value}" ]
+}
+
+CODE=""
+BODY=""
+HEADER_VALUE=""
 REJECTIONS=0
+CURL_CMD="$(build_curl_cmd)"
 for ATTEMPT in $(seq 1 "${MAX_RETRIES}"); do
-  OUT="$(kubectl -n "${NAMESPACE}" exec "${POD}" -- sh -c \
-    "curl -sk -m 60 -o /tmp/b -D /tmp/h -w '%{http_code}' -X POST '${URL}' \
-       -H 'X-Kong-LLM-Model: ${MODEL_ALIAS}' \
-       -H 'Content-Type: application/json' \
-       -d '${BODY}'; echo; \
-     grep -i '^${EXPECT_HEADER}:' /tmp/h | head -1 | cut -d' ' -f2- | tr -d '\r'; echo; \
-     head -c 500 /tmp/b | tr '\n' ' '" \
-    2>/dev/null || true)"
-  CODE="$(printf '%s\n' "${OUT}" | sed -n '1p')"
-  HDR="$(printf '%s\n' "${OUT}" | sed -n '2p')"
   MATCHED=false
-  [ "${CODE}" = "200" ] && [ -n "${HDR}" ] && MATCHED=true
+  > "${BODY_FILE}"
+  > "${HEADER_FILE}"
+  CODE="$(eval "${CURL_CMD}" 2>/dev/null || echo 000)"
+  BODY="$(cat "${BODY_FILE}" 2>/dev/null || echo '')"
+  # `|| true`: response_header_value's grep returns non-zero when the header
+  # is absent (expected on every rejection-path response, e.g. a 503 with no
+  # X-Kong-LLM-Model). Since this is a standalone `var="$(...)"` assignment,
+  # that non-zero status would otherwise trip `errexit` right here, silently
+  # killing the script before the match check below ever runs.
+  HEADER_VALUE="$(response_header_value "${EXPECT_HEADER}" || true)"
+  response_matches "${CODE}" "${HEADER_VALUE}" && MATCHED=true
 
-  if [ "${EXPECT_SUCCESS}" = "false" ]; then
+  if [ "${EXPECTED_SUCCESS}" = "false" ]; then
     if [ "${MATCHED}" = "false" ]; then
       REJECTIONS=$((REJECTIONS + 1))
-      echo "attempt ${ATTEMPT}/${MAX_RETRIES}: rejection ${REJECTIONS}/${REJECT_CONFIRMATIONS} (status='${CODE}')" >&2
-      if [ "${REJECTIONS}" -ge "${REJECT_CONFIRMATIONS}" ]; then
-        echo "ok: alias consistently unmatched (status='${CODE}')"
-        exit 0
-      fi
+      [ "${REJECTIONS}" -ge "${REJECT_CONFIRMATIONS}" ] && { print_result true "${CODE}" "${BODY}" "${HEADER_VALUE}" "${ATTEMPT}"; exit 0; }
     else
-      echo "attempt ${ATTEMPT}/${MAX_RETRIES}: alias unexpectedly matched (status='${CODE}' ${EXPECT_HEADER}=${HDR})" >&2
+      # A stale match (e.g. an old pod still serving during a rollout) breaks the
+      # streak: only REJECT_CONFIRMATIONS *consecutive* non-matches conclude success.
       REJECTIONS=0
     fi
   else
-    if [ "${MATCHED}" = "true" ]; then
-      echo "ok: status=${CODE} ${EXPECT_HEADER}=${HDR}"
-      exit 0
-    fi
-    echo "attempt ${ATTEMPT}/${MAX_RETRIES}: status='${CODE}' header='${HDR}'" >&2
+    [ "${MATCHED}" = "true" ] && { print_result true "${CODE}" "${BODY}" "${HEADER_VALUE}" "${ATTEMPT}"; exit 0; }
   fi
-  sleep "${RETRY_DELAY}"
+
+  echo "attempt ${ATTEMPT}/${MAX_RETRIES}: matched=${MATCHED} status='${CODE}' rejections=${REJECTIONS}/${REJECT_CONFIRMATIONS} ${EXPECT_HEADER}='${HEADER_VALUE}'" >&2
+  if [ "${ATTEMPT}" -lt "${MAX_RETRIES}" ]; then
+    sleep "${RETRY_DELAY}"
+  fi
 done
 
-if [ "${EXPECT_SUCCESS}" = "false" ]; then
-  echo "FAILED: alias matched a model after ${MAX_RETRIES} attempts, expected it to stay unmatched" >&2
+if [ "${EXPECTED_SUCCESS}" = "false" ]; then
+  print_result false "${CODE}" "${BODY}" "${HEADER_VALUE}" "${MAX_RETRIES}" "expected the alias to stay unmatched ${REJECT_CONFIRMATIONS} consecutive times, but never reached that streak within ${MAX_RETRIES} attempts (last streak: ${REJECTIONS})"
 else
-  echo "FAILED: no 200 with ${EXPECT_HEADER} after ${MAX_RETRIES} attempts (last status='${CODE}')" >&2
+  print_result false "${CODE}" "${BODY}" "${HEADER_VALUE}" "${MAX_RETRIES}" "no 200 with ${EXPECT_HEADER} after ${MAX_RETRIES} attempts"
 fi
 exit 1

--- a/test/e2e/chainsaw/common/scripts/aigw_chat_completion_from_cluster.sh
+++ b/test/e2e/chainsaw/common/scripts/aigw_chat_completion_from_cluster.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+# Abort on nonzero exit status, unbound variable, and pipefail.
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Runs aigw_chat_completion.sh from inside the cluster (the AIGatewayDataPlane
+# ingress Service's cluster-DNS name is only reachable in-cluster), by piping
+# it into a short-lived curl Pod's stdin, mirroring
+# aigw_agent_request_from_cluster.sh / pod_connectivity_test_http.sh.
+#
+# Variables (from environment):
+#   SCRIPT_PATH: (optional) Path to aigw_chat_completion.sh.
+#                Default: ../../common/scripts/aigw_chat_completion.sh
+#   NAMESPACE: Namespace the AIGatewayDataPlane / ingress Service and test Pod live in.
+#   DP_SVC: Ingress Service name (typically <aigw-dp-name>-ingress).
+#   CURL_IMAGE: (optional) Image for the in-cluster curl Pod. Default: curlimages/curl:latest.
+#   ROUTE_PATH, MODEL_ALIAS, EXPECT_HEADER, EXPECTED_SUCCESS, REJECT_CONFIRMATIONS,
+#   INCLUDE_HEADER, INCLUDE_BODY_MODEL, PORT, MAX_RETRIES, RETRY_DELAY: Forwarded
+#     through as-is to aigw_chat_completion.sh (see its own env docs).
+
+SCRIPT_PATH="${SCRIPT_PATH:-../../common/scripts/aigw_chat_completion.sh}"
+NAMESPACE="${NAMESPACE}"
+DP_SVC="${DP_SVC}"
+CURL_IMAGE="${CURL_IMAGE:-curlimages/curl:latest}"
+
+POD_NAME="aigw-chat-traffic-$(date +%s)-${RANDOM}"
+ADDRESS="${DP_SVC}.${NAMESPACE}.svc"
+
+cat "${SCRIPT_PATH}" | kubectl run "${POD_NAME}" \
+  --image="${CURL_IMAGE}" --image-pull-policy=IfNotPresent \
+  --rm -i --restart=Never \
+  --env="ADDRESS=${ADDRESS}" \
+  --env="ROUTE_PATH=${ROUTE_PATH}" \
+  --env="MODEL_ALIAS=${MODEL_ALIAS}" \
+  --env="EXPECT_HEADER=${EXPECT_HEADER:-X-Kong-LLM-Model}" \
+  --env="EXPECTED_SUCCESS=${EXPECTED_SUCCESS:-true}" \
+  --env="REJECT_CONFIRMATIONS=${REJECT_CONFIRMATIONS:-3}" \
+  --env="INCLUDE_HEADER=${INCLUDE_HEADER:-true}" \
+  --env="INCLUDE_BODY_MODEL=${INCLUDE_BODY_MODEL:-true}" \
+  --env="PORT=${PORT:-443}" \
+  --env="MAX_RETRIES=${MAX_RETRIES:-180}" \
+  --env="RETRY_DELAY=${RETRY_DELAY:-1}" \
+  -n "${NAMESPACE}" \
+  -- sh -s 2>/dev/null | grep -v '^pod "'

--- a/test/e2e/chainsaw/common/scripts/debug_snapshot.sh
+++ b/test/e2e/chainsaw/common/scripts/debug_snapshot.sh
@@ -271,7 +271,7 @@ OPERATOR_LOGS_FILE="${SNAPSHOT_DIR}/operator-logs.txt"
 } > "${OPERATOR_LOGS_FILE}"
 
 # Get all operator pods
-OPERATOR_PODS=$(kubectl get pods -n "${OPERATOR_NAMESPACE}" -l app.kubernetes.io/name=kong-operator -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || echo "")
+OPERATOR_PODS=$(kubectl get pods -n "${OPERATOR_NAMESPACE}" -l app.kubernetes.io/instance=kong-operator -o jsonpath='{.items[*].metadata.name}' 2>/dev/null || echo "")
 
 if [ -n "${OPERATOR_PODS}" ]; then
   for pod in ${OPERATOR_PODS}; do
@@ -357,8 +357,8 @@ OPERATOR_STATUS_FILE="${SNAPSHOT_DIR}/operator-pods-status.txt"
   echo ""
 } > "${OPERATOR_STATUS_FILE}"
 
-safe_kubectl "${OPERATOR_STATUS_FILE}" get pods -n "${OPERATOR_NAMESPACE}" -l app.kubernetes.io/name=kong-operator -o wide
-safe_kubectl "${OPERATOR_STATUS_FILE}" describe pods -n "${OPERATOR_NAMESPACE}" -l app.kubernetes.io/name=kong-operator
+safe_kubectl "${OPERATOR_STATUS_FILE}" get pods -n "${OPERATOR_NAMESPACE}" -l app.kubernetes.io/instance=kong-operator -o wide
+safe_kubectl "${OPERATOR_STATUS_FILE}" describe pods -n "${OPERATOR_NAMESPACE}" -l app.kubernetes.io/instance=kong-operator
 
 # 8. Create summary file
 echo "Creating summary..."
@@ -396,7 +396,7 @@ for ns in ${ALL_NAMESPACES}; do
   echo "" >> "${SUMMARY_FILE}"
 done
 
-echo "Operator pod count: $(kubectl get pods -n "${OPERATOR_NAMESPACE}" -l app.kubernetes.io/name=kong-operator --no-headers 2>/dev/null | wc -l | tr -d ' ')" >> "${SUMMARY_FILE}"
+echo "Operator pod count: $(kubectl get pods -n "${OPERATOR_NAMESPACE}" -l app.kubernetes.io/instance=kong-operator --no-headers 2>/dev/null | wc -l | tr -d ' ')" >> "${SUMMARY_FILE}"
 
 echo ""
 echo "=== Debug snapshot complete ==="


### PR DESCRIPTION

**What this PR does / why we need it**:

Turns out the model-route-selectors chainsaw test was green even though pathParam routing is actually broken on Konnect's side. The shared aigw_chat_completion.sh script was sending the model alias via both the header and the body on every request, no matter which selector the step claimed to be testing. AI Gateway happily accepts the alias from any of those sources, so the body fallback was quietly carrying the path-selector test the whole time instead of pathParam ever actually getting exercised.

- Added INCLUDE_HEADER / INCLUDE_BODY_MODEL switches so each step only sends the signal for the selector it's actually testing. Step 9 (path selector) now genuinely exercises pathParam extraction instead of riding the body fallback.
- Added a 4th model with no selector at all plus a new step 12 to cover the "no selector, format default" fallback documented on the CRD.
- Split into aigw_chat_completion.sh plus aigw_chat_completion_from_cluster.sh to match the agent_request.sh / _from_cluster.sh split, renamed EXPECT_SUCCESS to EXPECTED_SUCCESS for consistency, bumped retry defaults to 180x1s to match.
- Repointed ai-proxy, ai-proxy-mirror, and aigateway-policy at the new wrapper script. No behavior change there, they use headerParam which was never affected by any of this.


**Which issue this PR fixes**

Fixes #5216 

**Special notes for your reviewer**:

Step 10 (Verify-path-selector-routes-matching-alias) and step 9 (Verify-no-selector-model-routes-via-format-default) are expected to fail until the corresponding behavior is supported on the Konnect/AI Gateway side: pathParam selector extraction and the no-selector "format default" fallback are not yet working server-side, independent of anything in this repo.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
