### PR TITLE
test(e2e): re-enable eventgateway chainsaw suite

### DIFF
--- a/.github/workflows/__e2e_chainsaw_tests.yaml
+++ b/.github/workflows/__e2e_chainsaw_tests.yaml
@@ -33,9 +33,7 @@ jobs:
         - hybridgateway
         - konnect
         - aigateway
-        # TODO: fix eventgateway suite and re-enable it in the matrix once they are stable again.
-        # TODO: https://github.com/Kong/kong-operator/issues/4757
-        # - eventgateway
+        - eventgateway
     steps:
     - name: Harden Runner
       uses: step-security/harden-runner@05e31511f85b41b11d1cf0ef85d0992719546e2c # v2.21.0

--- a/Makefile
+++ b/Makefile
@@ -872,6 +872,7 @@ test.e2e.chainsaw.prereq.uninstall:
 test.e2e.chainsaw: chainsaw grpcurl ## Run chainsaw e2e tests.
 	GATEWAY_IMAGE=$(shell $(YQ) -r '.chainsaw.kong-ee | .image + ":" + .tag' < $(TEST_DEPENDENCIES_FILE)) \
 	AIGW_DP_IMAGE=$(shell $(YQ) -r '.chainsaw.aigw-dp | .image + ":" + .tag' < $(TEST_DEPENDENCIES_FILE)) \
+	KEG_DP_IMAGE=$(shell $(YQ) -r '.chainsaw.keg-dp | .image + ":" + .tag' < $(TEST_DEPENDENCIES_FILE)) \
 	GRPCURL_BIN=$(GRPCURL) \
 		$(CHAINSAW) test --config $(CHAINSAW_CONFIG) --quiet --test-dir $(CHAINSAW_TEST_DIR)
 

--- a/test/e2e/chainsaw/eventgateway/sni-routing/03-tls-server-policy.yaml
+++ b/test/e2e/chainsaw/eventgateway/sni-routing/03-tls-server-policy.yaml
@@ -25,8 +25,10 @@ spec:
               secretRef:
                 name: ($tls_secret_name)
                 namespace: ($namespace)
+                key: tls.crt
             key:
               type: secretRef
               secretRef:
                 name: ($tls_secret_name)
                 namespace: ($namespace)
+                key: tls.key

--- a/test/test_dependencies.yaml
+++ b/test/test_dependencies.yaml
@@ -34,3 +34,7 @@ chainsaw:
     image: kong/kong-ai-gateway-dev
     # renovate: datasource=docker depName=kong/kong-ai-gateway-dev versioning=docker
     tag: '2.0.2-rc.3'
+  keg-dp:
+    image: kong/kong-event-gateway
+    # renovate: datasource=docker depName=kong/kong-event-gateway versioning=docker
+    tag: '1.2.1'


### PR DESCRIPTION


**What this PR does / why we need it**:

Re-enable the eventgateway suite in the E2E chainsaw matrix (disabled in

- Add keg-dp entry to test_dependencies.yaml for Renovate tracking
- Expose KEG_DP_IMAGE in the test.e2e.chainsaw Makefile target
- Fix 03-tls-server-policy.yaml: add required `key` field to secretRef (SensitiveDataSecretRef.Key became required in bbde47ae)

**Which issue this PR fixes**

Fixes #4757

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
