### PR TITLE
[Backport release/2.2.x]fix(hybridgateway): propagate konghq.com/tags to generated KongPlugin  (#5284)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,11 @@
   `Deployment` to skip reconciliation of deployments if only `deployment.scaling`
   is changed in dataplane options.
   [#5003](https://github.com/Kong/kong-operator/pull/5003)
+- Hybrid gateway: Propagate tags in the annotation `konghq.com/tags` in `KongPlugin`s
+  to the copies when attached to `HTTPRoute`s and `GRPCRoute`s to propagate the
+  tags in `KongPlugin`s' annotation to plugins in Konnect.
+  [#5280](https://github.com/Kong/kong-operator/pull/5280)
+  [#5284](https://github.com/Kong/kong-operator/pull/5284)
 
 ## [v2.2.3]
 

--- a/controller/hybridgateway/builder/kongplugin.go
+++ b/controller/hybridgateway/builder/kongplugin.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"sort"
+	"strings"
 
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -12,6 +14,7 @@ import (
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/metadata"
 	gwtypes "github.com/kong/kong-operator/v2/internal/types"
 	"github.com/kong/kong-operator/v2/modules/manager/scheme"
+	pkgmetadata "github.com/kong/kong-operator/v2/pkg/metadata"
 )
 
 // KongPluginBuilder is a builder for configurationv1.KongPlugin resources.
@@ -98,6 +101,47 @@ func (b *KongPluginBuilder) MustBuild() configurationv1.KongPlugin {
 		panic(fmt.Errorf("failed to build KongPlugin: %w", err))
 	}
 	return plugin
+}
+
+// WithTagsFromAnnotations merges the konghq.com/tags annotation value from the given
+// sources into the KongPlugin being built. This ensures that when the generated
+// KongPlugin copy is later read by the Konnect ops layer (via metadata.ExtractTags),
+// the user-supplied tags are present. Multiple sources are merged and deduplicated.
+func (b *KongPluginBuilder) WithTagsFromAnnotations(sources ...pkgmetadata.ObjectWithAnnotations) *KongPluginBuilder {
+	var allTags []string
+	for _, src := range sources {
+		if src == nil {
+			continue
+		}
+		allTags = append(allTags, pkgmetadata.ExtractTags(src)...)
+	}
+	if len(allTags) == 0 {
+		return b
+	}
+	// Deduplicate while preserving order.
+	seen := make(map[string]struct{}, len(allTags))
+	deduped := make([]string, 0, len(allTags))
+	for _, t := range allTags {
+		// Trim trailing and leading whitespace from each tag to avoid duplicates that differ only by whitespace.
+		t = strings.TrimSpace(t)
+		if t == "" {
+			continue
+		}
+		if _, ok := seen[t]; !ok {
+			seen[t] = struct{}{}
+			deduped = append(deduped, t)
+		}
+	}
+	if len(deduped) == 0 {
+		return b
+	}
+
+	if b.plugin.Annotations == nil {
+		b.plugin.Annotations = make(map[string]string)
+	}
+	sort.Strings(deduped)
+	b.plugin.Annotations[pkgmetadata.AnnotationKeyTags] = strings.Join(deduped, ",")
+	return b
 }
 
 // WithPluginName sets the plugin name for the KongPlugin being built.

--- a/controller/hybridgateway/builder/kongplugin_test.go
+++ b/controller/hybridgateway/builder/kongplugin_test.go
@@ -204,3 +204,132 @@ func TestKongPluginBuilder_ChainedCalls(t *testing.T) {
 	assert.NotNil(t, plugin.Annotations)
 	assert.JSONEq(t, string(config), string(plugin.Config.Raw))
 }
+
+func TestKongPluginBuilder_WithTagsAnnotation(t *testing.T) {
+	t.Run("tags from single source", func(t *testing.T) {
+		route := &gwtypes.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-route",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"konghq.com/tags": "team-payments,env-prod",
+				},
+			},
+		}
+
+		plugin, err := NewKongPlugin().
+			WithName("test-plugin").
+			WithTagsFromAnnotations(route).
+			Build()
+		require.NoError(t, err)
+		assert.Equal(t, "env-prod,team-payments", plugin.Annotations["konghq.com/tags"])
+	})
+
+	t.Run("tags from multiple sources are merged and deduplicated", func(t *testing.T) {
+		route := &gwtypes.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-route",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"konghq.com/tags": "shared-tag,route-tag",
+				},
+			},
+		}
+		sourcePlugin := &configurationv1.KongPlugin{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "user-plugin",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"konghq.com/tags": "shared-tag,plugin-tag",
+				},
+			},
+		}
+
+		plugin, err := NewKongPlugin().
+			WithName("test-plugin").
+			WithTagsFromAnnotations(route, sourcePlugin).
+			Build()
+		require.NoError(t, err)
+		assert.Equal(t, "plugin-tag,route-tag,shared-tag", plugin.Annotations["konghq.com/tags"])
+	})
+
+	t.Run("no tags annotation when sources have no tags", func(t *testing.T) {
+		route := &gwtypes.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-route",
+				Namespace: "default",
+			},
+		}
+
+		plugin, err := NewKongPlugin().
+			WithName("test-plugin").
+			WithTagsFromAnnotations(route).
+			Build()
+		require.NoError(t, err)
+		assert.Empty(t, plugin.Annotations["konghq.com/tags"])
+	})
+
+	t.Run("nil source is safely skipped", func(t *testing.T) {
+		route := &gwtypes.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-route",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"konghq.com/tags": "my-tag",
+				},
+			},
+		}
+
+		plugin, err := NewKongPlugin().
+			WithName("test-plugin").
+			WithTagsFromAnnotations(route, nil).
+			Build()
+		require.NoError(t, err)
+		assert.Equal(t, "my-tag", plugin.Annotations["konghq.com/tags"])
+	})
+
+	t.Run("tags annotation preserved alongside tracking annotations", func(t *testing.T) {
+		route := &gwtypes.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-route",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"konghq.com/tags": "my-tag",
+				},
+			},
+		}
+		parentRef := &gwtypes.ParentReference{
+			Name: "test-gateway",
+		}
+
+		plugin, err := NewKongPlugin().
+			WithName("test-plugin").
+			WithAnnotations(route, parentRef).
+			WithTagsFromAnnotations(route).
+			Build()
+		require.NoError(t, err)
+		// Tags annotation should be present
+		assert.Equal(t, "my-tag", plugin.Annotations["konghq.com/tags"])
+		// Tracking annotations from BuildAnnotations should also be present
+		assert.NotEmpty(t, plugin.Annotations["gateway-operator.konghq.com/hybrid-gateways"])
+	})
+
+	t.Run("tags with spaces are trimmed", func(t *testing.T) {
+		route := &gwtypes.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-route",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"konghq.com/tags": "team-payments , env-prod,env-prod, ,  shared-tag  ",
+				},
+			},
+		}
+
+		plugin, err := NewKongPlugin().
+			WithName("test-plugin").
+			WithTagsFromAnnotations(route).
+			Build()
+		require.NoError(t, err)
+		assert.Equal(t, "env-prod,shared-tag,team-payments", plugin.Annotations["konghq.com/tags"])
+	})
+}

