### PR TITLE
[Backport release/2.2.x] fix: fix kongroute created without updating kongservice hybrid-route annotation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -61,6 +61,9 @@
   Kong resource no longer overwrite each other's references and continuously
   reapply the resource.
   [#4944](https://github.com/Kong/kong-operator/pull/4944)
+- HybridGateway: fix KongRoute created without updating KongService's
+  `hybrid-routes` annotation.
+  [#5136](https://github.com/Kong/kong-operator/pull/5136)
 - HybridGateway: shared Kong resources now converge when referenced by Routes
   attached to multiple Gateways, and SSA no-op detection correctly handles
   preserve-unknown fields. This prevents repeated apply loops from blocking

--- a/controller/hybridgateway/reconciler_utils.go
+++ b/controller/hybridgateway/reconciler_utils.go
@@ -201,11 +201,27 @@ func enforceState[t converter.RootObject](ctx context.Context, cl client.Client,
 					stopAtKind = "KongService"
 					continue
 				}
+				// if KongService is deleting, regard this dependency is not available
+				if !svc.GetDeletionTimestamp().IsZero() {
+					log.Debug(logger, "Service is being deleted for route, waiting", "service", svcName)
+					objectsSkipped++
+					stopAtKind = "KongService"
+					continue
+				}
 				if !k8sutils.HasConditionTrue(konnectv1alpha1.KonnectEntityProgrammedConditionType, &svc) {
 					log.Debug(logger, "Service not Programmed yet for route, waiting", "service", svcName)
 					objectsSkipped++
 					stopAtKind = "KongService"
 					continue
+				}
+				// ensure routeRef added into KongService's annotation, see https://github.com/Kong/kong-operator/issues/5133 for more.
+				if routeAnnotationKey != "" && !hybridRouteAnnotationContains(svc.GetAnnotations(), routeAnnotationKey, routeRef) {
+					if err := ensureHybridRouteAnnotationOnKongService(ctx, cl, &svc, routeAnnotationKey, routeRef); err != nil {
+						return false, false, fmt.Errorf("failed to update referenced KongService %s/%s hybrid-routes annotation before applying KongRoute %s: %w",
+							svc.GetNamespace(), svc.GetName(), desired.GetName(), err)
+					}
+					log.Debug(logger, "Updated referenced KongService hybrid-routes annotation before applying KongRoute",
+						"service", svcName, "route", desired.GetName())
 				}
 			}
 		case "KongPluginBinding":
@@ -460,6 +476,37 @@ func mergeCommaSeparatedValues(values ...string) string {
 	}
 	slices.Sort(merged)
 	return strings.Join(merged, ",")
+}
+
+// ensureHybridRouteAnnotationOnKongService checks if routeRef existed in KongService's annos with key annotationKey,
+// and adds it if not.
+func ensureHybridRouteAnnotationOnKongService(
+	ctx context.Context,
+	cl client.Client,
+	svc *configurationv1alpha1.KongService,
+	annotationKey, routeRef string,
+) error {
+	base := svc.DeepCopy()
+	anns := svc.GetAnnotations()
+	if anns == nil {
+		anns = map[string]string{}
+	}
+
+	current := anns[annotationKey]
+	if hybridRouteAnnotationContains(anns, annotationKey, routeRef) {
+		return nil
+	}
+	anns[annotationKey] = mergeCommaSeparatedValues(current, routeRef)
+	svc.SetAnnotations(anns)
+
+	return cl.Patch(ctx, svc, client.MergeFromWithOptions(base, client.MergeFromWithOptimisticLock{}))
+}
+
+func hybridRouteAnnotationContains(anns map[string]string, annotationKey, routeRef string) bool {
+	if len(anns) == 0 {
+		return false
+	}
+	return strings.Contains(","+anns[annotationKey]+",", ","+routeRef+",")
 }
 
 // enforceStatus updates the status of the root object managed by the provided APIConverter.

--- a/controller/hybridgateway/reconciler_utils_test.go
+++ b/controller/hybridgateway/reconciler_utils_test.go
@@ -2089,6 +2089,125 @@ func TestEnforceState_UpstreamGating(t *testing.T) {
 	}
 }
 
