### PR TITLE
test: support creating ipv6only clusters

### DIFF
--- a/test/conformance/suite_test.go
+++ b/test/conformance/suite_test.go
@@ -81,6 +81,15 @@ func TestMain(m *testing.M) {
 	// that would allow e.g. cross namespace traffic.
 	// Related upstream discussion: https://github.com/kubernetes-sigs/gateway-api/discussions/2137
 	env, err = testutils.BuildEnvironment(ctx, existingCluster, func(b *environments.Builder, t clusters.Type) {
+		if existingCluster == "" {
+			switch ipFamily := test.ClusterIPFamily(); ipFamily {
+			case clusters.IPv6:
+				b.WithIPv6Only()
+			case clusters.Dual:
+				exitOnErr(fmt.Errorf("dual-stack test clusters are not yet supported (KONG_TEST_CLUSTER_IP_FAMILY=dual)"))
+			case clusters.IPv4:
+			}
+		}
 		if !test.IsMetalLBDisabled() {
 			b.WithAddons(metallb.New())
 		}

--- a/test/e2e/environment.go
+++ b/test/e2e/environment.go
@@ -116,6 +116,13 @@ func CreateEnvironment(t *testing.T, ctx context.Context) TestEnvironment {
 		}
 	} else {
 		t.Log("no existing cluster found, deploying using Kubernetes In Docker (KIND)")
+		switch ipFamily := test.ClusterIPFamily(); ipFamily {
+		case clusters.IPv6:
+			builder.WithIPv6Only()
+		case clusters.Dual:
+			t.Fatal("dual-stack test clusters are not yet supported (KONG_TEST_CLUSTER_IP_FAMILY=dual)")
+		case clusters.IPv4:
+		}
 		if !test.IsCertManagerDisabled() {
 			builder.WithAddons(certmanager.New())
 		}

--- a/test/envvars.go
+++ b/test/envvars.go
@@ -5,6 +5,8 @@ import (
 	"os"
 	"strings"
 
+	"github.com/kong/kubernetes-testing-framework/pkg/clusters"
+
 	"github.com/kong/kong-operator/v2/pkg/consts"
 )
 
@@ -39,6 +41,37 @@ func IsMetalLBDisabled() bool {
 		fmt.Println("INFO: MetalLB plugin is enabled")
 	}
 	return ret
+}
+
+// ClusterIPFamily returns the IP family a newly created KIND test cluster
+// should be configured with. It reads the KONG_TEST_CLUSTER_IP_FAMILY
+// environment variable ("ipv4", "ipv6", or "dual"), defaulting to
+// clusters.IPv4 when unset or unrecognized.
+//
+// This only takes effect when a new KIND cluster is created: KTF does not
+// currently support configuring a non-default IP family on an existing
+// cluster (see KONG_TEST_CLUSTER), so the setting is ignored in that case.
+//
+// clusters.Dual is not yet wired up to an actual dual-stack KIND cluster
+// build (tracked in https://github.com/Kong/kong-operator/issues/5448) -
+// callers must reject it explicitly rather than silently falling back to
+// IPv4 or IPv6-only.
+func ClusterIPFamily() clusters.IPFamily {
+	raw := strings.ToLower(os.Getenv("KONG_TEST_CLUSTER_IP_FAMILY"))
+	var family clusters.IPFamily
+	switch raw {
+	case "ipv6":
+		family = clusters.IPv6
+	case "dual":
+		family = clusters.Dual
+	case "", "ipv4":
+		family = clusters.IPv4
+	default:
+		fmt.Printf("WARNING: unknown KONG_TEST_CLUSTER_IP_FAMILY %q, defaulting to %s\n", raw, clusters.IPv4)
+		family = clusters.IPv4
+	}
+	fmt.Printf("INFO: test cluster IP family is %s\n", family)
+	return family
 }
 
 // IsInstallingCRDsDisabled returns true if installing CRDs is disabled in the test environment.

--- a/test/integration/suite.go
+++ b/test/integration/suite.go
@@ -115,7 +115,21 @@ func Suite(m *testing.M, opts ...SuiteOption) {
 	fmt.Println("INFO: configuring cluster for testing environment")
 	env, err = testutils.BuildEnvironment(GetCtx(), existingCluster,
 		func(b *environments.Builder, ct clusters.Type) {
-			if !test.IsCalicoCNIDisabled() {
+			ipFamily := clusters.IPv4
+			if existingCluster == "" {
+				ipFamily = test.ClusterIPFamily()
+			}
+			switch ipFamily {
+			case clusters.IPv6:
+				b.WithIPv6Only()
+			case clusters.Dual:
+				exitOnErr(fmt.Errorf("dual-stack test clusters are not yet supported (KONG_TEST_CLUSTER_IP_FAMILY=dual)"))
+			case clusters.IPv4:
+			}
+			// Calico's default manifest hardcodes an IPv4 pool CIDR, which breaks
+			// pod networking on an IPv6-only cluster. KIND's default CNI already
+			// supports IPv6-only clusters, so skip Calico in that case.
+			if !test.IsCalicoCNIDisabled() && ipFamily != clusters.IPv6 {
 				b.WithCalicoCNI()
 			}
 			if !test.IsCertManagerDisabled() {


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR enabled tests to create ipv6-only clusters with env `KONG_TEST_CLUSTER_IP_FAMILY`

**Which issue this PR fixes**

Fixes #5348 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