--- a/controller/hybridgateway/plugin/plugin.go
+++ b/controller/hybridgateway/plugin/plugin.go
@@ -116,6 +116,8 @@ func PluginsForRule(
 			WithPluginName(plugin.PluginName).
 			WithPluginConfig(plugin.Config.Raw).
 			WithAnnotations(httpRoute, pRef).
+			// Copy the tags annotation from the original plugin to the new plugin copy.
+			WithTagsFromAnnotations(plugin).
 			Build()
 		if err != nil {
 			return nil, fmt.Errorf("failed to build KongPlugin %s: %w", pluginName, err)

--- a/controller/hybridgateway/plugin/plugin_test.go
+++ b/controller/hybridgateway/plugin/plugin_test.go
@@ -19,6 +19,7 @@ import (
 	gwtypes "github.com/kong/kong-operator/v2/internal/types"
 	"github.com/kong/kong-operator/v2/modules/manager/scheme"
 	"github.com/kong/kong-operator/v2/pkg/consts"
+	pkgmetadata "github.com/kong/kong-operator/v2/pkg/metadata"
 )
 
 var (
@@ -184,6 +185,47 @@ func TestPluginForFilter(t *testing.T) {
 				assert.Equal(t, "request-transformer", plugin.PluginName)
 				assert.Contains(t, plugin.Annotations, consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation)
 				assert.Equal(t, "test-namespace/test-route", plugin.Annotations[consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation])
+			},
+		},
+		{
+			name: "route tags are not merged into the tags annotation",
+			filter: gwtypes.HTTPRouteFilter{
+				Type: gatewayv1.HTTPRouteFilterRequestHeaderModifier,
+				RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+					Set: []gatewayv1.HTTPHeader{
+						{Name: "X-Custom-Header", Value: "custom-value"},
+					},
+				},
+			},
+			rule: gwtypes.HTTPRouteRule{
+				Matches: []gatewayv1.HTTPRouteMatch{
+					{
+						Path: &gatewayv1.HTTPPathMatch{
+							Type:  new(gatewayv1.PathMatchPathPrefix),
+							Value: new("/test"),
+						},
+					},
+				},
+			},
+			existingPlugin: nil,
+			httpRoute: &gwtypes.HTTPRoute{
+				TypeMeta: httpRouteTypeMeta,
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+					UID:       "test-uid",
+					Annotations: map[string]string{
+						pkgmetadata.AnnotationKeyTags: "team-b, team-a",
+					},
+				},
+			},
+			parentRef: &gwtypes.ParentReference{
+				Name: "test-gateway",
+			},
+			expectedError: false,
+			validatePlugin: func(t *testing.T, plugin *configurationv1.KongPlugin) {
+				require.NotNil(t, plugin)
+				assert.Empty(t, plugin.Annotations[pkgmetadata.AnnotationKeyTags])
 			},
 		},
 	}
