### PR TITLE
feat(on-prem): propagate tags in KongPlugin and KongClusterPlugin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -118,6 +118,9 @@
   matched by field `name` to adjust the resource requests and limits of the owned Deployment's
   containers (e.g. `mcp-server` or `init-mcp-server`). Names that don't match a container the
   operator manages are ignored.
+- Support using `tags` field in `KongPlugin` and `KongClusterPlugin` to specify
+  tags in generated Kong plugins in on-prem gateways.
+  [#5325](https://github.com/Kong/kong-operator/pull/5325)
 
 ### Changed
 

--- a/ingress-controller/internal/dataplane/kongstate/plugin.go
+++ b/ingress-controller/internal/dataplane/kongstate/plugin.go
@@ -7,6 +7,7 @@ import (
 
 	jsonpatch "github.com/evanphx/json-patch/v5"
 	"github.com/kong/go-kong/kong"
+	"github.com/samber/lo"
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	"sigs.k8s.io/yaml"
@@ -78,6 +79,13 @@ func kongPluginFromK8SClusterPlugin(
 		}
 	}
 
+	specTags := lo.Map(k8sPlugin.Tags, func(tag string, _ int) util.KongTag {
+		return util.KongTag{
+			// The tag should be propagated to Kong as-is, without any prefixing or suffixing.
+			Value: tag,
+		}
+	})
+
 	return Plugin{
 		Plugin: plugin{
 			Name:   k8sPlugin.PluginName,
@@ -88,7 +96,7 @@ func kongPluginFromK8SClusterPlugin(
 			InstanceName: k8sPlugin.InstanceName,
 			Disabled:     k8sPlugin.Disabled,
 			Protocols:    protocolsToStrings(k8sPlugin.Protocols),
-			Tags:         util.GenerateTagsForObject(&k8sPlugin),
+			Tags:         util.GenerateTagsForObject(&k8sPlugin, specTags...),
 		}.toKongPlugin(),
 		K8sParent: &k8sPlugin,
 	}, nil
@@ -132,6 +140,13 @@ func kongPluginFromK8SPlugin(
 		}
 	}
 
+	specTags := lo.Map(k8sPlugin.Tags, func(tag string, _ int) util.KongTag {
+		return util.KongTag{
+			// The tag should be propagated to Kong as-is, without any prefixing or suffixing.
+			Value: tag,
+		}
+	})
+
 	return Plugin{
 		Plugin: plugin{
 			Name:   k8sPlugin.PluginName,
@@ -142,7 +157,7 @@ func kongPluginFromK8SPlugin(
 			InstanceName: k8sPlugin.InstanceName,
 			Disabled:     k8sPlugin.Disabled,
 			Protocols:    protocolsToStrings(k8sPlugin.Protocols),
-			Tags:         util.GenerateTagsForObject(&k8sPlugin),
+			Tags:         util.GenerateTagsForObject(&k8sPlugin, specTags...),
 		}.toKongPlugin(),
 		K8sParent: &k8sPlugin,
 	}, nil

--- a/ingress-controller/internal/dataplane/kongstate/plugin_test.go
+++ b/ingress-controller/internal/dataplane/kongstate/plugin_test.go
@@ -64,6 +64,30 @@ func TestKongPluginFromK8SClusterPlugin(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "basic configuration with tags",
+			args: args{
+				plugin: configurationv1.KongClusterPlugin{
+					Protocols:    []configurationv1.KongProtocol{"http"},
+					PluginName:   "correlation-id",
+					InstanceName: "example",
+					Config: apiextensionsv1.JSON{
+						Raw: []byte(`{"header_name": "foo"}`),
+					},
+					Tags: []string{"example"},
+				},
+			},
+			want: kong.Plugin{
+				Name: new("correlation-id"),
+				Config: kong.Configuration{
+					"header_name": "foo",
+				},
+				Protocols:    kong.StringSlice("http"),
+				InstanceName: new("example"),
+				Tags:         kong.StringSlice("example"),
+			},
+			wantErr: false,
+		},
+		{
 			name: "secret configuration",
 			args: args{
 				plugin: configurationv1.KongClusterPlugin{
@@ -431,6 +455,30 @@ func TestKongPluginFromK8SPlugin(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			name: "basic configuration with tags",
+			args: args{
+				plugin: configurationv1.KongPlugin{
+					Protocols:    []configurationv1.KongProtocol{"http"},
+					PluginName:   "correlation-id",
+					InstanceName: "example",
+					Config: apiextensionsv1.JSON{
+						Raw: []byte(`{"header_name": "foo"}`),
+					},
+					Tags: []string{"example"},
+				},
+			},
+			want: kong.Plugin{
+				Name: new("correlation-id"),
+				Config: kong.Configuration{
+					"header_name": "foo",
+				},
+				Protocols:    kong.StringSlice("http"),
+				InstanceName: new("example"),
+				Tags:         kong.StringSlice("example"),
+			},
+			wantErr: false,
+		},
+		{
 			name: "secret configuration",
 			args: args{
 				plugin: configurationv1.KongPlugin{
@@ -757,9 +805,17 @@ func TestKongPluginFromK8SPlugin(t *testing.T) {
 				t.Errorf("kongPluginFromK8SPlugin error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
-			// don't care about tags in this test
+			// don't care about tags in comparing the plugin, since they are generated based on the KongPlugin object and not part of the plugin spec.
+			// we will check that the tags are generated correctly in the next assertion.
+			gotTags := got.Tags
 			got.Tags = nil
+			tt.want.Tags = nil
 			assert.Equal(tt.want, got.Plugin)
+			if len(tt.args.plugin.Tags) > 0 {
+				for _, tag := range tt.args.plugin.Tags {
+					assert.Contains(gotTags, &tag, "expected tag %s not found in generated tags", tag)
+				}
+			}
 			assert.NotEmpty(t, got.K8sParent)
 		})
 	}

--- a/test/integration/kic/plugin_test.go
+++ b/test/integration/kic/plugin_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"slices"
 	"strings"
 	"testing"
 	"time"
@@ -152,7 +153,7 @@ func TestPluginEssentials(t *testing.T) {
 			t.Logf("plugin for KongPlugin %s in Kong not found", kongplugin.Name)
 			return false
 		}
-		if plugin.Tags != nil && lo.Contains(plugin.Tags, new("teapot")) {
+		if plugin.Tags != nil && slices.Contains(plugin.Tags, new("teapot")) {
 			return true
 		}
 		t.Logf("plugin for KongPlugin %s in Kong does not have expected tags, actual tags: %s",
@@ -197,7 +198,7 @@ func TestPluginEssentials(t *testing.T) {
 			t.Logf("plugin for KongClusterPlugin %s in Kong not found", kongclusterplugin.Name)
 			return false
 		}
-		if plugin.Tags != nil && lo.Contains(plugin.Tags, new("legal")) {
+		if plugin.Tags != nil && slices.Contains(plugin.Tags, new("legal")) {
 			return true
 		}
 		t.Logf("plugin for KongClusterPlugin %s in Kong does not have expected tags, actual tags: %s",

--- a/test/integration/kic/plugin_test.go
+++ b/test/integration/kic/plugin_test.go
@@ -106,6 +106,7 @@ func TestPluginEssentials(t *testing.T) {
 		Config: apiextensionsv1.JSON{
 			Raw: []byte(`{"status_code": 451}`),
 		},
+		Tags: commonv1alpha1.Tags{"legal"},
 	}
 	c, err := clientset.NewForConfig(env.Cluster().Config())
 	require.NoError(t, err)
@@ -153,7 +154,8 @@ func TestPluginEssentials(t *testing.T) {
 			t.Logf("plugin for KongPlugin %s in Kong not found", kongplugin.Name)
 			return false
 		}
-		if plugin.Tags != nil && slices.Contains(plugin.Tags, new("teapot")) {
+		tags := lo.Map(plugin.Tags, func(t *string, _ int) string { return lo.FromPtrOr(t, "_") })
+		if slices.Contains(tags, "teapot") {
 			return true
 		}
 		t.Logf("plugin for KongPlugin %s in Kong does not have expected tags, actual tags: %s",
@@ -198,7 +200,9 @@ func TestPluginEssentials(t *testing.T) {
 			t.Logf("plugin for KongClusterPlugin %s in Kong not found", kongclusterplugin.Name)
 			return false
 		}
-		if plugin.Tags != nil && slices.Contains(plugin.Tags, new("legal")) {
+
+		tags := lo.Map(plugin.Tags, func(t *string, _ int) string { return lo.FromPtrOr(t, "_") })
+		if slices.Contains(tags, "legal") {
 			return true
 		}
 		t.Logf("plugin for KongClusterPlugin %s in Kong does not have expected tags, actual tags: %s",

--- a/test/integration/kic/plugin_test.go
+++ b/test/integration/kic/plugin_test.go
@@ -22,6 +22,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 
+	commonv1alpha1 "github.com/kong/kong-operator/v2/api/common/v1alpha1"
 	configurationv1 "github.com/kong/kong-operator/v2/api/configuration/v1"
 	"github.com/kong/kong-operator/v2/ingress-controller/test"
 	"github.com/kong/kong-operator/v2/ingress-controller/test/annotations"
@@ -90,6 +91,7 @@ func TestPluginEssentials(t *testing.T) {
 		Config: apiextensionsv1.JSON{
 			Raw: []byte(`{"status_code": 418}`),
 		},
+		Tags: commonv1alpha1.Tags{"teapot"},
 	}
 	kongclusterplugin := &configurationv1.KongClusterPlugin{
 		ObjectMeta: metav1.ObjectMeta{
@@ -136,6 +138,29 @@ func TestPluginEssentials(t *testing.T) {
 		return resp.StatusCode == http.StatusTeapot
 	}, ingressWait, waitTick)
 
+	t.Logf("validating that the plugin %s has the expected tags", kongplugin.Name)
+	require.Eventually(t, func() bool {
+		kc, err := helpers.NewKongAdminClient(proxyAdminURL, consts.KongTestPassword)
+		require.NoError(t, err, "failed to create Kong client")
+		plugins, err := kc.Plugins.ListAll(ctx)
+		require.NoError(t, err, "failed to list plugins")
+
+		plugin, found := lo.Find(plugins, func(p *kong.Plugin) bool {
+			return p != nil && p.Name != nil && *p.Name == kongplugin.PluginName
+		})
+		if !found {
+			t.Logf("plugin for KongPlugin %s in Kong not found", kongplugin.Name)
+			return false
+		}
+		if plugin.Tags != nil && lo.Contains(plugin.Tags, new("teapot")) {
+			return true
+		}
+		t.Logf("plugin for KongPlugin %s in Kong does not have expected tags, actual tags: %s",
+			kongplugin.Name,
+			strings.Join(lo.Map(plugin.Tags, func(t *string, _ int) string { return lo.FromPtrOr(t, "_") }), ","))
+		return false
+	}, ingressWait, waitTick)
+
 	t.Logf("updating Ingress to use cluster plugin %s", kongclusterplugin.Name)
 	require.Eventually(t, func() bool {
 		ingress, err := env.Cluster().Client().NetworkingV1().Ingresses(ns.Name).Get(ctx, ingress.Name, metav1.GetOptions{})
@@ -156,6 +181,29 @@ func TestPluginEssentials(t *testing.T) {
 		}
 		defer resp.Body.Close()
 		return resp.StatusCode == http.StatusUnavailableForLegalReasons
+	}, ingressWait, waitTick)
+
+	t.Logf("validating that the plugin %s has the expected tags", kongclusterplugin.Name)
+	require.Eventually(t, func() bool {
+		kc, err := helpers.NewKongAdminClient(proxyAdminURL, consts.KongTestPassword)
+		require.NoError(t, err, "failed to create Kong client")
+		plugins, err := kc.Plugins.ListAll(ctx)
+		require.NoError(t, err, "failed to list plugins")
+
+		plugin, found := lo.Find(plugins, func(p *kong.Plugin) bool {
+			return p != nil && p.Name != nil && *p.Name == kongclusterplugin.PluginName
+		})
+		if !found {
+			t.Logf("plugin for KongClusterPlugin %s in Kong not found", kongclusterplugin.Name)
+			return false
+		}
+		if plugin.Tags != nil && lo.Contains(plugin.Tags, new("legal")) {
+			return true
+		}
+		t.Logf("plugin for KongClusterPlugin %s in Kong does not have expected tags, actual tags: %s",
+			kongclusterplugin.Name,
+			strings.Join(lo.Map(plugin.Tags, func(t *string, _ int) string { return lo.FromPtrOr(t, "_") }), ","))
+		return false
 	}, ingressWait, waitTick)
 
 	t.Log("deleting Ingress and waiting for routes to be torn down")


### PR DESCRIPTION
**What this PR does / why we need it**:

Support `tags` field in `KongPlugin` and `KongClusterPlugin` to specify plugins. The tags from the field will be placed after tags for the k8s metadata and before the tags in the annotation `konghq.com/tags`.

**Which issue this PR fixes**

Fixes #5310 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
