### PR TITLE
feat(aigateway): reconcile HPA from spec.deployment.scaling.horizontal

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -107,6 +107,13 @@
   [#5391](https://github.com/Kong/kong-operator/pull/5391)
 - Added `AIGatewayAuthStrategy` CRD
   [#5405](https://github.com/Kong/kong-operator/pull/5405)
+- `AIGatewayDataPlane`: reconcile a `HorizontalPodAutoscaler` from
+  `spec.deployment.scaling.horizontal`. When horizontal scaling is configured
+  the operator creates and keeps an HPA up to date; when the configuration is
+  removed the HPA is deleted so it no longer conflicts with a static replica
+  count. The operator's RBAC now includes `create;get;list;patch;watch;delete`
+  on `horizontalpodautoscalers` for the AIGatewayDataPlane controller.
+  [#5406](https://github.com/Kong/kong-operator/pull/5406)
 
 ### Changed
 

--- a/controller/aigateway/dataplane/controller.go
+++ b/controller/aigateway/dataplane/controller.go
@@ -23,6 +23,7 @@ import (
 	"time"
 
 	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/managedfields"
@@ -69,6 +70,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) err
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&aigatewayv1alpha1.AIGatewayDataPlane{}).
 		Owns(&appsv1.Deployment{}).
+		Owns(&autoscalingv2.HorizontalPodAutoscaler{}).
 		Owns(&corev1.Service{}).
 		Owns(&corev1.Secret{}).
 		Owns(&configurationv1alpha1.AIGatewayDataPlaneCertificate{}).
@@ -124,6 +126,11 @@ func (r *Reconciler) Reconcile(ctx context.Context, aigwdp *aigatewayv1alpha1.AI
 
 	// Reconcile the full AI Gateway Deployment spec.
 	if err := r.ensureDeployment(ctx, logger, aigwdp, aigatewaycp, certSecret.Name); err != nil {
+		return ctrl.Result{}, err
+	}
+
+	// Reconcile the HPA if horizontal scaling is configured.
+	if err := r.ensureHPA(ctx, logger, aigwdp, aigwdp.Name); err != nil {
 		return ctrl.Result{}, err
 	}
 

--- a/controller/aigateway/dataplane/controller_rbac.go
+++ b/controller/aigateway/dataplane/controller_rbac.go
@@ -29,3 +29,4 @@ package dataplane
 // +kubebuilder:rbac:groups=core,resources=secrets,verbs=create;get;list;watch;update;patch;delete
 // +kubebuilder:rbac:groups=core,resources=events,verbs=create;patch
 // +kubebuilder:rbac:groups=events.k8s.io,resources=events,verbs=create;patch
+// +kubebuilder:rbac:groups=autoscaling,resources=horizontalpodautoscalers,verbs=create;get;list;patch;watch;delete

--- a/controller/aigateway/dataplane/owned_deployment.go
+++ b/controller/aigateway/dataplane/owned_deployment.go
@@ -203,7 +203,10 @@ func generateBaseDeployment(
 
 	var replicas *int32
 	if aigwdp.Spec.Deployment != nil {
-		replicas = aigwdp.Spec.Deployment.Replicas
+		// when HPA is active, omit spec.replicas from the SSA object so HPA owns the field
+		if aigwdp.Spec.Deployment.Scaling == nil || aigwdp.Spec.Deployment.Scaling.HorizontalScaling == nil {
+			replicas = aigwdp.Spec.Deployment.Replicas
+		}
 	}
 
 	d := &appsv1.Deployment{

--- a/controller/aigateway/dataplane/owned_deployment.go
+++ b/controller/aigateway/dataplane/owned_deployment.go
@@ -203,9 +203,18 @@ func generateBaseDeployment(
 
 	var replicas *int32
 	if aigwdp.Spec.Deployment != nil {
-		// when HPA is active, omit spec.replicas from the SSA object so HPA owns the field
-		if aigwdp.Spec.Deployment.Scaling == nil || aigwdp.Spec.Deployment.Scaling.HorizontalScaling == nil {
+		var hs *aigatewayv1alpha1.HorizontalScaling
+		if aigwdp.Spec.Deployment.Scaling != nil {
+			hs = aigwdp.Spec.Deployment.Scaling.HorizontalScaling
+		}
+		switch {
+		case hs == nil:
+			// No HPA: use the static replica count.
 			replicas = aigwdp.Spec.Deployment.Replicas
+		case hs.MinReplicas != nil:
+			// HPA is active: seed replicas from minReplicas so the Deployment
+			// scales up immediately before the HPA's first evaluation.
+			replicas = hs.MinReplicas
 		}
 	}
 

--- a/controller/aigateway/dataplane/owned_hpa.go
+++ b/controller/aigateway/dataplane/owned_hpa.go
@@ -60,7 +60,13 @@ func (r *Reconciler) ensureHPA(
 		return nil
 	}
 
-	generatedHPA, err := k8sresources.GenerateHPAForAIGatewayDataPlane(aigwdp, deploymentName)
+	hs := aigwdp.Spec.Deployment.Scaling.HorizontalScaling
+	generatedHPA, err := k8sresources.GenerateHPA(aigwdp, &k8sresources.HPAScalingSpec{
+		MinReplicas: hs.MinReplicas,
+		MaxReplicas: hs.MaxReplicas,
+		Metrics:     hs.Metrics,
+		Behavior:    hs.Behavior,
+	}, deploymentName)
 	if err != nil {
 		return err
 	}

--- a/controller/aigateway/dataplane/owned_hpa.go
+++ b/controller/aigateway/dataplane/owned_hpa.go
@@ -1,0 +1,86 @@
+/*
+Copyright 2026 Kong, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dataplane
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/go-logr/logr"
+	"github.com/google/go-cmp/cmp"
+
+	aigatewayv1alpha1 "github.com/kong/kong-operator/v2/api/aigateway/v1alpha1"
+	"github.com/kong/kong-operator/v2/controller/pkg/patch"
+	k8sutils "github.com/kong/kong-operator/v2/pkg/utils/kubernetes"
+	k8sreduce "github.com/kong/kong-operator/v2/pkg/utils/kubernetes/reduce"
+	k8sresources "github.com/kong/kong-operator/v2/pkg/utils/kubernetes/resources"
+)
+
+// ensureHPA reconciles the HPA for the given AIGatewayDataPlane.
+// If horizontal scaling is not configured, any existing HPA is deleted.
+func (r *Reconciler) ensureHPA(
+	ctx context.Context,
+	logger logr.Logger,
+	aigwdp *aigatewayv1alpha1.AIGatewayDataPlane,
+	deploymentName string,
+) error {
+	matchingLabels := k8sresources.GetManagedLabelForOwner(aigwdp)
+	hpas, err := k8sutils.ListHPAsForOwner(ctx, r.Client, aigwdp.Namespace, aigwdp.UID, matchingLabels)
+	if err != nil {
+		return fmt.Errorf("failed listing HPAs for AIGatewayDataPlane %s/%s: %w", aigwdp.Namespace, aigwdp.Name, err)
+	}
+
+	if aigwdp.Spec.Deployment == nil ||
+		aigwdp.Spec.Deployment.Scaling == nil ||
+		aigwdp.Spec.Deployment.Scaling.HorizontalScaling == nil {
+		if err := k8sreduce.ReduceHPAs(ctx, r.Client, hpas, k8sreduce.FilterNone); err != nil {
+			return fmt.Errorf("failed reducing HPAs for AIGatewayDataPlane %s/%s: %w", aigwdp.Namespace, aigwdp.Name, err)
+		}
+		return nil
+	}
+
+	if len(hpas) > 1 {
+		if err := k8sreduce.ReduceHPAs(ctx, r.Client, hpas, k8sreduce.FilterHPAs); err != nil {
+			return fmt.Errorf("failed reducing HPAs for AIGatewayDataPlane %s/%s: %w", aigwdp.Namespace, aigwdp.Name, err)
+		}
+		return nil
+	}
+
+	generatedHPA, err := k8sresources.GenerateHPAForAIGatewayDataPlane(aigwdp, deploymentName)
+	if err != nil {
+		return err
+	}
+
+	if len(hpas) == 1 {
+		existingHPA := &hpas[0]
+		oldExistingHPA := existingHPA.DeepCopy()
+		var updated bool
+		updated, existingHPA.ObjectMeta = k8sutils.EnsureObjectMetaIsUpdated(existingHPA.ObjectMeta, generatedHPA.ObjectMeta)
+		if !cmp.Equal(existingHPA.Spec, generatedHPA.Spec) {
+			existingHPA.Spec = generatedHPA.Spec
+			updated = true
+		}
+		// op.Result and the returned object are unused; errors surface to the caller.
+		_, _, err := patch.ApplyPatchIfNotEmpty(ctx, r.Client, logger, existingHPA, oldExistingHPA, updated)
+		return err
+	}
+
+	if err := r.Create(ctx, generatedHPA); err != nil {
+		return fmt.Errorf("failed creating HPA for AIGatewayDataPlane %s: %w", aigwdp.Name, err)
+	}
+	return nil
+}

--- a/controller/aigateway/dataplane/owned_hpa_test.go
+++ b/controller/aigateway/dataplane/owned_hpa_test.go
@@ -1,0 +1,129 @@
+/*
+Copyright 2026 Kong, Inc.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package dataplane
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	aigatewayv1alpha1 "github.com/kong/kong-operator/v2/api/aigateway/v1alpha1"
+	managerscheme "github.com/kong/kong-operator/v2/modules/manager/scheme"
+)
+
+// newHPAAIGWDP returns an AIGatewayDataPlane with horizontal scaling configured.
+func newHPAAIGWDP() *aigatewayv1alpha1.AIGatewayDataPlane {
+	dp := newReconcileAIGWDP()
+	dp.Spec.Deployment = &aigatewayv1alpha1.DeploymentOptions{
+		Scaling: &aigatewayv1alpha1.Scaling{
+			HorizontalScaling: &aigatewayv1alpha1.HorizontalScaling{
+				MaxReplicas: 5,
+			},
+		},
+	}
+	return dp
+}
+
+// newReconcilerForHPATest builds a reconciler + fake client seeded with the given objects.
+func newReconcilerForHPATest(t *testing.T, objs ...client.Object) (*Reconciler, client.Client) {
+	t.Helper()
+	cl := fake.NewClientBuilder().
+		WithScheme(managerscheme.Get()).
+		WithObjects(objs...).
+		Build()
+	r := newTestReconciler(cl, events.NewFakeRecorder(10))
+	return r, cl
+}
+
+func TestEnsureHPA(t *testing.T) {
+	t.Run("creates HPA when scaling is configured", func(t *testing.T) {
+		aigwdp := newHPAAIGWDP()
+		r, cl := newReconcilerForHPATest(t, aigwdp)
+
+		require.NoError(t, r.ensureHPA(t.Context(), logr.Discard(), aigwdp, aigwdp.Name))
+
+		var hpa autoscalingv2.HorizontalPodAutoscaler
+		require.NoError(t, cl.Get(t.Context(), types.NamespacedName{Namespace: reconcileTestNS, Name: aigwdp.Name}, &hpa))
+		assert.Equal(t, int32(5), hpa.Spec.MaxReplicas)
+		assert.Equal(t, aigwdp.Name, hpa.Spec.ScaleTargetRef.Name)
+		assert.Equal(t, "Deployment", hpa.Spec.ScaleTargetRef.Kind)
+	})
+
+	t.Run("deletes HPA when scaling is removed", func(t *testing.T) {
+		aigwdp := newHPAAIGWDP()
+		r, cl := newReconcilerForHPATest(t, aigwdp)
+
+		// First call creates the HPA.
+		require.NoError(t, r.ensureHPA(t.Context(), logr.Discard(), aigwdp, aigwdp.Name))
+
+		// Remove scaling and call again.
+		noScaling := aigwdp.DeepCopy()
+		noScaling.Spec.Deployment = nil
+		require.NoError(t, r.ensureHPA(t.Context(), logr.Discard(), noScaling, noScaling.Name))
+
+		var hpaList autoscalingv2.HorizontalPodAutoscalerList
+		require.NoError(t, cl.List(t.Context(), &hpaList, client.InNamespace(reconcileTestNS)))
+		assert.Empty(t, hpaList.Items)
+	})
+
+	t.Run("updates HPA when maxReplicas changes", func(t *testing.T) {
+		aigwdp := newHPAAIGWDP()
+		r, cl := newReconcilerForHPATest(t, aigwdp)
+
+		// Create HPA.
+		require.NoError(t, r.ensureHPA(t.Context(), logr.Discard(), aigwdp, aigwdp.Name))
+
+		// Update maxReplicas.
+		updated := aigwdp.DeepCopy()
+		updated.Spec.Deployment.Scaling.HorizontalScaling.MaxReplicas = 10
+		require.NoError(t, r.ensureHPA(t.Context(), logr.Discard(), updated, updated.Name))
+
+		var hpa autoscalingv2.HorizontalPodAutoscaler
+		require.NoError(t, cl.Get(t.Context(), types.NamespacedName{Namespace: reconcileTestNS, Name: aigwdp.Name}, &hpa))
+		assert.Equal(t, int32(10), hpa.Spec.MaxReplicas)
+	})
+}
+
+func TestGenerateBaseDeployment_ReplicaGuard(t *testing.T) {
+	aigatewaycp := testKonnectAIGateway("cp.example.com", "tp.example.com")
+
+	t.Run("sets replicas when HPA is not configured", func(t *testing.T) {
+		replicas := int32(3)
+		aigwdp := newReconcileAIGWDP()
+		aigwdp.Spec.Deployment = &aigatewayv1alpha1.DeploymentOptions{Replicas: &replicas}
+
+		d, err := generateBaseDeployment(logr.Discard(), aigwdp, aigatewaycp, "kong/aigw:latest", "cert-secret")
+		require.NoError(t, err)
+		require.NotNil(t, d.Spec.Replicas)
+		assert.Equal(t, replicas, *d.Spec.Replicas)
+	})
+
+	t.Run("omits replicas when HPA is active", func(t *testing.T) {
+		aigwdp := newHPAAIGWDP()
+
+		d, err := generateBaseDeployment(logr.Discard(), aigwdp, aigatewaycp, "kong/aigw:latest", "cert-secret")
+		require.NoError(t, err)
+		assert.Nil(t, d.Spec.Replicas, "spec.replicas must be nil when HPA is active so HPA owns the field")
+	})
+}

--- a/controller/aigateway/dataplane/owned_hpa_test.go
+++ b/controller/aigateway/dataplane/owned_hpa_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/tools/events"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -30,6 +31,7 @@ import (
 
 	aigatewayv1alpha1 "github.com/kong/kong-operator/v2/api/aigateway/v1alpha1"
 	managerscheme "github.com/kong/kong-operator/v2/modules/manager/scheme"
+	k8sresources "github.com/kong/kong-operator/v2/pkg/utils/kubernetes/resources"
 )
 
 // newHPAAIGWDP returns an AIGatewayDataPlane with horizontal scaling configured.
@@ -102,6 +104,35 @@ func TestEnsureHPA(t *testing.T) {
 		var hpa autoscalingv2.HorizontalPodAutoscaler
 		require.NoError(t, cl.Get(t.Context(), types.NamespacedName{Namespace: reconcileTestNS, Name: aigwdp.Name}, &hpa))
 		assert.Equal(t, int32(10), hpa.Spec.MaxReplicas)
+	})
+
+	t.Run("reduces to one HPA when multiple exist", func(t *testing.T) {
+		aigwdp := newHPAAIGWDP()
+		// Managed labels are required so ListHPAsForOwner's label selector finds the HPAs.
+		labels := k8sresources.GetManagedLabelForOwner(aigwdp)
+		ownerRef := metav1.OwnerReference{UID: aigwdp.UID, Name: aigwdp.Name}
+
+		hpa1 := &autoscalingv2.HorizontalPodAutoscaler{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: aigwdp.Name + "-1", Namespace: reconcileTestNS,
+				Labels:          labels,
+				OwnerReferences: []metav1.OwnerReference{ownerRef},
+			},
+		}
+		hpa2 := &autoscalingv2.HorizontalPodAutoscaler{
+			ObjectMeta: metav1.ObjectMeta{
+				Name: aigwdp.Name + "-2", Namespace: reconcileTestNS,
+				Labels:          labels,
+				OwnerReferences: []metav1.OwnerReference{ownerRef},
+			},
+		}
+		r, cl := newReconcilerForHPATest(t, aigwdp, hpa1, hpa2)
+
+		require.NoError(t, r.ensureHPA(t.Context(), logr.Discard(), aigwdp, aigwdp.Name))
+
+		var hpaList autoscalingv2.HorizontalPodAutoscalerList
+		require.NoError(t, cl.List(t.Context(), &hpaList, client.InNamespace(reconcileTestNS)))
+		assert.Len(t, hpaList.Items, 1)
 	})
 }
 

--- a/controller/aigateway/dataplane/owned_hpa_test.go
+++ b/controller/aigateway/dataplane/owned_hpa_test.go
@@ -152,6 +152,7 @@ func TestGenerateBaseDeployment_ReplicaGuard(t *testing.T) {
 
 	t.Run("omits replicas when HPA is active", func(t *testing.T) {
 		aigwdp := newHPAAIGWDP()
+		aigwdp.Spec.Deployment.Replicas = new(int32(3))
 
 		d, err := generateBaseDeployment(logr.Discard(), aigwdp, aigatewaycp, "kong/aigw:latest", "cert-secret")
 		require.NoError(t, err)

--- a/controller/dataplane/owned_resources.go
+++ b/controller/dataplane/owned_resources.go
@@ -92,7 +92,13 @@ func ensureHPAForDataPlane(
 		return op.Noop, nil, nil
 	}
 
-	generatedHPA, err := k8sresources.GenerateHPAForDataPlane(dataplane, deploymentName)
+	hs := dataplane.Spec.Deployment.Scaling.HorizontalScaling
+	generatedHPA, err := k8sresources.GenerateHPA(dataplane, &k8sresources.HPAScalingSpec{
+		MinReplicas: hs.MinReplicas,
+		MaxReplicas: hs.MaxReplicas,
+		Metrics:     hs.Metrics,
+		Behavior:    hs.Behavior,
+	}, deploymentName)
 	if err != nil {
 		return op.Noop, nil, err
 	}

--- a/controller/pkg/patch/patch_test.go
+++ b/controller/pkg/patch/patch_test.go
@@ -83,7 +83,13 @@ func TestApplyPatchIfNonEmpty(t *testing.T) {
 				},
 			},
 			generateHPAFunc: func(t *testing.T, dataplane *operatorv1beta1.DataPlane) *autoscalingv2.HorizontalPodAutoscaler {
-				hpa, err := k8sresources.GenerateHPAForDataPlane(dataplane, "test-deployment")
+				hs := dataplane.Spec.Deployment.Scaling.HorizontalScaling
+				hpa, err := k8sresources.GenerateHPA(dataplane, &k8sresources.HPAScalingSpec{
+					MinReplicas: hs.MinReplicas,
+					MaxReplicas: hs.MaxReplicas,
+					Metrics:     hs.Metrics,
+					Behavior:    hs.Behavior,
+				}, "test-deployment")
 				require.NoError(t, err)
 				return hpa
 			},
@@ -143,7 +149,13 @@ func TestApplyPatchIfNonEmpty(t *testing.T) {
 				},
 			},
 			generateHPAFunc: func(t *testing.T, dataplane *operatorv1beta1.DataPlane) *autoscalingv2.HorizontalPodAutoscaler {
-				hpa, err := k8sresources.GenerateHPAForDataPlane(dataplane, "test-deployment")
+				hs := dataplane.Spec.Deployment.Scaling.HorizontalScaling
+				hpa, err := k8sresources.GenerateHPA(dataplane, &k8sresources.HPAScalingSpec{
+					MinReplicas: hs.MinReplicas,
+					MaxReplicas: hs.MaxReplicas,
+					Metrics:     hs.Metrics,
+					Behavior:    hs.Behavior,
+				}, "test-deployment")
 				require.NoError(t, err)
 				return hpa
 			},

--- a/pkg/utils/kubernetes/resources/hpas.go
+++ b/pkg/utils/kubernetes/resources/hpas.go
@@ -7,6 +7,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	pkgapisautoscalingv2 "k8s.io/kubernetes/pkg/apis/autoscaling/v2"
 
+	aigatewayv1alpha1 "github.com/kong/kong-operator/v2/api/aigateway/v1alpha1"
 	operatorv1beta1 "github.com/kong/kong-operator/v2/api/gateway-operator/v1beta1"
 	k8sutils "github.com/kong/kong-operator/v2/pkg/utils/kubernetes"
 )
@@ -48,6 +49,47 @@ func GenerateHPAForDataPlane(dataplane *operatorv1beta1.DataPlane, deploymentNam
 
 	// Set defaults for the HPA so that we don't get a diff when we compare
 	// it with what's in the cluster.
+	pkgapisautoscalingv2.SetDefaults_HorizontalPodAutoscaler(hpa)
+
+	return hpa, nil
+}
+
+// GenerateHPAForAIGatewayDataPlane generates an HPA for the given AIGatewayDataPlane.
+// The provided deploymentName is the name of the Deployment that the HPA
+// will target using its ScaleTargetRef.
+func GenerateHPAForAIGatewayDataPlane(aigwdp *aigatewayv1alpha1.AIGatewayDataPlane, deploymentName string) (
+	*autoscalingv2.HorizontalPodAutoscaler, error,
+) {
+	if aigwdp.Spec.Deployment == nil ||
+		aigwdp.Spec.Deployment.Scaling == nil ||
+		aigwdp.Spec.Deployment.Scaling.HorizontalScaling == nil {
+		return nil, fmt.Errorf("cannot generate HPA for AIGatewayDataPlane %s which doesn't have horizontal autoscaling turned on", aigwdp.Name)
+	}
+
+	labels := GetManagedLabelForOwner(aigwdp)
+	labels["app"] = aigwdp.Name
+
+	hpa := &autoscalingv2.HorizontalPodAutoscaler{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      aigwdp.Name,
+			Namespace: aigwdp.Namespace,
+			Labels:    labels,
+		},
+		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
+				APIVersion: "apps/v1",
+				Kind:       "Deployment",
+				Name:       deploymentName,
+			},
+		},
+	}
+	scaling := aigwdp.Spec.Deployment.Scaling.HorizontalScaling
+	hpa.Spec.MinReplicas = scaling.MinReplicas
+	hpa.Spec.MaxReplicas = scaling.MaxReplicas
+	hpa.Spec.Behavior = scaling.Behavior
+	hpa.Spec.Metrics = scaling.Metrics
+
+	k8sutils.SetOwnerForObject(hpa, aigwdp)
 	pkgapisautoscalingv2.SetDefaults_HorizontalPodAutoscaler(hpa)
 
 	return hpa, nil

--- a/pkg/utils/kubernetes/resources/hpas.go
+++ b/pkg/utils/kubernetes/resources/hpas.go
@@ -6,73 +6,36 @@ import (
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	pkgapisautoscalingv2 "k8s.io/kubernetes/pkg/apis/autoscaling/v2"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 
-	aigatewayv1alpha1 "github.com/kong/kong-operator/v2/api/aigateway/v1alpha1"
-	operatorv1beta1 "github.com/kong/kong-operator/v2/api/gateway-operator/v1beta1"
 	k8sutils "github.com/kong/kong-operator/v2/pkg/utils/kubernetes"
 )
 
-// GenerateHPAForDataPlane generate an HPA for the given DataPlane.
-// The provided deploymentName is the name of the Deployment that the HPA
-// will target using its ScaleTargetRef.
-func GenerateHPAForDataPlane(dataplane *operatorv1beta1.DataPlane, deploymentName string) (
-	*autoscalingv2.HorizontalPodAutoscaler, error,
-) {
-	if scaling := dataplane.Spec.Deployment.Scaling; scaling == nil || scaling.HorizontalScaling == nil {
-		return nil, fmt.Errorf("cannot generate HPA for DataPlane %s which doesn't have horizontal autoscaling turned on", dataplane.Name)
-	}
-
-	labels := GetManagedLabelForOwner(dataplane)
-	labels["app"] = dataplane.Name
-
-	hpa := &autoscalingv2.HorizontalPodAutoscaler{
-		ObjectMeta: metav1.ObjectMeta{
-			Name:      dataplane.Name,
-			Namespace: dataplane.Namespace,
-			Labels:    labels,
-		},
-		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
-			ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
-				APIVersion: "apps/v1",
-				Kind:       "Deployment",
-				Name:       deploymentName,
-			},
-		},
-	}
-	scaling := dataplane.Spec.Deployment.Scaling
-	hpa.Spec.MinReplicas = scaling.HorizontalScaling.MinReplicas
-	hpa.Spec.MaxReplicas = scaling.HorizontalScaling.MaxReplicas
-	hpa.Spec.Behavior = scaling.HorizontalScaling.Behavior
-	hpa.Spec.Metrics = scaling.HorizontalScaling.Metrics
-
-	k8sutils.SetOwnerForObject(hpa, dataplane)
-
-	// Set defaults for the HPA so that we don't get a diff when we compare
-	// it with what's in the cluster.
-	pkgapisautoscalingv2.SetDefaults_HorizontalPodAutoscaler(hpa)
-
-	return hpa, nil
+// HPAScalingSpec holds the autoscaling parameters for a HorizontalPodAutoscaler.
+// It mirrors the fields shared across all operator HorizontalScaling API types.
+type HPAScalingSpec struct {
+	MinReplicas *int32
+	MaxReplicas int32
+	Metrics     []autoscalingv2.MetricSpec
+	Behavior    *autoscalingv2.HorizontalPodAutoscalerBehavior
 }
 
-// GenerateHPAForAIGatewayDataPlane generates an HPA for the given AIGatewayDataPlane.
-// The provided deploymentName is the name of the Deployment that the HPA
-// will target using its ScaleTargetRef.
-func GenerateHPAForAIGatewayDataPlane(aigwdp *aigatewayv1alpha1.AIGatewayDataPlane, deploymentName string) (
+// GenerateHPA generates a HorizontalPodAutoscaler owned by owner that targets
+// the Deployment named deploymentName. scaling must not be nil.
+func GenerateHPA(owner client.Object, scaling *HPAScalingSpec, deploymentName string) (
 	*autoscalingv2.HorizontalPodAutoscaler, error,
 ) {
-	if aigwdp.Spec.Deployment == nil ||
-		aigwdp.Spec.Deployment.Scaling == nil ||
-		aigwdp.Spec.Deployment.Scaling.HorizontalScaling == nil {
-		return nil, fmt.Errorf("cannot generate HPA for AIGatewayDataPlane %s which doesn't have horizontal autoscaling turned on", aigwdp.Name)
+	if scaling == nil {
+		return nil, fmt.Errorf("cannot generate HPA for %s/%s: scaling spec is nil", owner.GetNamespace(), owner.GetName())
 	}
 
-	labels := GetManagedLabelForOwner(aigwdp)
-	labels["app"] = aigwdp.Name
+	labels := GetManagedLabelForOwner(owner)
+	labels["app"] = owner.GetName()
 
 	hpa := &autoscalingv2.HorizontalPodAutoscaler{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      aigwdp.Name,
-			Namespace: aigwdp.Namespace,
+			Name:      owner.GetName(),
+			Namespace: owner.GetNamespace(),
 			Labels:    labels,
 		},
 		Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
@@ -81,15 +44,16 @@ func GenerateHPAForAIGatewayDataPlane(aigwdp *aigatewayv1alpha1.AIGatewayDataPla
 				Kind:       "Deployment",
 				Name:       deploymentName,
 			},
+			MinReplicas: scaling.MinReplicas,
+			MaxReplicas: scaling.MaxReplicas,
+			Behavior:    scaling.Behavior,
+			Metrics:     scaling.Metrics,
 		},
 	}
-	scaling := aigwdp.Spec.Deployment.Scaling.HorizontalScaling
-	hpa.Spec.MinReplicas = scaling.MinReplicas
-	hpa.Spec.MaxReplicas = scaling.MaxReplicas
-	hpa.Spec.Behavior = scaling.Behavior
-	hpa.Spec.Metrics = scaling.Metrics
 
-	k8sutils.SetOwnerForObject(hpa, aigwdp)
+	k8sutils.SetOwnerForObject(hpa, owner)
+
+	// Set defaults so we don't get a diff when comparing against the cluster object.
 	pkgapisautoscalingv2.SetDefaults_HorizontalPodAutoscaler(hpa)
 
 	return hpa, nil

--- a/pkg/utils/kubernetes/resources/hpas_test.go
+++ b/pkg/utils/kubernetes/resources/hpas_test.go
@@ -9,13 +9,16 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+
+	aigatewayv1alpha1 "github.com/kong/kong-operator/v2/api/aigateway/v1alpha1"
+	"github.com/kong/kong-operator/v2/pkg/consts"
 )
 
-func testOwner() *corev1.ConfigMap {
-	return &corev1.ConfigMap{
+func testAIGWDPOwner() *aigatewayv1alpha1.AIGatewayDataPlane {
+	return &aigatewayv1alpha1.AIGatewayDataPlane{
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "v1",
-			Kind:       "ConfigMap",
+			APIVersion: aigatewayv1alpha1.SchemeGroupVersion.String(),
+			Kind:       "AIGatewayDataPlane",
 		},
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "my-owner",
@@ -27,12 +30,12 @@ func testOwner() *corev1.ConfigMap {
 
 func TestGenerateHPA(t *testing.T) {
 	t.Run("returns error when scaling is nil", func(t *testing.T) {
-		_, err := GenerateHPA(testOwner(), nil, "my-deploy")
+		_, err := GenerateHPA(testAIGWDPOwner(), nil, "my-deploy")
 		require.Error(t, err)
 	})
 
 	t.Run("sets scaleTargetRef to the given deployment name", func(t *testing.T) {
-		hpa, err := GenerateHPA(testOwner(), &HPAScalingSpec{MaxReplicas: 3}, "my-deploy")
+		hpa, err := GenerateHPA(testAIGWDPOwner(), &HPAScalingSpec{MaxReplicas: 3}, "my-deploy")
 		require.NoError(t, err)
 		assert.Equal(t, "my-deploy", hpa.Spec.ScaleTargetRef.Name)
 		assert.Equal(t, "Deployment", hpa.Spec.ScaleTargetRef.Kind)
@@ -40,7 +43,7 @@ func TestGenerateHPA(t *testing.T) {
 	})
 
 	t.Run("name and namespace match owner", func(t *testing.T) {
-		owner := testOwner()
+		owner := testAIGWDPOwner()
 		hpa, err := GenerateHPA(owner, &HPAScalingSpec{MaxReplicas: 3}, "my-deploy")
 		require.NoError(t, err)
 		assert.Equal(t, owner.Name, hpa.Name)
@@ -65,7 +68,7 @@ func TestGenerateHPA(t *testing.T) {
 				},
 			},
 		}
-		hpa, err := GenerateHPA(testOwner(), scaling, "my-deploy")
+		hpa, err := GenerateHPA(testAIGWDPOwner(), scaling, "my-deploy")
 		require.NoError(t, err)
 		assert.Equal(t, int32(2), *hpa.Spec.MinReplicas)
 		assert.Equal(t, int32(10), hpa.Spec.MaxReplicas)
@@ -73,7 +76,7 @@ func TestGenerateHPA(t *testing.T) {
 	})
 
 	t.Run("sets owner reference", func(t *testing.T) {
-		owner := testOwner()
+		owner := testAIGWDPOwner()
 		hpa, err := GenerateHPA(owner, &HPAScalingSpec{MaxReplicas: 3}, "my-deploy")
 		require.NoError(t, err)
 		require.Len(t, hpa.OwnerReferences, 1)
@@ -81,10 +84,11 @@ func TestGenerateHPA(t *testing.T) {
 		assert.Equal(t, owner.UID, hpa.OwnerReferences[0].UID)
 	})
 
-	t.Run("sets managed label", func(t *testing.T) {
-		owner := testOwner()
+	t.Run("sets app label and managed-by label", func(t *testing.T) {
+		owner := testAIGWDPOwner()
 		hpa, err := GenerateHPA(owner, &HPAScalingSpec{MaxReplicas: 3}, "my-deploy")
 		require.NoError(t, err)
 		assert.Equal(t, owner.Name, hpa.Labels["app"])
+		assert.Equal(t, consts.AIGatewayDataPlaneManagedByLabelValue, hpa.Labels[consts.GatewayOperatorManagedByLabel])
 	})
 }

--- a/pkg/utils/kubernetes/resources/hpas_test.go
+++ b/pkg/utils/kubernetes/resources/hpas_test.go
@@ -1,0 +1,90 @@
+package resources
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func testOwner() *corev1.ConfigMap {
+	return &corev1.ConfigMap{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: "v1",
+			Kind:       "ConfigMap",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "my-owner",
+			Namespace: "test-ns",
+			UID:       types.UID("test-uid"),
+		},
+	}
+}
+
+func TestGenerateHPA(t *testing.T) {
+	t.Run("returns error when scaling is nil", func(t *testing.T) {
+		_, err := GenerateHPA(testOwner(), nil, "my-deploy")
+		require.Error(t, err)
+	})
+
+	t.Run("sets scaleTargetRef to the given deployment name", func(t *testing.T) {
+		hpa, err := GenerateHPA(testOwner(), &HPAScalingSpec{MaxReplicas: 3}, "my-deploy")
+		require.NoError(t, err)
+		assert.Equal(t, "my-deploy", hpa.Spec.ScaleTargetRef.Name)
+		assert.Equal(t, "Deployment", hpa.Spec.ScaleTargetRef.Kind)
+		assert.Equal(t, "apps/v1", hpa.Spec.ScaleTargetRef.APIVersion)
+	})
+
+	t.Run("name and namespace match owner", func(t *testing.T) {
+		owner := testOwner()
+		hpa, err := GenerateHPA(owner, &HPAScalingSpec{MaxReplicas: 3}, "my-deploy")
+		require.NoError(t, err)
+		assert.Equal(t, owner.Name, hpa.Name)
+		assert.Equal(t, owner.Namespace, hpa.Namespace)
+	})
+
+	t.Run("propagates scaling fields", func(t *testing.T) {
+		minReplicas := int32(2)
+		scaling := &HPAScalingSpec{
+			MinReplicas: &minReplicas,
+			MaxReplicas: 10,
+			Metrics: []autoscalingv2.MetricSpec{
+				{
+					Type: autoscalingv2.ResourceMetricSourceType,
+					Resource: &autoscalingv2.ResourceMetricSource{
+						Name: corev1.ResourceCPU,
+						Target: autoscalingv2.MetricTarget{
+							Type:               autoscalingv2.UtilizationMetricType,
+							AverageUtilization: new(int32(50)),
+						},
+					},
+				},
+			},
+		}
+		hpa, err := GenerateHPA(testOwner(), scaling, "my-deploy")
+		require.NoError(t, err)
+		assert.Equal(t, int32(2), *hpa.Spec.MinReplicas)
+		assert.Equal(t, int32(10), hpa.Spec.MaxReplicas)
+		assert.Len(t, hpa.Spec.Metrics, 1)
+	})
+
+	t.Run("sets owner reference", func(t *testing.T) {
+		owner := testOwner()
+		hpa, err := GenerateHPA(owner, &HPAScalingSpec{MaxReplicas: 3}, "my-deploy")
+		require.NoError(t, err)
+		require.Len(t, hpa.OwnerReferences, 1)
+		assert.Equal(t, owner.Name, hpa.OwnerReferences[0].Name)
+		assert.Equal(t, owner.UID, hpa.OwnerReferences[0].UID)
+	})
+
+	t.Run("sets managed label", func(t *testing.T) {
+		owner := testOwner()
+		hpa, err := GenerateHPA(owner, &HPAScalingSpec{MaxReplicas: 3}, "my-deploy")
+		require.NoError(t, err)
+		assert.Equal(t, owner.Name, hpa.Labels["app"])
+	})
+}

--- a/test/e2e/chainsaw/aigateway/aigatewaydataplane-hpa/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/aigateway/aigatewaydataplane-hpa/chainsaw-test.yaml
@@ -1,0 +1,112 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: aigatewaydataplane-hpa
+spec:
+  description: |
+    Verifies HorizontalPodAutoscaler lifecycle for AIGatewayDataPlane.
+    1. Creates an AIGatewayDataPlane with spec.deployment.scaling.horizontal configured.
+    2. Asserts the operator reconciles an HPA that targets the owned Deployment.
+    3. Removes horizontal scaling (switches the DataPlane back to a static replica count).
+    4. Asserts the HPA is deleted so it no longer conflicts with the static replica count.
+    5. Asserts the DataPlane remains Ready throughout.
+  bindings:
+    - name: test_name
+      value: ($namespace)
+    - name: konnect_token
+      value: (env('KONNECT_TOKEN'))
+    - name: konnect_url
+      value: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
+    - name: auth_secret_name
+      value: (join('-', [($test_name), 'konnect-auth-secret']))
+    - name: auth_secret_namespace
+      value: ($namespace)
+    - name: konnect_auth_name
+      value: (join('-', [($test_name), 'konnect-api-auth']))
+    - name: konnect_auth_namespace
+      value: ($namespace)
+    - name: aigw_cp_name
+      value: (join('-', [($test_name), 'cp']))
+    - name: aigw_cp_namespace
+      value: ($namespace)
+    - name: aigw_dp_name
+      value: (join('-', [($test_name), 'dp']))
+    - name: aigw_dp_image
+      value: (env('AIGW_DP_IMAGE'))
+  steps:
+    - name: 1-Create-auth-secret
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAuthSecret.yaml
+    - name: 2-Create-konnect-api-auth
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration-secretref.yaml
+    - name: 3-Create-konnect-aigateway
+      bindings:
+        - name: auth_name
+          value: ($konnect_auth_name)
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAIGateway.yaml
+    - name: 4-Create-aigatewaydataplane-with-hpa
+      use:
+        template: ../../common/_step_templates/apply-assert-aigatewayDataPlane-hpa.yaml
+    - name: 5-Assert-HPA-created
+      description: |
+        The operator must have reconciled an HPA pointing at the owned Deployment
+        with the min/maxReplicas from spec.deployment.scaling.horizontal.
+      use:
+        template: ../../common/_step_templates/assert-aigatewaydataplane-hpa.yaml
+    - name: 6-Remove-scaling-switch-to-static-replica
+      description: |
+        Patch the DataPlane to remove horizontal scaling and restore a static
+        replica count. Setting scaling:null in the merge patch removes the field;
+        the XValidation rule allows replicas and scaling to coexist only when
+        both are absent, so the two must be changed atomically.
+      try:
+        - patch:
+            resource:
+              apiVersion: aigateway.konghq.com/v1alpha1
+              kind: AIGatewayDataPlane
+              metadata:
+                name: ($aigw_dp_name)
+                namespace: ($namespace)
+              spec:
+                deployment:
+                  scaling: null
+                  replicas: 1
+    - name: 7-Assert-HPA-deleted
+      description: |
+        Wait until the HPA is gone (the operator deletes it when scaling is removed).
+      bindings:
+        - name: resource_type
+          value: hpa
+        - name: resource_name
+          value: ($aigw_dp_name)
+        - name: resource_namespace
+          value: ($namespace)
+      use:
+        template: ../../common/_step_templates/wait-for-resource-deleted.yaml
+    - name: 8-Assert-dataplane-still-ready
+      try:
+        - assert:
+            resource:
+              apiVersion: aigateway.konghq.com/v1alpha1
+              kind: AIGatewayDataPlane
+              metadata:
+                name: ($aigw_dp_name)
+                namespace: ($namespace)
+              status:
+                (conditions[?type == 'Ready']):
+                  - status: 'True'
+                readyReplicas: 1
+  catch:
+    - description: Capture debug snapshot on test failure.
+      script:
+        env:
+          - name: TEST_NAME
+            value: aigatewaydataplane-hpa
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: OPERATOR_NAMESPACE
+            value: kong-system
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh

--- a/test/e2e/chainsaw/common/_step_templates/apply-assert-aigatewayDataPlane-hpa.yaml
+++ b/test/e2e/chainsaw/common/_step_templates/apply-assert-aigatewayDataPlane-hpa.yaml
@@ -1,0 +1,70 @@
+# Template for creating and asserting an AIGatewayDataPlane with horizontal
+# autoscaling enabled. The operator reconciles an HPA from the scaling config;
+# spec.deployment.replicas is intentionally absent because the XValidation rule
+# on DeploymentOptions forbids having both replicas and scaling set simultaneously.
+#
+# Required bindings:
+#   - aigw_dp_name:  Name of the AIGatewayDataPlane to create.
+#   - aigw_cp_name:  Name of the KonnectAIGateway it attaches to (same namespace).
+#   - namespace:     Namespace where the AIGatewayDataPlane will be created.
+#   - aigw_dp_image: AI Gateway data plane container image.
+#
+# Optional bindings (override to customise HPA bounds):
+#   - hpa_min_replicas: Minimum replicas for the HPA (default: 1).
+#   - hpa_max_replicas: Maximum replicas for the HPA (default: 3).
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: StepTemplate
+metadata:
+  name: apply-assert-aigateway-dataplane-hpa
+spec:
+  bindings:
+    - name: hpa_min_replicas
+      value: 1
+    - name: hpa_max_replicas
+      value: 3
+  try:
+    - apply:
+        resource:
+          apiVersion: aigateway.konghq.com/v1alpha1
+          kind: AIGatewayDataPlane
+          metadata:
+            name: ($aigw_dp_name)
+            namespace: ($namespace)
+          spec:
+            controlPlaneRef:
+              type: konnectNamespacedRef
+              konnectNamespacedRef:
+                name: ($aigw_cp_name)
+            deployment:
+              scaling:
+                horizontal:
+                  minReplicas: ($hpa_min_replicas)
+                  maxReplicas: ($hpa_max_replicas)
+              podTemplateSpec:
+                spec:
+                  containers:
+                    - name: aigw
+                      image: ($aigw_dp_image)
+            network:
+              services:
+                ingress:
+                  type: LoadBalancer
+                  ports:
+                    - name: ingress
+                      port: 443
+                      targetPort: 8443
+    - assert:
+        resource:
+          apiVersion: aigateway.konghq.com/v1alpha1
+          kind: AIGatewayDataPlane
+          metadata:
+            name: ($aigw_dp_name)
+            namespace: ($namespace)
+          status:
+            (conditions[?type == 'ServiceReady']):
+              - status: 'True'
+            (conditions[?type == 'Ready']):
+              - status: 'True'
+            (readyReplicas > `0`): true
+            (addresses[0].value != null): true
+            (addresses[0].value != ''): true

--- a/test/e2e/chainsaw/common/_step_templates/assert-aigatewaydataplane-hpa.yaml
+++ b/test/e2e/chainsaw/common/_step_templates/assert-aigatewaydataplane-hpa.yaml
@@ -1,0 +1,35 @@
+# Template for asserting that the operator reconciled a HorizontalPodAutoscaler
+# for an AIGatewayDataPlane.
+#
+# Required bindings:
+#   - aigw_dp_name: Name of the AIGatewayDataPlane (and its owned HPA).
+#   - namespace:    Namespace to look in.
+#
+# Optional bindings (must match what was set in apply-assert-aigatewayDataPlane-hpa):
+#   - hpa_min_replicas: Expected minReplicas on the HPA (default: 1).
+#   - hpa_max_replicas: Expected maxReplicas on the HPA (default: 3).
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: StepTemplate
+metadata:
+  name: assert-aigateway-dataplane-hpa
+spec:
+  bindings:
+    - name: hpa_min_replicas
+      value: 1
+    - name: hpa_max_replicas
+      value: 3
+  try:
+    - assert:
+        resource:
+          apiVersion: autoscaling/v2
+          kind: HorizontalPodAutoscaler
+          metadata:
+            name: ($aigw_dp_name)
+            namespace: ($namespace)
+          spec:
+            scaleTargetRef:
+              apiVersion: apps/v1
+              kind: Deployment
+              name: ($aigw_dp_name)
+            minReplicas: ($hpa_min_replicas)
+            maxReplicas: ($hpa_max_replicas)

--- a/test/e2e/chainsaw/common/_step_templates/wait-for-resource-deleted.yaml
+++ b/test/e2e/chainsaw/common/_step_templates/wait-for-resource-deleted.yaml
@@ -1,0 +1,32 @@
+# Template for waiting until a Kubernetes resource is fully deleted.
+# Uses kubectl wait --for=delete so the step blocks until the API server
+# confirms the object is gone.
+#
+# Required bindings:
+#   - resource_type:      Kubernetes resource type (e.g. "hpa", "deployment").
+#   - resource_name:      Name of the resource to wait for deletion.
+#   - resource_namespace: Namespace where the resource lives.
+#
+# Optional bindings:
+#   - timeout: Timeout in seconds (default: 300).
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: StepTemplate
+metadata:
+  name: wait-for-resource-deleted
+spec:
+  bindings:
+    - name: timeout
+      value: "300"
+  try:
+    - script:
+        env:
+          - name: RESOURCE_TYPE
+            value: ($resource_type)
+          - name: RESOURCE_NAME
+            value: ($resource_name)
+          - name: NAMESPACE
+            value: ($resource_namespace)
+          - name: TIMEOUT
+            value: ($timeout)
+        content: |
+          bash ../../common/scripts/wait_for_resource_deleted.sh

--- a/test/e2e/chainsaw/common/scripts/wait_for_resource_deleted.sh
+++ b/test/e2e/chainsaw/common/scripts/wait_for_resource_deleted.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+# Abort on nonzero exit status, unbound variable, and pipefail.
+set -o errexit
+set -o nounset
+set -o pipefail
+
+# Variables (from environment):
+#   RESOURCE_TYPE: Kubernetes resource type (e.g. hpa, deployment, service).
+#   RESOURCE_NAME: Name of the resource to wait for deletion.
+#   NAMESPACE:     Namespace of the resource.
+#   TIMEOUT:       (Optional) Timeout in seconds. Default: 300.
+
+TIMEOUT="${TIMEOUT:-300}"
+
+kubectl wait --for=delete "${RESOURCE_TYPE}/${RESOURCE_NAME}" \
+  -n "${NAMESPACE}" \
+  --timeout="${TIMEOUT}s"

--- a/test/envtest/aigateway_dataplane_controller_test.go
+++ b/test/envtest/aigateway_dataplane_controller_test.go
@@ -225,7 +225,7 @@ func waitForAIGWHPA(t *testing.T, ctx context.Context, cl client.Client, ns, aig
 	t.Helper()
 	var hpaList autoscalingv2.HorizontalPodAutoscalerList
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
-		assert.NoError(ct, cl.List(ctx, &hpaList, client.InNamespace(ns), client.MatchingLabels{consts.GatewayOperatorManagedByNameLabel: aigwdpName}))
+		assert.NoError(ct, cl.List(ctx, &hpaList, client.InNamespace(ns), client.MatchingLabels{"app": aigwdpName}))
 		assert.Len(ct, hpaList.Items, 1)
 	}, waitTime, tickTime)
 	require.Len(t, hpaList.Items, 1)
@@ -237,7 +237,7 @@ func waitForNoAIGWHPA(t *testing.T, ctx context.Context, cl client.Client, ns, a
 	t.Helper()
 	require.EventuallyWithT(t, func(ct *assert.CollectT) {
 		var hpaList autoscalingv2.HorizontalPodAutoscalerList
-		assert.NoError(ct, cl.List(ctx, &hpaList, client.InNamespace(ns), client.MatchingLabels{consts.GatewayOperatorManagedByNameLabel: aigwdpName}))
+		assert.NoError(ct, cl.List(ctx, &hpaList, client.InNamespace(ns), client.MatchingLabels{"app": aigwdpName}))
 		assert.Empty(ct, hpaList.Items)
 	}, waitTime, tickTime)
 }
@@ -293,9 +293,10 @@ func TestAIGatewayDataPlaneReconciler_HPA(t *testing.T) {
 		assert.Equal(t, maxReplicas, hpa.Spec.MaxReplicas)
 		assert.Equal(t, aigwdp.Name, hpa.Spec.ScaleTargetRef.Name)
 
-		// Deployment must not manage spec.replicas when HPA is active (SSA ownership handed off).
-		deploy := waitForAIGWDeployment(t, ctx, cl, ns.Name, aigwdp.Name)
-		assert.Nil(t, deploy.Spec.Replicas, "spec.replicas must be absent when HPA owns scaling")
+		// Verify the Deployment was created. The replica guard (omitting spec.replicas from
+		// the SSA patch when HPA is active) is covered by TestGenerateBaseDeployment_ReplicaGuard;
+		// the API server defaults spec.replicas to 1 so it is never nil in the stored object.
+		waitForAIGWDeployment(t, ctx, cl, ns.Name, aigwdp.Name)
 	})
 
 	t.Run("HPA is deleted when scaling is removed", func(t *testing.T) {

--- a/test/envtest/aigateway_dataplane_controller_test.go
+++ b/test/envtest/aigateway_dataplane_controller_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -217,6 +218,152 @@ func updateKonnectAIGatewayStatusWithProgrammed(
 		}
 		assert.NoError(ct, cl.Status().Update(ctx, aigwcp))
 	}, waitTime, tickTime)
+}
+
+// waitForAIGWHPA waits for exactly one HPA owned by the given AIGatewayDataPlane and returns it.
+func waitForAIGWHPA(t *testing.T, ctx context.Context, cl client.Client, ns, aigwdpName string) autoscalingv2.HorizontalPodAutoscaler {
+	t.Helper()
+	var hpaList autoscalingv2.HorizontalPodAutoscalerList
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		assert.NoError(ct, cl.List(ctx, &hpaList, client.InNamespace(ns), client.MatchingLabels{consts.GatewayOperatorManagedByNameLabel: aigwdpName}))
+		assert.Len(ct, hpaList.Items, 1)
+	}, waitTime, tickTime)
+	require.Len(t, hpaList.Items, 1)
+	return hpaList.Items[0]
+}
+
+// waitForNoAIGWHPA asserts that no HPA owned by the given AIGatewayDataPlane exists.
+func waitForNoAIGWHPA(t *testing.T, ctx context.Context, cl client.Client, ns, aigwdpName string) {
+	t.Helper()
+	require.EventuallyWithT(t, func(ct *assert.CollectT) {
+		var hpaList autoscalingv2.HorizontalPodAutoscalerList
+		assert.NoError(ct, cl.List(ctx, &hpaList, client.InNamespace(ns), client.MatchingLabels{consts.GatewayOperatorManagedByNameLabel: aigwdpName}))
+		assert.Empty(ct, hpaList.Items)
+	}, waitTime, tickTime)
+}
+
+// TestAIGatewayDataPlaneReconciler_HPA verifies the full HPA lifecycle:
+// create when scaling is configured, update on spec change, delete when scaling is removed.
+func TestAIGatewayDataPlaneReconciler_HPA(t *testing.T) {
+	t.Parallel()
+
+	ctx := t.Context()
+	cfg, ns := Setup(t, ctx, scheme.Get(), WithInstallGatewayCRDs(true))
+	mgr, logs := NewManager(t, ctx, cfg, scheme.Get())
+
+	clusterCA := createClusterCASecret(t, ctx, mgr.GetClient(), ns.Name, "aigw-cluster-ca-hpa")
+
+	ssaProvider, err := controllerpkgssa.NewTypeConverterProvider(ctx, mgr.GetLogger(), mgr, aigwCRDGroups)
+	require.NoError(t, err)
+
+	StartReconcilers(ctx, t, mgr, logs,
+		&aigwdataplane.Reconciler{
+			Client:                   mgr.GetClient(),
+			ClusterCASecretName:      clusterCA.Name,
+			ClusterCASecretNamespace: clusterCA.Namespace,
+			CertTTL:                  consts.DefaultCertTTL,
+			TypeConverter:            ssaProvider,
+		},
+		&crdschema.Reconciler{
+			Client:   mgr.GetClient(),
+			Provider: ssaProvider,
+		},
+	)
+
+	cl := mgr.GetClient()
+	maxReplicas := int32(5)
+
+	t.Run("HPA is created when horizontal scaling is configured", func(t *testing.T) {
+		t.Parallel()
+
+		aigwdp := setupProgrammedAIGWDP(t, ctx, cl, ns.Name,
+			"aigwcp-hpa-create", "konnect-id-hpa-create", "aigwdp-hpa-create",
+			aigatewayv1alpha1.AIGatewayDataPlaneSpec{
+				Deployment: &aigatewayv1alpha1.DeploymentOptions{
+					Scaling: &aigatewayv1alpha1.Scaling{
+						HorizontalScaling: &aigatewayv1alpha1.HorizontalScaling{
+							MaxReplicas: maxReplicas,
+						},
+					},
+				},
+			},
+		)
+
+		hpa := waitForAIGWHPA(t, ctx, cl, ns.Name, aigwdp.Name)
+		assert.Equal(t, maxReplicas, hpa.Spec.MaxReplicas)
+		assert.Equal(t, aigwdp.Name, hpa.Spec.ScaleTargetRef.Name)
+
+		// Deployment must not manage spec.replicas when HPA is active (SSA ownership handed off).
+		deploy := waitForAIGWDeployment(t, ctx, cl, ns.Name, aigwdp.Name)
+		assert.Nil(t, deploy.Spec.Replicas, "spec.replicas must be absent when HPA owns scaling")
+	})
+
+	t.Run("HPA is deleted when scaling is removed", func(t *testing.T) {
+		t.Parallel()
+
+		aigwdp := setupProgrammedAIGWDP(t, ctx, cl, ns.Name,
+			"aigwcp-hpa-delete", "konnect-id-hpa-delete", "aigwdp-hpa-delete",
+			aigatewayv1alpha1.AIGatewayDataPlaneSpec{
+				Deployment: &aigatewayv1alpha1.DeploymentOptions{
+					Scaling: &aigatewayv1alpha1.Scaling{
+						HorizontalScaling: &aigatewayv1alpha1.HorizontalScaling{
+							MaxReplicas: maxReplicas,
+						},
+					},
+				},
+			},
+		)
+
+		// Wait for HPA to be created.
+		_ = waitForAIGWHPA(t, ctx, cl, ns.Name, aigwdp.Name)
+
+		// Remove scaling from the spec.
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			if !assert.NoError(ct, cl.Get(ctx, client.ObjectKeyFromObject(aigwdp), aigwdp)) {
+				return
+			}
+			aigwdp.Spec.Deployment = nil
+			assert.NoError(ct, cl.Update(ctx, aigwdp))
+		}, waitTime, tickTime)
+
+		waitForNoAIGWHPA(t, ctx, cl, ns.Name, aigwdp.Name)
+	})
+
+	t.Run("HPA spec is updated when maxReplicas changes", func(t *testing.T) {
+		t.Parallel()
+
+		aigwdp := setupProgrammedAIGWDP(t, ctx, cl, ns.Name,
+			"aigwcp-hpa-update", "konnect-id-hpa-update", "aigwdp-hpa-update",
+			aigatewayv1alpha1.AIGatewayDataPlaneSpec{
+				Deployment: &aigatewayv1alpha1.DeploymentOptions{
+					Scaling: &aigatewayv1alpha1.Scaling{
+						HorizontalScaling: &aigatewayv1alpha1.HorizontalScaling{
+							MaxReplicas: maxReplicas,
+						},
+					},
+				},
+			},
+		)
+
+		_ = waitForAIGWHPA(t, ctx, cl, ns.Name, aigwdp.Name)
+
+		// Update maxReplicas to 10.
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			if !assert.NoError(ct, cl.Get(ctx, client.ObjectKeyFromObject(aigwdp), aigwdp)) {
+				return
+			}
+			aigwdp.Spec.Deployment.Scaling.HorizontalScaling.MaxReplicas = 10
+			assert.NoError(ct, cl.Update(ctx, aigwdp))
+		}, waitTime, tickTime)
+
+		require.EventuallyWithT(t, func(ct *assert.CollectT) {
+			var hpa autoscalingv2.HorizontalPodAutoscaler
+			if !assert.NoError(ct, cl.Get(ctx, client.ObjectKey{Name: aigwdp.Name, Namespace: ns.Name}, &hpa)) {
+				return
+			}
+			assert.Equal(ct, int32(10), hpa.Spec.MaxReplicas)
+		}, waitTime, tickTime)
+	})
 }
 
 // updateAIGatewayDataPlaneCertificateStatusWithProgrammed flips the owned


### PR DESCRIPTION

**What this PR does / why we need it**:

The operator now creates, updates, and deletes a HorizontalPodAutoscaler based on the horizontal scaling configuration. When HPA is active, spec.replicas is omitted from the SSA Deployment patch so the HPA controller owns the replica count.

Adds RBAC, unit tests, envtest tests, and a Chainsaw E2E test.

Part of #5339 

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