+func TestEnforceState_KongRouteRequiresLiveServiceRouteAnnotation(t *testing.T) {
+	ctx := t.Context()
+	logger := logr.Discard()
+	s := scheme.Get()
+	ns := "ns"
+	root := gwtypes.HTTPRoute{
+		TypeMeta:   metav1.TypeMeta{APIVersion: gatewayv1.GroupVersion.String(), Kind: "HTTPRoute"},
+		ObjectMeta: metav1.ObjectMeta{Name: "httproute-owner", Namespace: ns},
+	}
+	routeRef := ns + "/httproute-owner"
+
+	programmedCondition := metav1.Condition{
+		Type:               "Programmed",
+		Status:             metav1.ConditionTrue,
+		Reason:             "Programmed",
+		LastTransitionTime: metav1.Now(),
+	}
+
+	svcGVK := schema.GroupVersionKind{Group: "configuration.konghq.com", Version: "v1alpha1", Kind: "KongService"}
+	routeGVK := schema.GroupVersionKind{Group: "configuration.konghq.com", Version: "v1alpha1", Kind: "KongRoute"}
+
+	makeDesiredService := func(name string) unstructured.Unstructured {
+		u := newUnstructured(ns, name, svcGVK, nil)
+		_ = unstructured.SetNestedField(u.Object, "example.com", "spec", "host")
+		_ = unstructured.SetNestedField(u.Object, int64(80), "spec", "port")
+		_ = unstructured.SetNestedField(u.Object, "httproute", "spec", "protocol")
+		u.SetAnnotations(map[string]string{
+			consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: "ns/other-route," + routeRef,
+		})
+		return u
+	}
+	makeDesiredRoute := func(name, serviceName string) unstructured.Unstructured {
+		u := newUnstructured(ns, name, routeGVK, nil)
+		_ = unstructured.SetNestedField(u.Object, map[string]any{
+			"namespacedRef": map[string]any{"name": serviceName},
+		}, "spec", "serviceRef")
+		return u
+	}
+	makeProgrammedService := func(name string, annotation string) *configurationv1alpha1.KongService {
+		svc := &configurationv1alpha1.KongService{}
+		svc.SetName(name)
+		svc.SetNamespace(ns)
+		svc.SetAnnotations(map[string]string{
+			consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation: annotation,
+		})
+		svc.Status.Conditions = []metav1.Condition{programmedCondition}
+		return svc
+	}
+
+	desired := []unstructured.Unstructured{
+		makeDesiredService("svc1"),
+		makeDesiredRoute("route1", "svc1"),
+		makeDesiredService("svc2"),
+		makeDesiredRoute("route2", "svc2"),
+	}
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(
+			makeProgrammedService("svc1", routeRef),
+			makeProgrammedService("svc2", "ns/other-route"),
+		).
+		Build()
+
+	conv := &fakeHTTPRouteConverter{desired: desired, root: root}
+	applied, waiting, err := enforceState(ctx, cl, logger, conv)
+	require.NoError(t, err)
+	assert.True(t, applied)
+	assert.True(t, waiting)
+
+	var svc2 configurationv1alpha1.KongService
+	require.NoError(t, cl.Get(ctx, client.ObjectKey{Namespace: ns, Name: "svc2"}, &svc2))
+	assert.Equal(t, routeRef+",ns/other-route", svc2.GetAnnotations()[consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation])
+
+	var route2 configurationv1alpha1.KongRoute
+	require.NoError(t, cl.Get(ctx, client.ObjectKey{Namespace: ns, Name: "route2"}, &route2))
+}
+
+func TestEnsureHybridRouteAnnotationOnKongService_Idempotent(t *testing.T) {
+	ctx := t.Context()
+	s := scheme.Get()
+	ns := "ns"
+	annotationKey := consts.GatewayOperatorHybridRoutesHTTPRouteAnnotation
+	routeRef := ns + "/httproute-owner"
+
+	svc := &configurationv1alpha1.KongService{}
+	svc.SetName("svc1")
+	svc.SetNamespace(ns)
+	svc.SetAnnotations(map[string]string{
+		annotationKey: "ns/other-route",
+	})
+
+	cl := fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(svc).
+		Build()
+
+	// First call adds routeRef to the annotation.
+	require.NoError(t, ensureHybridRouteAnnotationOnKongService(ctx, cl, svc, annotationKey, routeRef))
+	assert.Equal(t, routeRef+",ns/other-route", svc.GetAnnotations()[annotationKey])
+
+	var got configurationv1alpha1.KongService
+	require.NoError(t, cl.Get(ctx, client.ObjectKey{Namespace: ns, Name: "svc1"}, &got))
+	assert.Equal(t, routeRef+",ns/other-route", got.GetAnnotations()[annotationKey])
+
+	// Second call with the already-annotated object is a no-op: no duplicate
+	// entry, no patch against a stale resourceVersion.
+	require.NoError(t, ensureHybridRouteAnnotationOnKongService(ctx, cl, svc, annotationKey, routeRef))
+	assert.Equal(t, routeRef+",ns/other-route", svc.GetAnnotations()[annotationKey])
+
+	// Calling again with a freshly-fetched copy (simulating a re-reconcile)
+	// must also be a no-op and must not error out on the optimistic lock.
+	require.NoError(t, ensureHybridRouteAnnotationOnKongService(ctx, cl, &got, annotationKey, routeRef))
+	assert.Equal(t, routeRef+",ns/other-route", got.GetAnnotations()[annotationKey])
+
+	var final configurationv1alpha1.KongService
+	require.NoError(t, cl.Get(ctx, client.ObjectKey{Namespace: ns, Name: "svc1"}, &final))
+	assert.Equal(t, routeRef+",ns/other-route", final.GetAnnotations()[annotationKey])
+}
+
 // fakeHTTPRouteConverterWithHandleErr wraps fakeHTTPRouteConverter and returns an error
 // from HandleOrphanedResource so we can test error propagation in cleanOrphanedResources.
 type fakeHTTPRouteConverterWithHandleErr struct {


### PR DESCRIPTION
**What this PR does / why we need it**:

Backport #5136 to `release/2.2.x`.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes