### PR TITLE
feat(hybridgateway): Propagate tags in KongPlugin and KongPluginBinding to Konnect plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -137,8 +137,9 @@
   containers (e.g. `mcp-server` or `init-mcp-server`). Names that don't match a container the
   operator manages are ignored.
 - Support using `tags` field in `KongPlugin` and `KongClusterPlugin` to specify
-  tags in generated Kong plugins in on-prem gateways.
+  tags in generated Kong plugins in on-prem gateways and Konnect hybrid gateways.
   [#5325](https://github.com/Kong/kong-operator/pull/5325)
+  [#5354](https://github.com/Kong/kong-operator/pull/5354)
 
 ### Changed
 

--- a/controller/hybridgateway/builder/kongplugin.go
+++ b/controller/hybridgateway/builder/kongplugin.go
@@ -11,6 +11,7 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
+	commonv1alpha1 "github.com/kong/kong-operator/v2/api/common/v1alpha1"
 	configurationv1 "github.com/kong/kong-operator/v2/api/configuration/v1"
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/metadata"
 	gwtypes "github.com/kong/kong-operator/v2/internal/types"
@@ -142,6 +143,12 @@ func (b *KongPluginBuilder) WithTagsFromAnnotations(sources ...pkgmetadata.Objec
 	}
 	sort.Strings(deduped)
 	b.plugin.Annotations[pkgmetadata.AnnotationKeyTags] = strings.Join(deduped, ",")
+	return b
+}
+
+// WithTags sets the spec.Tags field for the KongPlugin being built.
+func (b *KongPluginBuilder) WithTags(tags commonv1alpha1.Tags) *KongPluginBuilder {
+	b.plugin.Tags = tags
 	return b
 }
 

--- a/controller/hybridgateway/builder/kongplugin_test.go
+++ b/controller/hybridgateway/builder/kongplugin_test.go
@@ -8,6 +8,7 @@ import (
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
+	commonv1alpha1 "github.com/kong/kong-operator/v2/api/common/v1alpha1"
 	configurationv1 "github.com/kong/kong-operator/v2/api/configuration/v1"
 	gwtypes "github.com/kong/kong-operator/v2/internal/types"
 )
@@ -172,6 +173,47 @@ func TestKongPluginBuilder_WithPluginConfig(t *testing.T) {
 	plugin, err := builder.Build()
 	require.NoError(t, err)
 	assert.JSONEq(t, string(config), string(plugin.Config.Raw))
+}
+
+func TestKongPluginBuilder_WithTags(t *testing.T) {
+	t.Run("sets tags", func(t *testing.T) {
+		plugin, err := NewKongPlugin().
+			WithName("test-plugin").
+			WithTags(commonv1alpha1.Tags{"team-payments", "env-prod"}).
+			Build()
+		require.NoError(t, err)
+		assert.Equal(t, commonv1alpha1.Tags{"team-payments", "env-prod"}, plugin.Tags)
+	})
+
+	t.Run("nil tags", func(t *testing.T) {
+		plugin, err := NewKongPlugin().
+			WithName("test-plugin").
+			WithTags(nil).
+			Build()
+		require.NoError(t, err)
+		assert.Empty(t, plugin.Tags)
+	})
+
+	t.Run("composes with WithTagsFromAnnotations", func(t *testing.T) {
+		sourcePlugin := &configurationv1.KongPlugin{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "user-plugin",
+				Annotations: map[string]string{
+					"konghq.com/tags": "annotation-tag",
+				},
+			},
+			Tags: commonv1alpha1.Tags{"spec-tag"},
+		}
+
+		plugin, err := NewKongPlugin().
+			WithName("test-plugin").
+			WithTagsFromAnnotations(sourcePlugin).
+			WithTags(sourcePlugin.Tags).
+			Build()
+		require.NoError(t, err)
+		assert.Equal(t, "annotation-tag", plugin.Annotations["konghq.com/tags"])
+		assert.Equal(t, commonv1alpha1.Tags{"spec-tag"}, plugin.Tags)
+	})
 }
 
 func TestKongPluginBuilder_ChainedCalls(t *testing.T) {

--- a/controller/hybridgateway/plugin/grpc_plugin.go
+++ b/controller/hybridgateway/plugin/grpc_plugin.go
@@ -98,6 +98,7 @@ func GRPCPluginsForRule(
 			WithAnnotations(grpcRoute, pRef).
 			// Copy the tags annotation from the original plugin to the new plugin copy.
 			WithTagsFromAnnotations(plugin).
+			WithTags(plugin.Tags).
 			Build()
 		if err != nil {
 			return nil, fmt.Errorf("failed to build KongPlugin %s: %w", pluginName, err)

--- a/controller/hybridgateway/plugin/grpc_plugin_test.go
+++ b/controller/hybridgateway/plugin/grpc_plugin_test.go
@@ -13,6 +13,7 @@ import (
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	commonv1alpha1 "github.com/kong/kong-operator/v2/api/common/v1alpha1"
 	configurationv1 "github.com/kong/kong-operator/v2/api/configuration/v1"
 	gwtypes "github.com/kong/kong-operator/v2/internal/types"
 	"github.com/kong/kong-operator/v2/modules/manager/scheme"
@@ -296,4 +297,54 @@ func TestGRPCPluginsForRule_ExtensionRef_TagsAnnotation(t *testing.T) {
 	require.Len(t, plugins, 1)
 	// Should only include the tags from the referenced plugin, not the route.
 	assert.Equal(t, "plugin-tag", plugins[0].Annotations[pkgmetadata.AnnotationKeyTags])
+}
+
+func TestGRPCPluginsForRule_ExtensionRef_Tags(t *testing.T) {
+	logger := logr.Discard()
+	ctx := context.Background()
+
+	grpcRoute := &gwtypes.GRPCRoute{
+		TypeMeta: grpcRouteTypeMeta,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "test-namespace",
+			UID:       "test-uid",
+		},
+	}
+	parentRef := &gwtypes.ParentReference{
+		Name: "test-gateway",
+	}
+
+	referencedPlugin := &configurationv1.KongPlugin{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "referenced-plugin",
+			Namespace: "test-namespace",
+		},
+		PluginName: "rate-limiting",
+		Tags:       commonv1alpha1.Tags{"team-payments", "env-prod"},
+	}
+
+	rule := gwtypes.GRPCRouteRule{
+		Filters: []gatewayv1.GRPCRouteFilter{
+			{
+				Type: gatewayv1.GRPCRouteFilterExtensionRef,
+				ExtensionRef: &gatewayv1.LocalObjectReference{
+					Group: gatewayv1.Group(configurationv1.GroupVersion.Group),
+					Kind:  "KongPlugin",
+					Name:  "referenced-plugin",
+				},
+			},
+		},
+	}
+
+	fakeClient := fakectrlruntimeclient.NewClientBuilder().
+		WithScheme(scheme.Get()).
+		WithObjects(referencedPlugin).
+		Build()
+
+	plugins, err := GRPCPluginsForRule(ctx, logger, fakeClient, grpcRoute, rule, parentRef)
+	require.NoError(t, err)
+	require.Len(t, plugins, 1)
+
+	assert.Equal(t, commonv1alpha1.Tags{"team-payments", "env-prod"}, plugins[0].Tags)
 }

--- a/controller/hybridgateway/plugin/plugin.go
+++ b/controller/hybridgateway/plugin/plugin.go
@@ -118,6 +118,7 @@ func PluginsForRule(
 			WithAnnotations(httpRoute, pRef).
 			// Copy the tags annotation from the original plugin to the new plugin copy.
 			WithTagsFromAnnotations(plugin).
+			WithTags(plugin.Tags).
 			Build()
 		if err != nil {
 			return nil, fmt.Errorf("failed to build KongPlugin %s: %w", pluginName, err)

--- a/controller/hybridgateway/plugin/plugin_test.go
+++ b/controller/hybridgateway/plugin/plugin_test.go
@@ -14,6 +14,7 @@ import (
 	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
+	commonv1alpha1 "github.com/kong/kong-operator/v2/api/common/v1alpha1"
 	configurationv1 "github.com/kong/kong-operator/v2/api/configuration/v1"
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/metadata"
 	gwtypes "github.com/kong/kong-operator/v2/internal/types"
@@ -463,4 +464,54 @@ func TestPluginsForRule_ExtensionRef_TagsAnnotation(t *testing.T) {
 	require.Len(t, plugins, 1)
 
 	assert.Equal(t, "plugin-tag,route-tag", plugins[0].Annotations[pkgmetadata.AnnotationKeyTags])
+}
+
+func TestPluginsForRule_ExtensionRef_Tags(t *testing.T) {
+	logger := logr.Discard()
+	ctx := context.Background()
+
+	httpRoute := &gwtypes.HTTPRoute{
+		TypeMeta: httpRouteTypeMeta,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "test-namespace",
+			UID:       "test-uid",
+		},
+	}
+	parentRef := &gwtypes.ParentReference{
+		Name: "test-gateway",
+	}
+
+	referencedPlugin := &configurationv1.KongPlugin{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "referenced-plugin",
+			Namespace: "test-namespace",
+		},
+		PluginName: "rate-limiting",
+		Tags:       commonv1alpha1.Tags{"team-payments", "env-prod"},
+	}
+
+	rule := gwtypes.HTTPRouteRule{
+		Filters: []gwtypes.HTTPRouteFilter{
+			{
+				Type: gatewayv1.HTTPRouteFilterExtensionRef,
+				ExtensionRef: &gatewayv1.LocalObjectReference{
+					Group: gatewayv1.Group(configurationv1.GroupVersion.Group),
+					Kind:  "KongPlugin",
+					Name:  "referenced-plugin",
+				},
+			},
+		},
+	}
+
+	fakeClient := fakectrlruntimeclient.NewClientBuilder().
+		WithScheme(scheme.Get()).
+		WithObjects(referencedPlugin).
+		Build()
+
+	plugins, err := PluginsForRule(ctx, logger, fakeClient, httpRoute, rule, parentRef)
+	require.NoError(t, err)
+	require.Len(t, plugins, 1)
+
+	assert.Equal(t, commonv1alpha1.Tags{"team-payments", "env-prod"}, plugins[0].Tags)
 }

--- a/controller/konnect/ops/ops_kongpluginbinding.go
+++ b/controller/konnect/ops/ops_kongpluginbinding.go
@@ -228,7 +228,13 @@ func kongPluginBindingToSDKPluginInput(
 		return nil, err
 	}
 
-	tags := GenerateTagsForObject(pluginBinding, metadata.ExtractTags(plugin)...)
+	// Tags are collected in this order so that, if the merged tag set exceeds the
+	// Konnect tags cap, the typed spec.Tags on the plugin take priority over the
+	// binding's own spec.Tags, which in turn take priority over the legacy
+	// annotation-based tags (see GenerateTagsForObject's truncation behavior).
+	additionalTags := append(append([]string{}, plugin.Tags...), pluginBinding.Spec.Tags...)
+	additionalTags = append(additionalTags, metadata.ExtractTags(plugin)...)
+	tags := GenerateTagsForObject(pluginBinding, additionalTags...)
 	return kongPluginWithTargetsToKongPluginInput(pluginBinding, plugin, targets, tags)
 }
 

--- a/controller/konnect/ops/ops_kongpluginbinding_test.go
+++ b/controller/konnect/ops/ops_kongpluginbinding_test.go
@@ -1,6 +1,7 @@
 package ops
 
 import (
+	"fmt"
 	"testing"
 
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
@@ -50,6 +51,7 @@ func TestKongPluginBindingToSDKPluginInput_Tags(t *testing.T) {
 					Kind: "KongService",
 				},
 			},
+			Tags: commonv1alpha1.Tags{"spec-binding-tag"},
 		},
 		Status: configurationv1alpha1.KongPluginBindingStatus{
 			Konnect: &konnectv1alpha2.KonnectEntityStatusWithControlPlaneRef{
@@ -71,6 +73,7 @@ func TestKongPluginBindingToSDKPluginInput_Tags(t *testing.T) {
 				},
 			},
 			PluginName: "basic-auth",
+			Tags:       commonv1alpha1.Tags{"spec-plugin-tag"},
 		},
 		&configurationv1alpha1.KongService{
 			TypeMeta: metav1.TypeMeta{
@@ -106,8 +109,102 @@ func TestKongPluginBindingToSDKPluginInput_Tags(t *testing.T) {
 		"duplicate-tag",
 		"tag3",
 		"tag4",
+		"spec-plugin-tag",
+		"spec-binding-tag",
 	}
 	require.ElementsMatch(t, expectedTags, output.Tags)
+}
+
+// TestKongPluginBindingToSDKPluginInput_TagsTruncationPriority verifies that when the
+// combined tag set exceeds Konnect's tag cap, tags from the referenced KongPlugin's
+// spec.Tags are preserved over the KongPluginBinding's own spec.Tags.
+func TestKongPluginBindingToSDKPluginInput_TagsTruncationPriority(t *testing.T) {
+	ctx := t.Context()
+
+	pluginTags := make(commonv1alpha1.Tags, 15)
+	for i := range pluginTags {
+		pluginTags[i] = fmt.Sprintf("plugin-tag-%02d", i)
+	}
+	bindingTags := make(commonv1alpha1.Tags, 15)
+	for i := range bindingTags {
+		bindingTags[i] = fmt.Sprintf("binding-tag-%02d", i)
+	}
+
+	pb := &configurationv1alpha1.KongPluginBinding{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "KongPluginBinding",
+			APIVersion: "configuration.konghq.com/v1alpha1",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "plugin-binding-1",
+			Namespace: "default",
+			UID:       k8stypes.UID(uuid.NewString()),
+		},
+		Spec: configurationv1alpha1.KongPluginBindingSpec{
+			PluginReference: configurationv1alpha1.PluginRef{
+				Name: "plugin-1",
+				Kind: new("KongPlugin"),
+			},
+			Targets: &configurationv1alpha1.KongPluginBindingTargets{
+				ServiceReference: &configurationv1alpha1.TargetRefWithGroupKind{
+					Name: "service-1",
+					Kind: "KongService",
+				},
+			},
+			Tags: bindingTags,
+		},
+		Status: configurationv1alpha1.KongPluginBindingStatus{
+			Konnect: &konnectv1alpha2.KonnectEntityStatusWithControlPlaneRef{
+				ControlPlaneID: uuid.NewString(),
+			},
+		},
+	}
+	cl := fake.NewClientBuilder().WithScheme(scheme.Get()).WithObjects(
+		&configurationv1.KongPlugin{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "KongPlugin",
+				APIVersion: "configuration.konghq.com/v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "plugin-1",
+				Namespace: "default",
+			},
+			PluginName: "basic-auth",
+			Tags:       pluginTags,
+		},
+		&configurationv1alpha1.KongService{
+			TypeMeta: metav1.TypeMeta{
+				Kind:       "KongService",
+				APIVersion: "configuration.konghq.com/v1alpha1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "service-1",
+				Namespace: "default",
+			},
+			Status: configurationv1alpha1.KongServiceStatus{
+				Konnect: &konnectv1alpha2.KonnectEntityStatusWithControlPlaneAndCertificateAndCACertificatesRefs{
+					KonnectEntityStatus: konnectv1alpha2.KonnectEntityStatus{
+						ID: "12345",
+					},
+				},
+			},
+		},
+	).Build()
+
+	output, err := kongPluginBindingToSDKPluginInput(ctx, cl, pb)
+	require.NoError(t, err)
+
+	// Capped at 20 tags total: k8s-metadata tags for the binding (7, no namespace tag
+	// since GetNamespace() truncation logic still includes it -> 8) plus the first 12
+	// of the 15 plugin tags. None of the binding's own spec.Tags should survive, since
+	// they are positioned after the plugin's tags in the truncation order.
+	require.Len(t, output.Tags, 20)
+	for i := range 12 {
+		require.Contains(t, output.Tags, fmt.Sprintf("plugin-tag-%02d", i))
+	}
+	for _, tag := range bindingTags {
+		require.NotContains(t, output.Tags, tag)
+	}
 }
 
 func TestKongPluginWithTargetsToKongPluginInput(t *testing.T) {

--- a/test/e2e/chainsaw/common/scripts/debug_snapshot.sh
+++ b/test/e2e/chainsaw/common/scripts/debug_snapshot.sh
@@ -98,7 +98,7 @@ for ns in ${ALL_NAMESPACES}; do
 
   # Kong Configuration resources (base Kong gateway config only)
   capture_resource_group "${RESOURCES_FILE}" "${ns}" "Kong Configuration Resources" \
-    "kongcertificates.configuration.konghq.com,kongsnis.configuration.konghq.com,kongroutes.configuration.konghq.com,kongservices.configuration.konghq.com,kongupstreams.configuration.konghq.com,kongtargets.configuration.konghq.com,kongvaults.configuration.konghq.com,kongreferencegrants.configuration.konghq.com,kongplugins.configuration.konghq.com,kongclusterplugins.configuration.konghq.com,kongconsumers.configuration.konghq.com,kongconsumergroups.configuration.konghq.com,kongupstreampolicies.configuration.konghq.com"
+    "kongcertificates.configuration.konghq.com,kongsnis.configuration.konghq.com,kongroutes.configuration.konghq.com,kongservices.configuration.konghq.com,kongupstreams.configuration.konghq.com,kongtargets.configuration.konghq.com,kongvaults.configuration.konghq.com,kongreferencegrants.configuration.konghq.com,kongplugins.configuration.konghq.com,kongclusterplugins.configuration.konghq.com,kongpluginbindings.configuration.konghq.com,kongconsumers.configuration.konghq.com,kongconsumergroups.configuration.konghq.com,kongupstreampolicies.configuration.konghq.com"
 
   # Konnect resources (base only - excluding KonnectAPIAuthConfiguration captured separately with redaction)
   capture_resource_group "${RESOURCES_FILE}" "${ns}" "Konnect Resources" \

--- a/test/e2e/chainsaw/common/scripts/verify_konnect_plugin_tags.sh
+++ b/test/e2e/chainsaw/common/scripts/verify_konnect_plugin_tags.sh
@@ -45,7 +45,7 @@ while [[ $ATTEMPT -lt $RETRY_COUNT ]]; do
     --arg plugin_name "$PLUGIN_REFERENCE_NAME" '
       [
         .items[]
-        | select(.spec.pluginReference.name == $plugin_name)
+        | select(.spec.pluginReference.name | contains($plugin_name))
         | select(.status.konnect.id != null and .status.konnect.controlPlaneID != null)
         | {id: .status.konnect.id, controlPlaneID: .status.konnect.controlPlaneID}
       ][0] // empty

--- a/test/e2e/chainsaw/common/scripts/verify_konnect_plugin_tags.sh
+++ b/test/e2e/chainsaw/common/scripts/verify_konnect_plugin_tags.sh
@@ -1,0 +1,107 @@
+#!/bin/bash
+# Abort on nonzero exit status, unbound variable, and pipefail.
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Verifies that the tags configured on a KongPlugin propagated all the way to the
+# real Konnect-side plugin entity, by resolving the KongPluginBinding generated for
+# it and querying the Konnect Admin API directly.
+#
+# Variables (from environment):
+#   NAMESPACE: The namespace to search for the KongPluginBinding.
+#   PLUGIN_REFERENCE_NAME: The name of the KongPlugin referenced by the binding
+#     (spec.pluginReference.name).
+#   KONNECT_TOKEN: Bearer token for the Konnect Admin API.
+#   KONNECT_URL: Konnect server host, e.g. eu.api.konghq.tech.
+#   EXPECTED_TAGS: Comma-separated list of tags that must all be present on the
+#     Konnect-side plugin's tags array.
+#   RETRY_COUNT: (Optional) Number of retries. Default: 180.
+#   RETRY_DELAY: (Optional) Delay between retries in seconds. Default: 1.
+
+NAMESPACE="${NAMESPACE}"
+PLUGIN_REFERENCE_NAME="${PLUGIN_REFERENCE_NAME}"
+KONNECT_TOKEN="${KONNECT_TOKEN}"
+KONNECT_URL="${KONNECT_URL}"
+EXPECTED_TAGS="${EXPECTED_TAGS}"
+RETRY_COUNT="${RETRY_COUNT:-180}"
+RETRY_DELAY="${RETRY_DELAY:-1}"
+
+IFS=',' read -r -a EXPECTED_TAGS_ARRAY <<< "${EXPECTED_TAGS}"
+
+ATTEMPT=0
+LAST_ERROR=""
+
+while [[ $ATTEMPT -lt $RETRY_COUNT ]]; do
+  ATTEMPT=$((ATTEMPT + 1))
+
+  BINDINGS_JSON=$(kubectl get kongpluginbindings.configuration.konghq.com -n "$NAMESPACE" -o json 2>&1) || {
+    LAST_ERROR="failed to list KongPluginBindings: ${BINDINGS_JSON}"
+    sleep "$RETRY_DELAY"
+    continue
+  }
+
+  BINDING_INFO=$(echo "$BINDINGS_JSON" | jq -r \
+    --arg plugin_name "$PLUGIN_REFERENCE_NAME" '
+      [
+        .items[]
+        | select(.spec.pluginReference.name == $plugin_name)
+        | select(.status.konnect.id != null and .status.konnect.controlPlaneID != null)
+        | {id: .status.konnect.id, controlPlaneID: .status.konnect.controlPlaneID}
+      ][0] // empty
+      | if type == "object" then @json else empty end')
+
+  if [[ -z "$BINDING_INFO" || "$BINDING_INFO" == "null" ]]; then
+    LAST_ERROR="no KongPluginBinding referencing KongPlugin \"${PLUGIN_REFERENCE_NAME}\" with a populated Konnect status was found yet"
+    sleep "$RETRY_DELAY"
+    continue
+  fi
+
+  PLUGIN_ID=$(echo "$BINDING_INFO" | jq -r '.id')
+  CONTROL_PLANE_ID=$(echo "$BINDING_INFO" | jq -r '.controlPlaneID')
+
+  HTTP_STATUS=$(curl -s -o /tmp/verify_konnect_plugin_tags_response.json -w '%{http_code}' \
+    -H "Authorization: Bearer ${KONNECT_TOKEN}" \
+    "https://${KONNECT_URL}/v2/control-planes/${CONTROL_PLANE_ID}/core-entities/plugins/${PLUGIN_ID}") || true
+  RESPONSE_BODY=$(cat /tmp/verify_konnect_plugin_tags_response.json)
+
+  if [[ "$HTTP_STATUS" != "200" ]]; then
+    LAST_ERROR="Konnect API returned HTTP ${HTTP_STATUS}: ${RESPONSE_BODY}"
+    sleep "$RETRY_DELAY"
+    continue
+  fi
+
+  MISSING_TAGS=()
+  for expected_tag in "${EXPECTED_TAGS_ARRAY[@]}"; do
+    if ! echo "$RESPONSE_BODY" | jq -e --arg tag "$expected_tag" '.tags // [] | index($tag) != null' > /dev/null; then
+      MISSING_TAGS+=("$expected_tag")
+    fi
+  done
+
+  if [[ ${#MISSING_TAGS[@]} -eq 0 ]]; then
+    cat <<EOF
+{
+  "success": true,
+  "plugin_id": "$PLUGIN_ID",
+  "control_plane_id": "$CONTROL_PLANE_ID",
+  "tags": $(echo "$RESPONSE_BODY" | jq -c '.tags // []'),
+  "retry_attempt": $ATTEMPT
+}
+EOF
+    exit 0
+  fi
+
+  LAST_ERROR="Konnect plugin ${PLUGIN_ID} is missing expected tags: $(printf '%s,' "${MISSING_TAGS[@]}")"
+  sleep "$RETRY_DELAY"
+done
+
+cat <<EOF
+{
+  "error": "$LAST_ERROR",
+  "namespace": "$NAMESPACE",
+  "plugin_reference_name": "$PLUGIN_REFERENCE_NAME",
+  "expected_tags": "$EXPECTED_TAGS",
+  "retry_count": $RETRY_COUNT
+}
+EOF
+exit 1

--- a/test/e2e/chainsaw/common/scripts/verify_konnect_plugin_tags.sh
+++ b/test/e2e/chainsaw/common/scripts/verify_konnect_plugin_tags.sh
@@ -45,7 +45,7 @@ while [[ $ATTEMPT -lt $RETRY_COUNT ]]; do
     --arg plugin_name "$PLUGIN_REFERENCE_NAME" '
       [
         .items[]
-        | select(.spec.pluginReference.name | contains($plugin_name))
+        | select(.spec.pluginRef.name | contains($plugin_name))
         | select(.status.konnect.id != null and .status.konnect.controlPlaneID != null)
         | {id: .status.konnect.id, controlPlaneID: .status.konnect.controlPlaneID}
       ][0] // empty

--- a/test/e2e/chainsaw/hybridgateway/httproute-extenstionref-filter/01-httproute-single-plugin.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-extenstionref-filter/01-httproute-single-plugin.yaml
@@ -4,6 +4,9 @@ apiVersion: configuration.konghq.com/v1
 metadata:
   name: rate-limit-single
   namespace: ($namespace)
+tags:
+  - team-payments
+  - env-e2e
 plugin: rate-limiting
 config:
   minute: 1000

--- a/test/e2e/chainsaw/hybridgateway/httproute-extenstionref-filter/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-extenstionref-filter/chainsaw-test.yaml
@@ -171,7 +171,7 @@ spec:
               - name: NAMESPACE
                 value: ($namespace)
               - name: PLUGIN_REFERENCE_NAME
-                value: rate-limit-single
+                value: join('.',[$(namespace),'rate-limiting'])
               - name: KONNECT_TOKEN
                 value: ($konnect_token)
               - name: KONNECT_URL

--- a/test/e2e/chainsaw/hybridgateway/httproute-extenstionref-filter/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-extenstionref-filter/chainsaw-test.yaml
@@ -171,7 +171,7 @@ spec:
               - name: NAMESPACE
                 value: ($namespace)
               - name: PLUGIN_REFERENCE_NAME
-                value: join('.',[$(namespace),'rate-limiting'])
+                value: (join('.',[($namespace),'rate-limiting']))
               - name: KONNECT_TOKEN
                 value: ($konnect_token)
               - name: KONNECT_URL

--- a/test/e2e/chainsaw/hybridgateway/httproute-extenstionref-filter/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/hybridgateway/httproute-extenstionref-filter/chainsaw-test.yaml
@@ -162,6 +162,27 @@ spec:
       use:
         template: ../../common/_step_templates/verify-rate-limiting-plugin.yaml
 
+    # Step 7e: Verify the KongPlugin's tags propagated to the real Konnect-side plugin.
+    - name: 7e-Verify-single-plugin-tags
+      description: Verify tags on the referenced KongPlugin reached the Konnect plugin
+      try:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+              - name: PLUGIN_REFERENCE_NAME
+                value: rate-limit-single
+              - name: KONNECT_TOKEN
+                value: ($konnect_token)
+              - name: KONNECT_URL
+                value: ($konnect_url)
+              - name: EXPECTED_TAGS
+                value: "team-payments,env-e2e"
+            content: |
+              bash ../../common/scripts/verify_konnect_plugin_tags.sh
+            check:
+              (json_parse($stdout).success): true
+
     # Step 8a: Create HTTPRoute with multiple ExtensionRef filters.
     - name: 8a-Create-multiple-extensionref-filters
       description: Create an HTTPRoute with 2 ExtensionRef filters (rate-limiting + response-transformer)


### PR DESCRIPTION
**What this PR does / why we need it**:

- Propagate tags in `KongPlugin`s and `KongPluginBinding`s to Konnect plugins in Konnect entity controller
- Copy `tags` field in `KongPlugin` attached to `HTTPRoute` and `GRPCRoute`
- Update chainsaw test case to verify that tags in plugins are correctly set

**Which issue this PR fixes**

Fixes #5309 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
