### PR TITLE
chore: skip e2e aigateway-model-route-selectors

### DIFF
--- a/test/e2e/chainsaw/aigateway/model-route-selectors/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/aigateway/model-route-selectors/chainsaw-test.yaml
@@ -3,6 +3,8 @@ kind: Test
 metadata:
   name: aigateway-model-route-selectors
 spec:
+  # Skipping this test: the path-selector case fails server-side.
+  skip: true
   description: |
     AIGatewayModel route selectors. Stands up a Konnect AIGateway
     control plane, a shared OpenAI-compatible provider, and three AIGatewayModel


### PR DESCRIPTION
**What this PR does / why we need it**:

there is a koko-side issue causing aigatewaymodel ci failures.
```
  - lastTransitionTime: "2026-08-24T03:45:24Z"
    message: '{"status":400,"title":"Bad Request","type":"https://kongapi.info/konnect/bad-request","instance":"","detail":"Bad
      Request: config.route.model[0]: named capture group ''model_name'' was not found
      in pcre_pattern","invalid_parameters":[{"dependents":null,"field":"config.route.model[0]","reason":"named
      capture group ''model_name'' was not found in pcre_pattern","rule":null,"source":"body"}]}'
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
