### PR TITLE
ci(muthur): pin ksai scripts to action tag

### DIFF
--- a/.github/workflows/muthur.yaml
+++ b/.github/workflows/muthur.yaml
@@ -9,9 +9,9 @@ name: Muthur
 #
 # kong-operator is public and Kong/ksai is internal, so ksai actions are checked out locally
 # via sparse-checkout and referenced by path rather than by a remote `uses:`, which GitHub
-# won't resolve from a public repo into a private one. codeowners-authz, ai-reviewer-federated
-# and the kreview plugin each version independently in Kong/ksai, so each is pinned to its own
-# release tag, bumped by Renovate.
+# won't resolve from a public repo into a private one. codeowners-authz and ai-reviewer-federated
+# version independently in Kong/ksai, so each is pinned to its own release tag, bumped by
+# Renovate. The kreview plugin and the trusted scripts are read from the reviewer's own tag.
 
 on:
   issue_comment:
@@ -108,10 +108,14 @@ jobs:
             .github/actions/ai-reviewer-federated
           persist-credentials: false
 
-      # A local-path action has no github.action_ref, so it can no longer default the
-      # kreview plugin checkout to its own ref: ksai_ref pins the plugin explicitly instead.
+      # A local-path action has no github.action_ref, so it cannot default its plugin and
+      # trusted-scripts checkout to its own ref: ksai_ref has to name that ref explicitly.
+      # Left unset the action resolves an empty ref, which actions/checkout reads as Kong/ksai's
+      # default branch - so the action stays pinned while the scripts it loads track main, and
+      # any change there breaks this workflow with no change here.
       - uses: ./_ksai-review/.github/actions/ai-reviewer-federated
         with:
+          ksai_ref: ${{ env.AI_REVIEWER_FEDERATED_REF }}
           trigger_phrase: "/muthur"
           # GITHUB_TOKEN checks out the PR head, reacts, and posts the review comment.
           source_org_github_token: ${{ github.token }}


### PR DESCRIPTION
**What this PR does / why we need it**:

`/muthur` has failed on every run since Aug 31 with `TypeError: ownsVerb is not a function`.

Kong/ksai is internal and this repo is public, so the reviewer action is checked out and run by local path. A local-path action gets no `github.action_ref`, and that is exactly what the action falls back on when `ksai_ref` is unset. It therefore resolved an empty ref, which `actions/checkout` reads as Kong/ksai's default branch. So since #5361 dropped `ksai_ref`, the action has been pinned at `v1.17.5` while the trusted scripts it loads came from `main`. A function rename on `main` on Aug 31 broke the pair 45 minutes later.

Naming the ref explicitly puts the scripts and the action back on one tag. That is what #5361 intended - it just needs the reviewer's own tag rather than the kreview plugin tag that caused the original `MODULE_NOT_FOUND`.

**Special notes for your reviewer**:

`issue_comment` workflows always run from the default branch, so this cannot be exercised from the PR branch. It takes effect on merge.

Separately, I am adding a guard on the Kong/ksai side so an empty ref fails loudly instead of quietly reading `main`.

**PR Readiness Checklist**:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
