### PR TITLE
fix(aigateway): reflect full Deployment rollout in AIGatewayDataPlaneReady condition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -139,6 +139,10 @@
   tags in `KongPlugin`s' annotation to plugins in Konnect.
   [#5280](https://github.com/Kong/kong-operator/pull/5280)
   [#5284](https://github.com/Kong/kong-operator/pull/5284)
+- AIGatewayDataPlane: fix the `Ready` condition to reflect a fully completed
+  Deployment rollout instead of flipping `True` as soon as any pod (old or
+  new) was ready.
+  [#5365](https://github.com/Kong/kong-operator/pull/5365)
 
 ## [v2.3.0-rc.3]
 

--- a/controller/aigateway/dataplane/controller_test.go
+++ b/controller/aigateway/dataplane/controller_test.go
@@ -340,11 +340,11 @@ func TestReconciler_Reconcile(t *testing.T) {
 					metav1.ConditionTrue,
 					aigatewayv1alpha1.CertificateProvisionedReason,
 				)
-				// Ready=False because the fake Deployment has no ready replicas yet.
+				// Ready=False because the fake Deployment's rollout is not complete.
 				assertCondition(t, aigwdp,
 					aigatewayv1alpha1.ReadyType,
 					metav1.ConditionFalse,
-					aigatewayv1alpha1.DependenciesNotReadyReason,
+					aigatewayv1alpha1.WaitingToBecomeReadyReason,
 				)
 
 				// Events: 2nd reconcile must emit DeploymentCreated and ServiceCreated.

--- a/controller/aigateway/dataplane/status.go
+++ b/controller/aigateway/dataplane/status.go
@@ -36,7 +36,9 @@ import (
 // ensureReadyStatus computes the Ready condition for an AIGatewayDataPlane.
 // It first checks whether any non-Ready condition is False; if so it sets
 // Ready=False immediately without fetching the Deployment. Otherwise it reads
-// the owned Deployment's replica counts and sets Ready based on readyReplicas.
+// the owned Deployment and sets Ready based on DeploymentRolloutComplete,
+// which requires the controller to have observed the current generation and
+// all desired replicas to be updated and available.
 // Status is not patched here; the caller flushes via applyStatus.
 func ensureReadyStatus(
 	ctx context.Context,

--- a/controller/aigateway/dataplane/status.go
+++ b/controller/aigateway/dataplane/status.go
@@ -78,15 +78,14 @@ func ensureReadyStatus(
 	aigwdp.Status.Replicas = deployment.Status.Replicas
 	aigwdp.Status.ReadyReplicas = deployment.Status.ReadyReplicas
 
-	// Mark Not Ready only when zero pods are serving traffic.
-	// During a rolling update some replicas are still ready, so we stay Ready
-	// throughout the rollout and only flip to False when there is nothing left to serve.
-	if deployment.Status.ReadyReplicas == 0 {
+	// Ready only once the current generation has been fully rolled out, not
+	// merely once some pods happen to be ready.
+	if !k8sutils.DeploymentRolloutComplete(deployment) {
 		apimeta.SetStatusCondition(&aigwdp.Status.Conditions, metav1.Condition{
 			Type:               string(aigatewayv1alpha1.ReadyType),
 			Status:             metav1.ConditionFalse,
-			Reason:             string(aigatewayv1alpha1.DependenciesNotReadyReason),
-			Message:            aigatewayv1alpha1.DependenciesNotReadyMessage,
+			Reason:             string(aigatewayv1alpha1.WaitingToBecomeReadyReason),
+			Message:            aigatewayv1alpha1.WaitingToBecomeReadyMessage,
 			ObservedGeneration: aigwdp.Generation,
 		})
 	} else {

--- a/controller/aigateway/dataplane/status_test.go
+++ b/controller/aigateway/dataplane/status_test.go
@@ -35,12 +35,20 @@ func Test_ensureReadyStatus(t *testing.T) {
 		}
 	}
 
-	deploy := func(ready, total int32) *appsv1.Deployment {
+	// deploy builds a Deployment with the given generation/replica counts so
+	// tests can control DeploymentRolloutComplete's inputs precisely.
+	deploy := func(generation, observedGeneration int64, specReplicas, replicas, updatedReplicas, availableReplicas, readyReplicas int32) *appsv1.Deployment {
 		d := &appsv1.Deployment{
-			ObjectMeta: metav1.ObjectMeta{Namespace: testCASecretNamespace, Name: testDPName},
+			ObjectMeta: metav1.ObjectMeta{Namespace: testCASecretNamespace, Name: testDPName, Generation: generation},
+			Spec:       appsv1.DeploymentSpec{Replicas: new(specReplicas)},
 		}
-		d.Status.Replicas = total
-		d.Status.ReadyReplicas = ready
+		d.Status = appsv1.DeploymentStatus{
+			ObservedGeneration: observedGeneration,
+			Replicas:           replicas,
+			UpdatedReplicas:    updatedReplicas,
+			AvailableReplicas:  availableReplicas,
+			ReadyReplicas:      readyReplicas,
+		}
 		return d
 	}
 
@@ -62,24 +70,34 @@ func Test_ensureReadyStatus(t *testing.T) {
 		},
 		{
 			name:              "deployment exists but zero ready: Ready=False",
-			objects:           []client.Object{deploy(0, 2)},
+			objects:           []client.Object{deploy(1, 1, 2, 2, 0, 0, 0)},
 			wantReadyStatus:   metav1.ConditionFalse,
+			wantReason:        string(aigatewayv1alpha1.WaitingToBecomeReadyReason),
 			wantReplicas:      2,
 			wantReadyReplicas: 0,
 		},
 		{
-			name:              "deployment has ready replicas: Ready=True",
-			objects:           []client.Object{deploy(2, 2)},
+			name:              "deployment fully rolled out: Ready=True",
+			objects:           []client.Object{deploy(1, 1, 2, 2, 2, 2, 2)},
 			wantReadyStatus:   metav1.ConditionTrue,
 			wantReplicas:      2,
 			wantReadyReplicas: 2,
 		},
 		{
-			name:              "rolling update: some ready replicas: stays Ready=True",
-			objects:           []client.Object{deploy(1, 2)},
-			wantReadyStatus:   metav1.ConditionTrue,
+			name:              "rolling update in progress: some ready replicas: Ready=False until rollout completes",
+			objects:           []client.Object{deploy(1, 1, 2, 2, 1, 1, 1)},
+			wantReadyStatus:   metav1.ConditionFalse,
+			wantReason:        string(aigatewayv1alpha1.WaitingToBecomeReadyReason),
 			wantReplicas:      2,
 			wantReadyReplicas: 1,
+		},
+		{
+			name:              "stale observed generation: Ready=False even though replica counts look complete",
+			objects:           []client.Object{deploy(2, 1, 2, 2, 2, 2, 2)},
+			wantReadyStatus:   metav1.ConditionFalse,
+			wantReason:        string(aigatewayv1alpha1.WaitingToBecomeReadyReason),
+			wantReplicas:      2,
+			wantReadyReplicas: 2,
 		},
 		{
 			name: "GET error propagated",

--- a/controller/aigateway/dataplane/status_test.go
+++ b/controller/aigateway/dataplane/status_test.go
@@ -100,6 +100,17 @@ func Test_ensureReadyStatus(t *testing.T) {
 			wantReadyReplicas: 2,
 		},
 		{
+			// spec.deployment.replicas=0 is a valid, explicit scale-down. Every
+			// counter trivially matches (0 == 0), but there are no pods serving
+			// traffic, so this must not report Ready=True.
+			name:              "spec.replicas=0: Ready=False even though every counter is 0",
+			objects:           []client.Object{deploy(1, 1, 0, 0, 0, 0, 0)},
+			wantReadyStatus:   metav1.ConditionFalse,
+			wantReason:        string(aigatewayv1alpha1.WaitingToBecomeReadyReason),
+			wantReplicas:      0,
+			wantReadyReplicas: 0,
+		},
+		{
 			name: "GET error propagated",
 			buildClient: func(base client.WithWatch) client.Client {
 				return interceptor.NewClient(base, interceptor.Funcs{

--- a/pkg/utils/kubernetes/deployment.go
+++ b/pkg/utils/kubernetes/deployment.go
@@ -1,0 +1,22 @@
+package kubernetes
+
+import (
+	appsv1 "k8s.io/api/apps/v1"
+)
+
+// DeploymentRolloutComplete reports whether deployment's current generation
+// has been fully rolled out: the controller has observed the latest spec,
+// and all desired replicas have been updated and are available. It mirrors
+// the check `kubectl rollout status` performs.
+func DeploymentRolloutComplete(deployment *appsv1.Deployment) bool {
+	replicas := int32(1)
+	if deployment.Spec.Replicas != nil {
+		replicas = *deployment.Spec.Replicas
+	}
+
+	status := deployment.Status
+	return status.ObservedGeneration >= deployment.Generation &&
+		status.UpdatedReplicas == replicas &&
+		status.Replicas == replicas &&
+		status.AvailableReplicas == replicas
+}

--- a/pkg/utils/kubernetes/deployment.go
+++ b/pkg/utils/kubernetes/deployment.go
@@ -7,11 +7,17 @@ import (
 // DeploymentRolloutComplete reports whether deployment's current generation
 // has been fully rolled out: the controller has observed the latest spec,
 // and all desired replicas have been updated and are available. It mirrors
-// the check `kubectl rollout status` performs.
+// the check `kubectl rollout status` performs, except a deployment scaled to
+// zero replicas is never considered complete here (unlike kubectl, which
+// treats that as a trivially successful rollout). Callers use this to mean
+// "healthy and serving", which zero replicas never is.
 func DeploymentRolloutComplete(deployment *appsv1.Deployment) bool {
 	replicas := int32(1)
 	if deployment.Spec.Replicas != nil {
 		replicas = *deployment.Spec.Replicas
+	}
+	if replicas == 0 {
+		return false
 	}
 
 	status := deployment.Status

--- a/pkg/utils/kubernetes/deployment_test.go
+++ b/pkg/utils/kubernetes/deployment_test.go
@@ -89,6 +89,20 @@ func TestDeploymentRolloutComplete(t *testing.T) {
 			deployment: &appsv1.Deployment{},
 			want:       false,
 		},
+		{
+			name: "explicit spec.replicas=0: not complete even though every counter matches",
+			deployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Spec:       appsv1.DeploymentSpec{Replicas: new(int32(0))},
+				Status: appsv1.DeploymentStatus{
+					ObservedGeneration: 1,
+					Replicas:           0,
+					UpdatedReplicas:    0,
+					AvailableReplicas:  0,
+				},
+			},
+			want: false,
+		},
 	}
 
 	for _, tc := range tests {

--- a/pkg/utils/kubernetes/deployment_test.go
+++ b/pkg/utils/kubernetes/deployment_test.go
@@ -1,0 +1,99 @@
+package kubernetes
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	appsv1 "k8s.io/api/apps/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func TestDeploymentRolloutComplete(t *testing.T) {
+	tests := []struct {
+		name       string
+		deployment *appsv1.Deployment
+		want       bool
+	}{
+		{
+			name: "fully rolled out",
+			deployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
+				Spec:       appsv1.DeploymentSpec{Replicas: new(int32(2))},
+				Status: appsv1.DeploymentStatus{
+					ObservedGeneration: 2,
+					Replicas:           2,
+					UpdatedReplicas:    2,
+					AvailableReplicas:  2,
+				},
+			},
+			want: true,
+		},
+		{
+			name: "stale observed generation",
+			deployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Generation: 3},
+				Spec:       appsv1.DeploymentSpec{Replicas: new(int32(2))},
+				Status: appsv1.DeploymentStatus{
+					ObservedGeneration: 2,
+					Replicas:           2,
+					UpdatedReplicas:    2,
+					AvailableReplicas:  2,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "rollout in progress: old replica still available, new one not yet",
+			deployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Generation: 2},
+				Spec:       appsv1.DeploymentSpec{Replicas: new(int32(2))},
+				Status: appsv1.DeploymentStatus{
+					ObservedGeneration: 2,
+					Replicas:           2,
+					UpdatedReplicas:    1,
+					AvailableReplicas:  2,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "rollout in progress: not all replicas available yet",
+			deployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Spec:       appsv1.DeploymentSpec{Replicas: new(int32(2))},
+				Status: appsv1.DeploymentStatus{
+					ObservedGeneration: 1,
+					Replicas:           2,
+					UpdatedReplicas:    2,
+					AvailableReplicas:  1,
+				},
+			},
+			want: false,
+		},
+		{
+			name: "nil spec.replicas defaults to 1, fully rolled out",
+			deployment: &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Generation: 1},
+				Spec:       appsv1.DeploymentSpec{Replicas: nil},
+				Status: appsv1.DeploymentStatus{
+					ObservedGeneration: 1,
+					Replicas:           1,
+					UpdatedReplicas:    1,
+					AvailableReplicas:  1,
+				},
+			},
+			want: true,
+		},
+		{
+			name:       "zero-value deployment is not rolled out",
+			deployment: &appsv1.Deployment{},
+			want:       false,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			assert.Equal(t, tc.want, DeploymentRolloutComplete(tc.deployment))
+		})
+	}
+}

--- a/test/e2e/chainsaw/aigateway/aigatewaydataplane-lifecycle/06-aigatewaydataplane-rollout.yaml
+++ b/test/e2e/chainsaw/aigateway/aigatewaydataplane-lifecycle/06-aigatewaydataplane-rollout.yaml
@@ -15,10 +15,13 @@ spec:
         containers:
           - name: aigw
             image: ($aigw_dp_image)
-            # Deliberately slow: gives a wide, deterministic window during a
-            # later rollout in which the new pod exists but is not yet Ready.
             readinessProbe:
               initialDelaySeconds: 30
+            # New env var changes the pod template hash, forcing a real
+            # rolling update (new ReplicaSet + new pod).
+            env:
+              - name: ROLLOUT_TRIGGER
+                value: "v2"
   network:
     services:
       ingress:

--- a/test/e2e/chainsaw/aigateway/aigatewaydataplane-lifecycle/06-assert-rolling.yaml
+++ b/test/e2e/chainsaw/aigateway/aigatewaydataplane-lifecycle/06-assert-rolling.yaml
@@ -1,0 +1,9 @@
+apiVersion: aigateway.konghq.com/v1alpha1
+kind: AIGatewayDataPlane
+metadata:
+  name: ($aigw_dp_name)
+  namespace: ($namespace)
+status:
+  (conditions[?type == 'Ready']):
+    - status: 'False'
+      reason: WaitingToBecomeReady

--- a/test/e2e/chainsaw/aigateway/aigatewaydataplane-lifecycle/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/aigateway/aigatewaydataplane-lifecycle/chainsaw-test.yaml
@@ -5,10 +5,15 @@ metadata:
 spec:
   description: |
     Lifecycle test for AIGatewayDataPlane cross-reference, condition correctness,
-    and watch reconciliation.
+    watch reconciliation, and rollout-readiness (issue #5340).
     1. Creates DataPlane before its KonnectAIGateway → asserts KonnectAIGatewayResolved=False/NotFound.
     2. Creates KonnectAIGateway → asserts watch fires → DataPlane reaches Ready=True.
-    3. Deletes KonnectAIGateway → asserts DataPlane conditions degrade
+    3. Triggers a second rollout (podTemplateSpec change) → while the new pod
+       is still starting up (and the old pod is still serving), asserts
+       Ready=False/WaitingToBecomeReady.
+    4. Once the new pod passes its (delayed) probe and the old pod is scaled
+       down, asserts Ready=True again.
+    5. Deletes KonnectAIGateway → asserts DataPlane conditions degrade
   bindings:
     - name: test_name
       value: ($namespace)
@@ -52,6 +57,23 @@ spec:
       use:
         template: ../../common/_step_templates/apply-assert-konnectAIGateway.yaml
     - name: Assert-watch-fired
+      try:
+        - assert:
+            file: 05-assert-ready.yaml
+    - name: Trigger-second-rollout
+      description: |
+        Apply an updated podTemplateSpec (new env var) so the Deployment gets
+        a new pod template hash and a real rolling update starts. The old pod
+        keeps serving (default maxUnavailable=0/maxSurge=1 for replicas=1)
+        while the new pod is created and starts its 30s-delayed readiness
+        probe, giving a wide, deterministic window in which Ready must be
+        False.
+      try:
+        - apply:
+            file: 06-aigatewaydataplane-rollout.yaml
+        - assert:
+            file: 06-assert-rolling.yaml
+    - name: Assert-rollout-completes
       try:
         - assert:
             file: 05-assert-ready.yaml


### PR DESCRIPTION




**What this PR does / why we need it**:

Ready no longer flips True until the current generation is fully rolled out (was: as soon as any pod was ready). Adds a shared DeploymentRolloutComplete helper and folds the rollout-readiness scenario into the aigatewaydataplane-lifecycle chainsaw test.

Part of #5340

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