@@ -366,4 +408,59 @@ func TestGetReferencedKongPlugin(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPluginsForRule_ExtensionRef_TagsAnnotation(t *testing.T) {
+	logger := logr.Discard()
+	ctx := context.Background()
+
+	httpRoute := &gwtypes.HTTPRoute{
+		TypeMeta: httpRouteTypeMeta,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "test-namespace",
+			UID:       "test-uid",
+			Annotations: map[string]string{
+				pkgmetadata.AnnotationKeyTags: "route-tag",
+			},
+		},
+	}
+	parentRef := &gwtypes.ParentReference{
+		Name: "test-gateway",
+	}
+
+	referencedPlugin := &configurationv1.KongPlugin{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "referenced-plugin",
+			Namespace: "test-namespace",
+			Annotations: map[string]string{
+				pkgmetadata.AnnotationKeyTags: "plugin-tag,route-tag",
+			},
+		},
+		PluginName: "rate-limiting",
+	}
+
+	rule := gwtypes.HTTPRouteRule{
+		Filters: []gwtypes.HTTPRouteFilter{
+			{
+				Type: gatewayv1.HTTPRouteFilterExtensionRef,
+				ExtensionRef: &gatewayv1.LocalObjectReference{
+					Group: gatewayv1.Group(configurationv1.GroupVersion.Group),
+					Kind:  "KongPlugin",
+					Name:  "referenced-plugin",
+				},
+			},
+		},
+	}
+
+	fakeClient := fakectrlruntimeclient.NewClientBuilder().
+		WithScheme(scheme.Get()).
+		WithObjects(referencedPlugin).
+		Build()
+
+	plugins, err := PluginsForRule(ctx, logger, fakeClient, httpRoute, rule, parentRef)
+	require.NoError(t, err)
+	require.Len(t, plugins, 1)
+
+	assert.Equal(t, "plugin-tag,route-tag", plugins[0].Annotations[pkgmetadata.AnnotationKeyTags])
 }

--- a/controller/hybridgateway/plugin/request_termination.go
+++ b/controller/hybridgateway/plugin/request_termination.go
@@ -40,6 +40,7 @@ func RequestTerminationForBackendNotFound(
 		WithNamespace(metadata.NamespaceFromParentRef(httpRoute, pRef)).
 		WithLabels(httpRoute, pRef).
 		WithAnnotations(httpRoute, pRef).
+		WithTagsFromAnnotations(httpRoute).
 		WithPluginName("request-termination").
 		WithPluginConfig(config).
 		Build()

--- a/controller/konnect/ops/objects_metadata.go
+++ b/controller/konnect/ops/objects_metadata.go
@@ -66,12 +66,17 @@ func GenerateTagsForObject(obj ObjectWithMetadata, additionalTags ...string) []s
 		annotationTags = append(annotationTags, truncate(tag, maxAllowedTagLength))
 	}
 
