### PR TITLE
[Backport release/2.0.x]fix(konnect): Truncate tags and label values by unicode runes (#5306)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,6 +41,14 @@
 - [v0.1.1](#v011)
 - [v0.1.0](#v010)
 
+## Unreleased
+
+### Fixes
+
+- Konnect entities: Fix truncating of tags to cut at 128 unicode runes
+  (UTF8 code points).
+  [#5306](https://github.com/Kong/kong-operator/pull/5306)
+
 ## [v2.0.11]
 
 > Release date: 2026-07-21

--- a/controller/konnect/ops/objects_metadata.go
+++ b/controller/konnect/ops/objects_metadata.go
@@ -5,6 +5,7 @@ import (
 	"maps"
 	"slices"
 	"sort"
+	"unicode/utf8"
 
 	"github.com/samber/lo"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -135,9 +136,11 @@ func UIDLabelForObject(obj client.Object) string {
 	return fmt.Sprintf("%s:%s", KubernetesUIDLabelKey, obj.GetUID())
 }
 
+// truncate truncates a string to the specified limit in runes, since tags supports unicode runes.
+// If the string is shorter than or equal to the limit, it returns the original string.
 func truncate(s string, limit int) string {
-	if len(s) <= limit {
+	if utf8.RuneCountInString(s) <= limit {
 		return s
 	}
-	return s[:limit]
+	return string([]rune(s)[:limit])
 }


### PR DESCRIPTION
(cherry picked from commit cde9d23f2ae1d7de2be46cf9417ec22c08eb21f9)

**What this PR does / why we need it**:

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
