### PR TITLE
chore(makefile): download `node` before downloading `markdownlint-cli`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -190,10 +190,16 @@ TELEPRESENCE= $(PROJECT_DIR)/bin/installs/github-telepresenceio-telepresence/$(T
 download.telepresence: mise ## Download telepresence locally if necessary.
 	$(MAKE) mise-install TOOL_BIN=$(TELEPRESENCE) DEP_VER=github:telepresenceio/telepresence
 
+NODE_VERSION = $(shell $(YQ) -p toml -o yaml '.tools["node"]' < $(MISE_FILE))
+NODE = $(PROJECT_DIR)/bin/installs/node/$(NODE_VERSION)/bin/node
+.PHONY: download.node
+download.node: mise ## Download node locally if necessary.
+	$(MAKE) mise-install TOOL_BIN=$(NODE) DEP_VER=node@$(NODE_VERSION)
+
 MARKDOWNLINT_VERSION = $(shell $(YQ) -p toml -o yaml '.tools["markdownlint-cli2"].version' < $(MISE_FILE))
 MARKDOWNLINT = $(PROJECT_DIR)/bin/installs/markdownlint-cli2/$(MARKDOWNLINT_VERSION)/node_modules/.bin/markdownlint-cli2
 .PHONY: download.markdownlint-cli2
-download.markdownlint-cli2: mise ## Download markdownlint-cli2 locally if necessary.
+download.markdownlint-cli2: mise download.node ## Download markdownlint-cli2 locally if necessary.
 	$(MAKE) mise-install TOOL_BIN=$(MARKDOWNLINT) DEP_VER=markdownlint-cli2@$(MARKDOWNLINT_VERSION)
 
 HELM_VERSION = $(shell $(YQ) -p toml -o yaml '.tools["aqua:helm/helm"].version' < $(MISE_FILE))


### PR DESCRIPTION
**What this PR does / why we need it**:

Download `node` before downloading `markdownlint-cli2` to fix failures in `lint-markdownlint` in CIs.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
