### PR TITLE
Revert: "chore: skip e2e aigateway-model-route-selectors (#5346)"

### DIFF
--- a/test/e2e/chainsaw/aigateway/model-route-selectors/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/aigateway/model-route-selectors/chainsaw-test.yaml
@@ -3,8 +3,6 @@ kind: Test
 metadata:
   name: aigateway-model-route-selectors
 spec:
-  # Skipping this test: the path-selector case fails server-side.
-  skip: true
   description: |
     AIGatewayModel route selectors. Stands up a Konnect AIGateway
     control plane, a shared OpenAI-compatible provider, and three AIGatewayModel


### PR DESCRIPTION
**What this PR does / why we need it**:

re-enable e2e aigateway-model-route-selectors, which is skipped because of a koko-side issue.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

only approve it until the koko-side issue resolved.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
