### PR TITLE
[Backport release/2.2.x ]fix(konnect): Truncate tags and label values by unicode runes (#5306)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -80,6 +80,9 @@
   tags in `KongPlugin`s' annotation to plugins in Konnect.
   [#5280](https://github.com/Kong/kong-operator/pull/5280)
   [#5284](https://github.com/Kong/kong-operator/pull/5284)
+- Konnect entities: Fix truncating of tags to cut at 128 unicode runes
+  (UTF8 code points).
+  [#5306](https://github.com/Kong/kong-operator/pull/5306)
 
 ## [v2.2.3]
 

--- a/controller/konnect/ops/objects_metadata.go
+++ b/controller/konnect/ops/objects_metadata.go
@@ -5,6 +5,7 @@ import (
 	"maps"
 	"slices"
 	"sort"
+	"unicode/utf8"
 
 	"github.com/samber/lo"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -163,9 +164,11 @@ func WithKubernetesMetadataLabelsPtr(obj ObjectWithMetadata, userSetLabels map[s
 	return out
 }
 
+// truncate truncates a string to the specified limit in runes, since tags supports unicode runes.
+// If the string is shorter than or equal to the limit, it returns the original string.
 func truncate(s string, limit int) string {
-	if len(s) <= limit {
+	if utf8.RuneCountInString(s) <= limit {
 		return s
 	}
-	return s[:limit]
+	return string([]rune(s)[:limit])
 }


### PR DESCRIPTION
(cherry picked from commit cde9d23f2ae1d7de2be46cf9417ec22c08eb21f9)

**What this PR does / why we need it**:

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
