### PR TITLE
[Backport release/2.1.x] fix(hybridgateway): propagate konghq.com/tags to generated KongPlugin (#5284)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -62,6 +62,11 @@
 - Konnect entities: Fix truncating of tags to cut at 128 unicode runes
   (UTF8 code points).
   [#5306](https://github.com/Kong/kong-operator/pull/5306)
+- Hybrid gateway: Propagate tags in the annotation `konghq.com/tags` in `KongPlugin`s
+  to the copies when attached to `HTTPRoute`s and `GRPCRoute`s to propagate the
+  tags in `KongPlugin`s' annotation to plugins in Konnect.
+  [#5280](https://github.com/Kong/kong-operator/pull/5280)
+  [#5284](https://github.com/Kong/kong-operator/pull/5284)
 
 ## [v2.1.9]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -67,6 +67,7 @@
   tags in `KongPlugin`s' annotation to plugins in Konnect.
   [#5280](https://github.com/Kong/kong-operator/pull/5280)
   [#5284](https://github.com/Kong/kong-operator/pull/5284)
+  [#5400](https://github.com/Kong/kong-operator/pull/5400)
 
 ## [v2.1.9]
 

--- a/controller/hybridgateway/builder/kongplugin.go
+++ b/controller/hybridgateway/builder/kongplugin.go
@@ -5,6 +5,8 @@ import (
 	"errors"
 	"fmt"
 	"maps"
+	"sort"
+	"strings"
 
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
@@ -12,6 +14,7 @@ import (
 	"github.com/kong/kong-operator/v2/controller/hybridgateway/metadata"
 	gwtypes "github.com/kong/kong-operator/v2/internal/types"
 	"github.com/kong/kong-operator/v2/modules/manager/scheme"
+	pkgmetadata "github.com/kong/kong-operator/v2/pkg/metadata"
 )
 
 // KongPluginBuilder is a builder for configurationv1.KongPlugin resources.
@@ -98,6 +101,47 @@ func (b *KongPluginBuilder) MustBuild() configurationv1.KongPlugin {
 		panic(fmt.Errorf("failed to build KongPlugin: %w", err))
 	}
 	return plugin
+}
+
+// WithTagsFromAnnotations merges the konghq.com/tags annotation value from the given
+// sources into the KongPlugin being built. This ensures that when the generated
+// KongPlugin copy is later read by the Konnect ops layer (via metadata.ExtractTags),
+// the user-supplied tags are present. Multiple sources are merged and deduplicated.
+func (b *KongPluginBuilder) WithTagsFromAnnotations(sources ...pkgmetadata.ObjectWithAnnotations) *KongPluginBuilder {
+	var allTags []string
+	for _, src := range sources {
+		if src == nil {
+			continue
+		}
+		allTags = append(allTags, pkgmetadata.ExtractTags(src)...)
+	}
+	if len(allTags) == 0 {
+		return b
+	}
+	// Deduplicate while preserving order.
+	seen := make(map[string]struct{}, len(allTags))
+	deduped := make([]string, 0, len(allTags))
+	for _, t := range allTags {
+		// Trim trailing and leading whitespace from each tag to avoid duplicates that differ only by whitespace.
+		t = strings.TrimSpace(t)
+		if t == "" {
+			continue
+		}
+		if _, ok := seen[t]; !ok {
+			seen[t] = struct{}{}
+			deduped = append(deduped, t)
+		}
+	}
+	if len(deduped) == 0 {
+		return b
+	}
+
+	if b.plugin.Annotations == nil {
+		b.plugin.Annotations = make(map[string]string)
+	}
+	sort.Strings(deduped)
+	b.plugin.Annotations[pkgmetadata.AnnotationKeyTags] = strings.Join(deduped, ",")
+	return b
 }
 
 // WithPluginName sets the plugin name for the KongPlugin being built.

--- a/controller/hybridgateway/builder/kongplugin_test.go
+++ b/controller/hybridgateway/builder/kongplugin_test.go
@@ -204,3 +204,132 @@ func TestKongPluginBuilder_ChainedCalls(t *testing.T) {
 	assert.NotNil(t, plugin.Annotations)
 	assert.JSONEq(t, string(config), string(plugin.Config.Raw))
 }
+
+func TestKongPluginBuilder_WithTagsAnnotation(t *testing.T) {
+	t.Run("tags from single source", func(t *testing.T) {
+		route := &gwtypes.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-route",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"konghq.com/tags": "team-payments,env-prod",
+				},
+			},
+		}
+
+		plugin, err := NewKongPlugin().
+			WithName("test-plugin").
+			WithTagsFromAnnotations(route).
+			Build()
+		require.NoError(t, err)
+		assert.Equal(t, "env-prod,team-payments", plugin.Annotations["konghq.com/tags"])
+	})
+
+	t.Run("tags from multiple sources are merged and deduplicated", func(t *testing.T) {
+		route := &gwtypes.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-route",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"konghq.com/tags": "shared-tag,route-tag",
+				},
+			},
+		}
+		sourcePlugin := &configurationv1.KongPlugin{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "user-plugin",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"konghq.com/tags": "shared-tag,plugin-tag",
+				},
+			},
+		}
+
+		plugin, err := NewKongPlugin().
+			WithName("test-plugin").
+			WithTagsFromAnnotations(route, sourcePlugin).
+			Build()
+		require.NoError(t, err)
+		assert.Equal(t, "plugin-tag,route-tag,shared-tag", plugin.Annotations["konghq.com/tags"])
+	})
+
+	t.Run("no tags annotation when sources have no tags", func(t *testing.T) {
+		route := &gwtypes.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-route",
+				Namespace: "default",
+			},
+		}
+
+		plugin, err := NewKongPlugin().
+			WithName("test-plugin").
+			WithTagsFromAnnotations(route).
+			Build()
+		require.NoError(t, err)
+		assert.Empty(t, plugin.Annotations["konghq.com/tags"])
+	})
+
+	t.Run("nil source is safely skipped", func(t *testing.T) {
+		route := &gwtypes.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-route",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"konghq.com/tags": "my-tag",
+				},
+			},
+		}
+
+		plugin, err := NewKongPlugin().
+			WithName("test-plugin").
+			WithTagsFromAnnotations(route, nil).
+			Build()
+		require.NoError(t, err)
+		assert.Equal(t, "my-tag", plugin.Annotations["konghq.com/tags"])
+	})
+
+	t.Run("tags annotation preserved alongside tracking annotations", func(t *testing.T) {
+		route := &gwtypes.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-route",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"konghq.com/tags": "my-tag",
+				},
+			},
+		}
+		parentRef := &gwtypes.ParentReference{
+			Name: "test-gateway",
+		}
+
+		plugin, err := NewKongPlugin().
+			WithName("test-plugin").
+			WithAnnotations(route, parentRef).
+			WithTagsFromAnnotations(route).
+			Build()
+		require.NoError(t, err)
+		// Tags annotation should be present
+		assert.Equal(t, "my-tag", plugin.Annotations["konghq.com/tags"])
+		// Tracking annotations from BuildAnnotations should also be present
+		assert.NotEmpty(t, plugin.Annotations["gateway-operator.konghq.com/hybrid-gateways"])
+	})
+
+	t.Run("tags with spaces are trimmed", func(t *testing.T) {
+		route := &gwtypes.HTTPRoute{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "test-route",
+				Namespace: "default",
+				Annotations: map[string]string{
+					"konghq.com/tags": "team-payments , env-prod,env-prod, ,  shared-tag  ",
+				},
+			},
+		}
+
+		plugin, err := NewKongPlugin().
+			WithName("test-plugin").
+			WithTagsFromAnnotations(route).
+			Build()
+		require.NoError(t, err)
+		assert.Equal(t, "env-prod,shared-tag,team-payments", plugin.Annotations["konghq.com/tags"])
+	})
+}

