### PR TITLE
ci: fix agentic review workflow by unpinning kreview

### DIFF
--- a/.github/workflows/muthur.yaml
+++ b/.github/workflows/muthur.yaml
@@ -20,7 +20,6 @@ on:
 env:
   CODEOWNERS_AUTHZ_REF: codeowners-authz/v1.3.1
   AI_REVIEWER_FEDERATED_REF: ai-reviewer-federated/v1.17.5
-  KREVIEW_PLUGIN_REF: plugins/kreview/v0.9.1
 
 jobs:
   # Authorization runs in its own job, before the review job's concurrency group, so an
@@ -113,7 +112,6 @@ jobs:
       # kreview plugin checkout to its own ref: ksai_ref pins the plugin explicitly instead.
       - uses: ./_ksai-review/.github/actions/ai-reviewer-federated
         with:
-          ksai_ref: ${{ env.KREVIEW_PLUGIN_REF }}
           trigger_phrase: "/muthur"
           # GITHUB_TOKEN checks out the PR head, reacts, and posts the review comment.
           source_org_github_token: ${{ github.token }}


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix: https://github.com/Kong/kong-operator/actions/runs/32720594004/job/97411026869#step:4:977

```
Error: Cannot find module '/home/runner/work/_temp/ksai-scripts/ksai/dispatch.cjs'
  Require stack:
  - /home/runner/work/_actions/actions/github-script/3a2844b7e9c422d3c10d287c895573f7108da1b3/dist/index.js
      at Module._resolveFilename (node:internal/modules/cjs/loader:1517:15)
      at wrapResolveFilename (node:internal/modules/cjs/loader:1071:27)
      at resolveForCJSWithHooks (node:internal/modules/cjs/loader:1122:12)
      at resolve (node:internal/modules/helpers:171:31)
      at Object.apply (/home/runner/work/_actions/actions/github-script/3a2844b7e9c422d3c10d287c895573f7108da1b3/dist/index.js:65040:43)
      at eval (eval at callAsyncFunction (/home/runner/work/_actions/actions/github-script/3a2844b7e9c422d3c10d287c895573f7108da1b3/dist/index.js:64949:16), <anonymous>:4:28)
      at callAsyncFunction (/home/runner/work/_actions/actions/github-script/3a2844b7e9c422d3c10d287c895573f7108da1b3/dist/index.js:64950:12)
      at main (/home/runner/work/_actions/actions/github-script/3a2844b7e9c422d3c10d287c895573f7108da1b3/dist/index.js:65100:26)
      at /home/runner/work/_actions/actions/github-script/3a2844b7e9c422d3c10d287c895573f7108da1b3/dist/index.js:65069:1
      at /home/runner/work/_actions/actions/github-script/3a2844b7e9c422d3c10d287c895573f7108da1b3/dist/index.js:65147:3 {
    code: 'MODULE_NOT_FOUND',
    requireStack: [
      '/home/runner/work/_actions/actions/github-script/3a2844b7e9c422d3c10d287c895573f7108da1b3/dist/index.js'
    ]
  }
  Error: Unhandled error: Error: Cannot find module '/home/runner/work/_temp/ksai-scripts/ksai/dispatch.cjs'
```

By unpinning kreview and thus making it use the same ref as already used to check out the action `ai-reviewer-federated`.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