+	// Truncate the additional tags to ensure they are within the maximum allowed tag length.
+	truncatedAdditional := make([]string, 0, len(additionalTags))
+	for _, tag := range additionalTags {
+		truncatedAdditional = append(truncatedAdditional, truncate(tag, maxAllowedTagLength))
+	}
 	k8sMetaTags := generateKubernetesMetadataTags(obj)
 
-	// We concatenate the tags in this order to ensure that the k8sMetaTags and additionalTags (from spec) are never
-	// truncated below. CEL rules ensure that the total length of k8sMetaTags and additionalTags never exceeds
-	// the maximum allowed tags count. That means we will only discard tags from annotations.
-	allTags := lo.Uniq(slices.Concat(k8sMetaTags, additionalTags, annotationTags))
+	// We concatenate the tags in this order to ensure that the k8sMetaTags and additionalTags
+	// (from spec or annotation of `KongPlugin` to create plugins for `HTTPRoute` or `GRPCRoute`) are always preserved.
+	// That means we will only discard tags from annotations.
+	allTags := lo.Uniq(slices.Concat(k8sMetaTags, truncatedAdditional, annotationTags))
 
 	// If the total number of tags exceeds the maximum allowed tags counts, we limit the number of tags to the maximum
 	// allowed tags count, discarding the tags from annotations.

--- a/controller/konnect/ops/objects_metadata_test.go
+++ b/controller/konnect/ops/objects_metadata_test.go
@@ -294,6 +294,28 @@ func TestGenerateTagsForObject(t *testing.T) {
 			},
 		},
 		{
+			name: "too long tags in additional tags are truncated",
+			obj:  namespacedObject(),
+			additionalTags: []string{
+				"tag1",
+				"tag2",
+				"long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-tag-that-would-end-here-and-no-more-things-should-be-preserved",
+			},
+			expectedTags: []string{
+				"k8s-generation:2",
+				"k8s-group:test.objects.io",
+				"k8s-kind:TestObjectKind",
+				"k8s-name:test-object",
+				"k8s-namespace:test-namespace",
+				"k8s-uid:test-uid",
+				"k8s-version:v1",
+				"long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-tag-that-would-end-here",
+				"managed-by:kong-operator",
+				"tag1",
+				"tag2",
+			},
+		},
+		{
 			name: "when too many tags in total, last from annotations are discarded",
 			obj: func() testObjectKind {
 				obj := namespacedObject()

--- a/pkg/metadata/tags.go
+++ b/pkg/metadata/tags.go
@@ -1,6 +1,7 @@
 package metadata
 
 import (
+	"reflect"
 	"strings"
 )
 
@@ -9,6 +10,14 @@ import (
 //
 //godoclint:disable max-len
 func ExtractTags(obj ObjectWithAnnotations) []string {
+	if obj == nil {
+		return nil
+	}
+	// If the object is a nil pointer, return nil to avoid panics when calling GetAnnotations().
+	if v := reflect.ValueOf(obj); v.Kind() == reflect.Pointer && v.IsNil() {
+		return nil
+	}
+
 	ann, ok := obj.GetAnnotations()[AnnotationKeyTags]
 	if !ok || len(ann) == 0 {
 		return nil

--- a/pkg/metadata/tags_test.go
+++ b/pkg/metadata/tags_test.go
@@ -48,6 +48,16 @@ func TestExtractTags(t *testing.T) {
 			},
 			expected: nil,
 		},
+		{
+			name:     "Nil object",
+			obj:      nil,
+			expected: nil,
+		},
+		{
+			name:     "Nil pointer object",
+			obj:      (*configurationv1.KongConsumer)(nil),
+			expected: nil,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION

(cherry picked from commit ae1df5a1c5ed9a4f89298cf12787c510d6531615)

**What this PR does / why we need it**:

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