--- a/controller/hybridgateway/plugin/plugin.go
+++ b/controller/hybridgateway/plugin/plugin.go
@@ -116,6 +116,8 @@ func PluginsForRule(
 			WithPluginName(plugin.PluginName).
 			WithPluginConfig(plugin.Config.Raw).
 			WithAnnotations(httpRoute, pRef).
+			// Copy the tags annotation from the original plugin to the new plugin copy.
+			WithTagsFromAnnotations(plugin).
 			Build()
 		if err != nil {
 			return nil, fmt.Errorf("failed to build KongPlugin %s: %w", pluginName, err)

--- a/controller/hybridgateway/plugin/plugin_test.go
+++ b/controller/hybridgateway/plugin/plugin_test.go
@@ -20,6 +20,7 @@ import (
 	gwtypes "github.com/kong/kong-operator/v2/internal/types"
 	"github.com/kong/kong-operator/v2/modules/manager/scheme"
 	"github.com/kong/kong-operator/v2/pkg/consts"
+	pkgmetadata "github.com/kong/kong-operator/v2/pkg/metadata"
 )
 
 func TestAppendHTTPRouteToPluginAnnotations(t *testing.T) {
@@ -172,6 +173,46 @@ func TestPluginForFilter(t *testing.T) {
 				assert.Equal(t, "request-transformer", plugin.PluginName)
 				assert.Contains(t, plugin.Annotations, consts.GatewayOperatorHybridRoutesAnnotation)
 				assert.Equal(t, "test-namespace/test-route", plugin.Annotations[consts.GatewayOperatorHybridRoutesAnnotation])
+			},
+		},
+		{
+			name: "route tags are not merged into the tags annotation",
+			filter: gwtypes.HTTPRouteFilter{
+				Type: gatewayv1.HTTPRouteFilterRequestHeaderModifier,
+				RequestHeaderModifier: &gatewayv1.HTTPHeaderFilter{
+					Set: []gatewayv1.HTTPHeader{
+						{Name: "X-Custom-Header", Value: "custom-value"},
+					},
+				},
+			},
+			rule: gwtypes.HTTPRouteRule{
+				Matches: []gatewayv1.HTTPRouteMatch{
+					{
+						Path: &gatewayv1.HTTPPathMatch{
+							Type:  ptr.To(gatewayv1.PathMatchPathPrefix),
+							Value: ptr.To("/test"),
+						},
+					},
+				},
+			},
+			existingPlugin: nil,
+			httpRoute: &gwtypes.HTTPRoute{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "test-route",
+					Namespace: "test-namespace",
+					UID:       "test-uid",
+					Annotations: map[string]string{
+						pkgmetadata.AnnotationKeyTags: "team-b, team-a",
+					},
+				},
+			},
+			parentRef: &gwtypes.ParentReference{
+				Name: "test-gateway",
+			},
+			expectedError: false,
+			validatePlugin: func(t *testing.T, plugin *configurationv1.KongPlugin) {
+				require.NotNil(t, plugin)
+				assert.Empty(t, plugin.Annotations[pkgmetadata.AnnotationKeyTags])
 			},
 		},
 	}
@@ -354,4 +395,59 @@ func TestGetReferencedKongPlugin(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestPluginsForRule_ExtensionRef_TagsAnnotation(t *testing.T) {
+	logger := logr.Discard()
+	ctx := context.Background()
+
+	httpRoute := &gwtypes.HTTPRoute{
+		TypeMeta: httpRouteTypeMeta,
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "test-route",
+			Namespace: "test-namespace",
+			UID:       "test-uid",
+			Annotations: map[string]string{
+				pkgmetadata.AnnotationKeyTags: "route-tag",
+			},
+		},
+	}
+	parentRef := &gwtypes.ParentReference{
+		Name: "test-gateway",
+	}
+
+	referencedPlugin := &configurationv1.KongPlugin{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "referenced-plugin",
+			Namespace: "test-namespace",
+			Annotations: map[string]string{
+				pkgmetadata.AnnotationKeyTags: "plugin-tag,route-tag",
+			},
+		},
+		PluginName: "rate-limiting",
+	}
+
+	rule := gwtypes.HTTPRouteRule{
+		Filters: []gwtypes.HTTPRouteFilter{
+			{
+				Type: gatewayv1.HTTPRouteFilterExtensionRef,
+				ExtensionRef: &gatewayv1.LocalObjectReference{
+					Group: gatewayv1.Group(configurationv1.GroupVersion.Group),
+					Kind:  "KongPlugin",
+					Name:  "referenced-plugin",
+				},
+			},
+		},
+	}
+
+	fakeClient := fakectrlruntimeclient.NewClientBuilder().
+		WithScheme(scheme.Get()).
+		WithObjects(referencedPlugin).
+		Build()
+
+	plugins, err := PluginsForRule(ctx, logger, fakeClient, httpRoute, rule, parentRef)
+	require.NoError(t, err)
+	require.Len(t, plugins, 1)
+
+	assert.Equal(t, "plugin-tag,route-tag", plugins[0].Annotations[pkgmetadata.AnnotationKeyTags])
 }

--- a/controller/hybridgateway/plugin/plugin_test.go
+++ b/controller/hybridgateway/plugin/plugin_test.go
@@ -402,7 +402,6 @@ func TestPluginsForRule_ExtensionRef_TagsAnnotation(t *testing.T) {
 	ctx := context.Background()
 
 	httpRoute := &gwtypes.HTTPRoute{
-		TypeMeta: httpRouteTypeMeta,
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-route",
 			Namespace: "test-namespace",

--- a/controller/konnect/ops/objects_metadata.go
+++ b/controller/konnect/ops/objects_metadata.go
@@ -61,12 +61,17 @@ func GenerateTagsForObject(obj ObjectWithMetadata, additionalTags ...string) []s
 		annotationTags = append(annotationTags, truncate(tag, maxAllowedTagLength))
 	}
 
+	// Truncate the additional tags to ensure they are within the maximum allowed tag length.
+	truncatedAdditional := make([]string, 0, len(additionalTags))
+	for _, tag := range additionalTags {
+		truncatedAdditional = append(truncatedAdditional, truncate(tag, maxAllowedTagLength))
+	}
 	k8sMetaTags := generateKubernetesMetadataTags(obj)
 
-	// We concatenate the tags in this order to ensure that the k8sMetaTags and additionalTags (from spec) are never
-	// truncated below. CEL rules ensure that the total length of k8sMetaTags and additionalTags never exceeds
-	// the maximum allowed tags count. That means we will only discard tags from annotations.
-	allTags := lo.Uniq(slices.Concat(k8sMetaTags, additionalTags, annotationTags))
+	// We concatenate the tags in this order to ensure that the k8sMetaTags and additionalTags
+	// (from spec or annotation of `KongPlugin` to create plugins for `HTTPRoute` or `GRPCRoute`) are always preserved.
+	// That means we will only discard tags from annotations.
+	allTags := lo.Uniq(slices.Concat(k8sMetaTags, truncatedAdditional, annotationTags))
 
 	// If the total number of tags exceeds the maximum allowed tags counts, we limit the number of tags to the maximum
 	// allowed tags count, discarding the tags from annotations.

--- a/controller/konnect/ops/objects_metadata_test.go
+++ b/controller/konnect/ops/objects_metadata_test.go
@@ -284,6 +284,28 @@ func TestGenerateTagsForObject(t *testing.T) {
 			},
 		},
 		{
+			name: "too long tags in additional tags are truncated",
+			obj:  namespacedObject(),
+			additionalTags: []string{
+				"tag1",
+				"tag2",
+				"long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-tag-that-would-end-here-and-no-more-things-should-be-preserved",
+			},
+			expectedTags: []string{
+				"k8s-generation:2",
+				"k8s-group:test.objects.io",
+				"k8s-kind:TestObjectKind",
+				"k8s-name:test-object",
+				"k8s-namespace:test-namespace",
+				"k8s-uid:test-uid",
+				"k8s-version:v1",
+				"long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-tag-that-would-end-here",
+				"managed-by:kong-operator",
+				"tag1",
+				"tag2",
+			},
+		},
+		{
 			name: "when too many tags in total, last from annotations are discarded",
 			obj: func() testObjectKind {
 				obj := namespacedObject()

--- a/controller/konnect/ops/objects_metadata_test.go
+++ b/controller/konnect/ops/objects_metadata_test.go
@@ -300,7 +300,6 @@ func TestGenerateTagsForObject(t *testing.T) {
 				"k8s-uid:test-uid",
 				"k8s-version:v1",
 				"long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-long-tag-that-would-end-here",
-				"managed-by:kong-operator",
 				"tag1",
 				"tag2",
 			},

--- a/go.mod
+++ b/go.mod
@@ -216,7 +216,7 @@ require (
 	github.com/jmespath/go-jmespath v0.4.1-0.20220621161143-b0104c826a24 // indirect
 	github.com/jmoiron/sqlx v1.3.5 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
-	github.com/klauspost/compress v1.18.5 // indirect
+	github.com/klauspost/compress v1.18.7 // indirect
 	github.com/kr/text v0.2.0 // indirect
 	github.com/liggitt/tabwriter v0.0.0-20181228230101-89fcab3d43de // indirect
 	github.com/lucasb-eyer/go-colorful v1.2.0 // indirect
@@ -234,11 +234,11 @@ require (
 	github.com/mitchellh/hashstructure v1.1.0 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
-	github.com/moby/go-archive v0.2.0 // indirect
+	github.com/moby/go-archive v0.3.0 // indirect
 	github.com/moby/patternmatcher v0.6.1 // indirect
 	github.com/moby/spdystream v0.5.1 // indirect
-	github.com/moby/sys/sequential v0.6.0 // indirect
-	github.com/moby/sys/user v0.4.0 // indirect
+	github.com/moby/sys/sequential v0.7.0 // indirect
+	github.com/moby/sys/user v0.4.1 // indirect
 	github.com/moby/sys/userns v0.1.0 // indirect
 	github.com/moby/term v0.5.2 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/go.sum
+++ b/go.sum
@@ -378,8 +378,8 @@ github.com/jpillora/backoff v1.0.0 h1:uvFg412JmmHBHw7iwprIxkPMI+sGQ4kzOWsMeHnm2E
 github.com/jpillora/backoff v1.0.0/go.mod h1:J/6gKK9jxlEcS3zixgDgUAsiuZ7yrSoa/FX5e0EB2j4=
 github.com/json-iterator/go v1.1.12 h1:PV8peI4a0ysnczrg+LtxykD8LfKY9ML6u2jnxaEnrnM=
 github.com/json-iterator/go v1.1.12/go.mod h1:e30LSqwooZae/UwlEbR2852Gd8hjQvJoHmT4TnhNGBo=
-github.com/klauspost/compress v1.18.5 h1:/h1gH5Ce+VWNLSWqPzOVn6XBO+vJbCNGvjoaGBFW2IE=
-github.com/klauspost/compress v1.18.5/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
+github.com/klauspost/compress v1.18.7 h1:aUyZsS4kH3QTKurYhAOwAHxllVPnOthb3vPfnF1Ehjw=
+github.com/klauspost/compress v1.18.7/go.mod h1:cwPg85FWrGar70rWktvGQj8/hthj3wpl0PGDogxkrSQ=
 github.com/kong/go-database-reconciler v1.33.0 h1:EAwap2hSCwHUJfVxbF+uw6UruqC47hNMGRbXhinY9IE=
 github.com/kong/go-database-reconciler v1.33.0/go.mod h1:CTFu9hfOh2L4qPniCUCqLYhKiuVA0UsQe0Iv4jZc58o=
 github.com/kong/go-kong v0.73.1 h1:7lLubnXD3ggMlQJXqh4zHAGPaD6Mf7BWjYu/VfAkW1w=
@@ -448,8 +448,8 @@ github.com/mitchellh/reflectwalk v1.0.2 h1:G2LzWKi524PWgd3mLHV8Y5k7s6XUvT0Gef6zx
 github.com/mitchellh/reflectwalk v1.0.2/go.mod h1:mSTlrgnPZtwu0c4WaC2kGObEpuNDbx0jmZXqmk4esnw=
 github.com/moby/docker-image-spec v1.3.1 h1:jMKff3w6PgbfSa69GfNg+zN/XLhfXJGnEx3Nl2EsFP0=
 github.com/moby/docker-image-spec v1.3.1/go.mod h1:eKmb5VW8vQEh/BAr2yvVNvuiJuY6UIocYsFu/DxxRpo=
-github.com/moby/go-archive v0.2.0 h1:zg5QDUM2mi0JIM9fdQZWC7U8+2ZfixfTYoHL7rWUcP8=
-github.com/moby/go-archive v0.2.0/go.mod h1:mNeivT14o8xU+5q1YnNrkQVpK+dnNe/K6fHqnTg4qPU=
+github.com/moby/go-archive v0.3.0 h1:nos4BtzzUIqB406BgQnWGMI4qib9BZ8XUHU+ucv/n1c=
+github.com/moby/go-archive v0.3.0/go.mod h1:Npdv43fFqlhZW7Xo8fbm3ZMYFvAGNviUPqX21VERbcE=
 github.com/moby/moby/api v1.54.1 h1:TqVzuJkOLsgLDDwNLmYqACUuTehOHRGKiPhvH8V3Nn4=
 github.com/moby/moby/api v1.54.1/go.mod h1:+RQ6wluLwtYaTd1WnPLykIDPekkuyD/ROWQClE83pzs=
 github.com/moby/moby/client v0.4.0 h1:S+2XegzHQrrvTCvF6s5HFzcrywWQmuVnhOXe2kiWjIw=
@@ -460,10 +460,10 @@ github.com/moby/spdystream v0.5.1 h1:9sNYeYZUcci9R6/w7KDaFWEWeV4LStVG78Mpyq/Zm/Y
 github.com/moby/spdystream v0.5.1/go.mod h1:xBAYlnt/ay+11ShkdFKNAG7LsyK/tmNBVvVOwrfMgdI=
 github.com/moby/sys/atomicwriter v0.1.0 h1:kw5D/EqkBwsBFi0ss9v1VG3wIkVhzGvLklJ+w3A14Sw=
 github.com/moby/sys/atomicwriter v0.1.0/go.mod h1:Ul8oqv2ZMNHOceF643P6FKPXeCmYtlQMvpizfsSoaWs=
-github.com/moby/sys/sequential v0.6.0 h1:qrx7XFUd/5DxtqcoH1h438hF5TmOvzC/lspjy7zgvCU=
-github.com/moby/sys/sequential v0.6.0/go.mod h1:uyv8EUTrca5PnDsdMGXhZe6CCe8U/UiTWd+lL+7b/Ko=
-github.com/moby/sys/user v0.4.0 h1:jhcMKit7SA80hivmFJcbB1vqmw//wU61Zdui2eQXuMs=
-github.com/moby/sys/user v0.4.0/go.mod h1:bG+tYYYJgaMtRKgEmuueC0hJEAZWwtIbZTB+85uoHjs=
+github.com/moby/sys/sequential v0.7.0 h1:ASQNGNROJSuOO6LL6bPHbKvuZu6NU8P4ldPWk31zj/8=
+github.com/moby/sys/sequential v0.7.0/go.mod h1:NfSTAp6V3fw4tmkD62PEcOKeZKquXT8VKCkf7aVR79o=
+github.com/moby/sys/user v0.4.1 h1:RgjRlaDKi/Xmyrz4t8lyzXT6v2ooFeO/7xtchmhVWE0=
+github.com/moby/sys/user v0.4.1/go.mod h1:E9QsW5WRe1kUAf7kW8hXKwu1uhsZEAdPLYHYSDudF4Y=
 github.com/moby/sys/userns v0.1.0 h1:tVLXkFOxVu9A64/yh59slHVv9ahO9UIev4JZusOLG/g=
 github.com/moby/sys/userns v0.1.0/go.mod h1:IHUYgu/kao6N8YZlp9Cf444ySSvCmDlmzUcYfDHOl28=
 github.com/moby/term v0.5.2 h1:6qk3FJAFDs6i/q3W/pQ97SX192qKfZgGjCQqfCJkgzQ=

--- a/pkg/metadata/tags.go
+++ b/pkg/metadata/tags.go
@@ -1,6 +1,7 @@
 package metadata
 
 import (
+	"reflect"
 	"strings"
 )
 
@@ -9,6 +10,14 @@ import (
 //
 //godoclint:disable max-len
 func ExtractTags(obj ObjectWithAnnotations) []string {
+	if obj == nil {
+		return nil
+	}
+	// If the object is a nil pointer, return nil to avoid panics when calling GetAnnotations().
+	if v := reflect.ValueOf(obj); v.Kind() == reflect.Pointer && v.IsNil() {
+		return nil
+	}
+
 	ann, ok := obj.GetAnnotations()[AnnotationKeyTags]
 	if !ok || len(ann) == 0 {
 		return nil

--- a/pkg/metadata/tags_test.go
+++ b/pkg/metadata/tags_test.go
@@ -48,6 +48,16 @@ func TestExtractTags(t *testing.T) {
 			},
 			expected: nil,
 		},
+		{
+			name:     "Nil object",
+			obj:      nil,
+			expected: nil,
+		},
+		{
+			name:     "Nil pointer object",
+			obj:      (*configurationv1.KongConsumer)(nil),
+			expected: nil,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION


(cherry picked from commit ae1df5a1c5ed9a4f89298cf12787c510d6531615)

**What this PR does / why we need it**:

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
