### PR TITLE
tests: fix KIC plugin integration tests

### DIFF
--- a/test/integration/kic/consumer_test.go
+++ b/test/integration/kic/consumer_test.go
@@ -170,5 +170,5 @@ func TestConsumerCredential(t *testing.T) {
 
 	t.Log("deleting Ingress and waiting for routes to be torn down")
 	require.NoError(t, clusters.DeleteIngress(ctx, env.Cluster(), ns.Name, ingress))
-	helpers.EventuallyGETPath(t, nil, proxyHTTPSURL.String(), "/test_plugin_essentials", &helpers.HTTPSOptions{InsecureSkipVerify: true}, http.StatusNotFound, "no Route matched with those values", nil, ingressWait, waitTick)
+	helpers.EventuallyGETPath(t, nil, proxyHTTPSURL.String(), "/test_consumer_credential", &helpers.HTTPSOptions{InsecureSkipVerify: true}, http.StatusNotFound, "no Route matched with those values", nil, ingressWait, waitTick)
 }

--- a/test/integration/kic/plugin_test.go
+++ b/test/integration/kic/plugin_test.go
@@ -39,6 +39,7 @@ func TestPluginEssentials(t *testing.T) {
 
 	t.Parallel()
 	ns, cleaner := helpers.Setup(ctx, t, env)
+	path := "/" + helpers.LabelValueForTest(t)
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
 	container := generators.NewContainer("httpbin", test.HTTPBinImage, test.HTTPBinPort)
@@ -54,7 +55,7 @@ func TestPluginEssentials(t *testing.T) {
 	cleaner.Add(service)
 
 	t.Logf("creating an ingress for service %s with ingress.class %s", service.Name, consts.IngressClass)
-	ingress := generators.NewIngressForService("/test_plugin_essentials", map[string]string{
+	ingress := generators.NewIngressForService(path, map[string]string{
 		"konghq.com/strip-path": "true",
 	}, service)
 	ingress.Spec.IngressClassName = kong.String(consts.IngressClass)
@@ -64,7 +65,7 @@ func TestPluginEssentials(t *testing.T) {
 
 	t.Log("waiting for routes from Ingress to be operational")
 	assert.Eventually(t, func() bool {
-		resp, err := helpers.DefaultHTTPClient(helpers.WithInsecureSkipVerify()).Get(fmt.Sprintf("%s/test_plugin_essentials", proxyHTTPSURL))
+		resp, err := helpers.DefaultHTTPClient(helpers.WithInsecureSkipVerify()).Get(fmt.Sprintf("%s%s", proxyHTTPSURL, path))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyHTTPSURL, err)
 			return false
@@ -131,7 +132,7 @@ func TestPluginEssentials(t *testing.T) {
 
 	t.Logf("validating that plugin %s was successfully configured", kongplugin.Name)
 	assert.Eventually(t, func() bool {
-		resp, err := helpers.DefaultHTTPClient(helpers.WithInsecureSkipVerify()).Get(fmt.Sprintf("%s/test_plugin_essentials", proxyHTTPSURL))
+		resp, err := helpers.DefaultHTTPClient(helpers.WithInsecureSkipVerify()).Get(fmt.Sprintf("%s%s", proxyHTTPSURL, path))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyHTTPSURL, err)
 			return false
@@ -147,8 +148,12 @@ func TestPluginEssentials(t *testing.T) {
 		plugins, err := kc.Plugins.ListAll(ctx)
 		require.NoError(t, err, "failed to list plugins")
 
+		uidTag := "k8s-uid:" + string(kongplugin.UID)
 		plugin, found := lo.Find(plugins, func(p *kong.Plugin) bool {
-			return p != nil && p.Name != nil && *p.Name == kongplugin.PluginName
+			return p != nil && slices.Contains(
+				lo.Map(p.Tags, func(t *string, _ int) string { return lo.FromPtrOr(t, "") }),
+				uidTag,
+			)
 		})
 		if !found {
 			t.Logf("plugin for KongPlugin %s in Kong not found", kongplugin.Name)
@@ -177,7 +182,7 @@ func TestPluginEssentials(t *testing.T) {
 
 	t.Logf("validating that clusterplugin %s was successfully configured", kongclusterplugin.Name)
 	assert.Eventually(t, func() bool {
-		resp, err := helpers.DefaultHTTPClient(helpers.WithInsecureSkipVerify()).Get(fmt.Sprintf("%s/test_plugin_essentials", proxyHTTPSURL))
+		resp, err := helpers.DefaultHTTPClient(helpers.WithInsecureSkipVerify()).Get(fmt.Sprintf("%s%s", proxyHTTPSURL, path))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyHTTPSURL, err)
 			return false
@@ -193,8 +198,12 @@ func TestPluginEssentials(t *testing.T) {
 		plugins, err := kc.Plugins.ListAll(ctx)
 		require.NoError(t, err, "failed to list plugins")
 
+		uidTag := "k8s-uid:" + string(kongclusterplugin.UID)
 		plugin, found := lo.Find(plugins, func(p *kong.Plugin) bool {
-			return p != nil && p.Name != nil && *p.Name == kongclusterplugin.PluginName
+			return p != nil && slices.Contains(
+				lo.Map(p.Tags, func(t *string, _ int) string { return lo.FromPtrOr(t, "") }),
+				uidTag,
+			)
 		})
 		if !found {
 			t.Logf("plugin for KongClusterPlugin %s in Kong not found", kongclusterplugin.Name)
@@ -213,7 +222,7 @@ func TestPluginEssentials(t *testing.T) {
 
 	t.Log("deleting Ingress and waiting for routes to be torn down")
 	require.NoError(t, clusters.DeleteIngress(ctx, env.Cluster(), ns.Name, ingress))
-	helpers.EventuallyExpectHTTP404WithNoRoute(t, proxyHTTPSURL, proxyHTTPSURL.String(), "/test_plugin_essentials", &helpers.HTTPSOptions{InsecureSkipVerify: true}, ingressWait, waitTick, nil)
+	helpers.EventuallyExpectHTTP404WithNoRoute(t, proxyHTTPSURL, proxyHTTPSURL.String(), path, &helpers.HTTPSOptions{InsecureSkipVerify: true}, ingressWait, waitTick, nil)
 }
 
 func TestPluginConfigPatch(t *testing.T) {
@@ -221,6 +230,7 @@ func TestPluginConfigPatch(t *testing.T) {
 
 	t.Parallel()
 	ns, cleaner := helpers.Setup(ctx, t, env)
+	path := "/" + helpers.LabelValueForTest(t)
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
 	container := generators.NewContainer("httpbin", test.HTTPBinImage, test.HTTPBinPort)
@@ -236,7 +246,7 @@ func TestPluginConfigPatch(t *testing.T) {
 	cleaner.Add(service)
 
 	t.Logf("creating an ingress for service %s with ingress.class %s", service.Name, consts.IngressClass)
-	ingress := generators.NewIngressForService("/test_plugin_essentials", map[string]string{
+	ingress := generators.NewIngressForService(path, map[string]string{
 		"konghq.com/strip-path": "true",
 	}, service)
 	ingress.Spec.IngressClassName = kong.String(consts.IngressClass)
@@ -246,7 +256,7 @@ func TestPluginConfigPatch(t *testing.T) {
 
 	t.Log("waiting for routes from Ingress to be operational")
 	assert.Eventually(t, func() bool {
-		resp, err := helpers.DefaultHTTPClient(helpers.WithInsecureSkipVerify()).Get(fmt.Sprintf("%s/test_plugin_essentials", proxyHTTPSURL))
+		resp, err := helpers.DefaultHTTPClient(helpers.WithInsecureSkipVerify()).Get(fmt.Sprintf("%s%s", proxyHTTPSURL, path))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyHTTPSURL, err)
 			return false
@@ -348,7 +358,7 @@ func TestPluginConfigPatch(t *testing.T) {
 
 	t.Logf("validating that plugin %s was successfully configured", kongplugin.Name)
 	assert.Eventually(t, func() bool {
-		resp, err := helpers.DefaultHTTPClient(helpers.WithInsecureSkipVerify()).Get(fmt.Sprintf("%s/test_plugin_essentials", proxyHTTPSURL))
+		resp, err := helpers.DefaultHTTPClient(helpers.WithInsecureSkipVerify()).Get(fmt.Sprintf("%s%s", proxyHTTPSURL, path))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyHTTPSURL, err)
 			return false
@@ -371,7 +381,7 @@ func TestPluginConfigPatch(t *testing.T) {
 
 	t.Logf("validating that clusterplugin %s was successfully configured", kongclusterplugin.Name)
 	assert.Eventually(t, func() bool {
-		resp, err := helpers.DefaultHTTPClient(helpers.WithInsecureSkipVerify()).Get(fmt.Sprintf("%s/test_plugin_essentials", proxyHTTPSURL))
+		resp, err := helpers.DefaultHTTPClient(helpers.WithInsecureSkipVerify()).Get(fmt.Sprintf("%s%s", proxyHTTPSURL, path))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyHTTPSURL, err)
 			return false
@@ -383,7 +393,7 @@ func TestPluginConfigPatch(t *testing.T) {
 
 	t.Log("deleting Ingress and waiting for routes to be torn down")
 	require.NoError(t, clusters.DeleteIngress(ctx, env.Cluster(), ns.Name, ingress))
-	helpers.EventuallyExpectHTTP404WithNoRoute(t, proxyHTTPSURL, proxyHTTPSURL.String(), "/test_plugin_essentials", &helpers.HTTPSOptions{InsecureSkipVerify: true}, ingressWait, waitTick, nil)
+	helpers.EventuallyExpectHTTP404WithNoRoute(t, proxyHTTPSURL, proxyHTTPSURL.String(), path, &helpers.HTTPSOptions{InsecureSkipVerify: true}, ingressWait, waitTick, nil)
 }
 
 func TestPluginOrdering(t *testing.T) {
@@ -776,6 +786,7 @@ func TestPluginNullInConfig(t *testing.T) {
 
 	t.Parallel()
 	ns, cleaner := helpers.Setup(ctx, t, env)
+	path := "/" + helpers.LabelValueForTest(t)
 
 	t.Log("deploying a minimal HTTP container deployment to test Ingress routes")
 	container := generators.NewContainer("httpbin", test.HTTPBinImage, test.HTTPBinPort)
@@ -791,7 +802,7 @@ func TestPluginNullInConfig(t *testing.T) {
 	cleaner.Add(service)
 
 	t.Logf("creating an ingress for service %s with ingress.class %s", service.Name, consts.IngressClass)
-	ingress := generators.NewIngressForService("/test_plugin_essentials", map[string]string{
+	ingress := generators.NewIngressForService(path, map[string]string{
 		"konghq.com/strip-path": "true",
 	}, service)
 	ingress.Spec.IngressClassName = kong.String(consts.IngressClass)
@@ -801,7 +812,7 @@ func TestPluginNullInConfig(t *testing.T) {
 
 	t.Log("waiting for routes from Ingress to be operational")
 	assert.Eventually(t, func() bool {
-		resp, err := helpers.DefaultHTTPClient(helpers.WithInsecureSkipVerify()).Get(fmt.Sprintf("%s/test_plugin_essentials", proxyHTTPSURL))
+		resp, err := helpers.DefaultHTTPClient(helpers.WithInsecureSkipVerify()).Get(fmt.Sprintf("%s%s", proxyHTTPSURL, path))
 		if err != nil {
 			t.Logf("WARNING: error while waiting for %s: %v", proxyHTTPSURL, err)
 			return false
@@ -856,8 +867,12 @@ func TestPluginNullInConfig(t *testing.T) {
 		plugins, err := kc.Plugins.ListAll(ctx)
 		require.NoError(t, err, "failed to list plugins")
 
+		uidTag := "k8s-uid:" + string(kongplugin.UID)
 		datadogPlugin, found := lo.Find(plugins, func(p *kong.Plugin) bool {
-			return p.Name != nil && *p.Name == "datadog"
+			return p != nil && slices.Contains(
+				lo.Map(p.Tags, func(t *string, _ int) string { return lo.FromPtrOr(t, "") }),
+				uidTag,
+			)
 		})
 		if !found {
 			t.Logf("datadog plugin not found. %d Plugins found: %s",

--- a/test/integration/kic/plugin_test.go
+++ b/test/integration/kic/plugin_test.go
@@ -21,6 +21,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	apiextensionsv1 "k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 	gatewayclient "sigs.k8s.io/gateway-api/pkg/client/clientset/versioned"
 
 	commonv1alpha1 "github.com/kong/kong-operator/v2/api/common/v1alpha1"
@@ -33,6 +34,14 @@ import (
 	"github.com/kong/kong-operator/v2/test/helpers"
 	"github.com/kong/kong-operator/v2/test/integration/kic/consts"
 )
+
+func findPluginByUID(plugins []*kong.Plugin, uid types.UID) (*kong.Plugin, bool) {
+	tag := "k8s-uid:" + string(uid)
+	return lo.Find(plugins, func(p *kong.Plugin) bool {
+		return p != nil && slices.Contains(
+			lo.Map(p.Tags, func(t *string, _ int) string { return lo.FromPtrOr(t, "") }), tag)
+	})
+}
 
 func TestPluginEssentials(t *testing.T) {
 	ctx := t.Context()
@@ -148,13 +157,7 @@ func TestPluginEssentials(t *testing.T) {
 		plugins, err := kc.Plugins.ListAll(ctx)
 		require.NoError(t, err, "failed to list plugins")
 
-		uidTag := "k8s-uid:" + string(kongplugin.UID)
-		plugin, found := lo.Find(plugins, func(p *kong.Plugin) bool {
-			return p != nil && slices.Contains(
-				lo.Map(p.Tags, func(t *string, _ int) string { return lo.FromPtrOr(t, "") }),
-				uidTag,
-			)
-		})
+		plugin, found := findPluginByUID(plugins, kongplugin.UID)
 		if !found {
 			t.Logf("plugin for KongPlugin %s in Kong not found", kongplugin.Name)
 			return false
@@ -198,13 +201,7 @@ func TestPluginEssentials(t *testing.T) {
 		plugins, err := kc.Plugins.ListAll(ctx)
 		require.NoError(t, err, "failed to list plugins")
 
-		uidTag := "k8s-uid:" + string(kongclusterplugin.UID)
-		plugin, found := lo.Find(plugins, func(p *kong.Plugin) bool {
-			return p != nil && slices.Contains(
-				lo.Map(p.Tags, func(t *string, _ int) string { return lo.FromPtrOr(t, "") }),
-				uidTag,
-			)
-		})
+		plugin, found := findPluginByUID(plugins, kongclusterplugin.UID)
 		if !found {
 			t.Logf("plugin for KongClusterPlugin %s in Kong not found", kongclusterplugin.Name)
 			return false
@@ -867,13 +864,7 @@ func TestPluginNullInConfig(t *testing.T) {
 		plugins, err := kc.Plugins.ListAll(ctx)
 		require.NoError(t, err, "failed to list plugins")
 
-		uidTag := "k8s-uid:" + string(kongplugin.UID)
-		datadogPlugin, found := lo.Find(plugins, func(p *kong.Plugin) bool {
-			return p != nil && slices.Contains(
-				lo.Map(p.Tags, func(t *string, _ int) string { return lo.FromPtrOr(t, "") }),
-				uidTag,
-			)
-		})
+		datadogPlugin, found := findPluginByUID(plugins, kongplugin.UID)
 		if !found {
 			t.Logf("datadog plugin not found. %d Plugins found: %s",
 				len(plugins),


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix issues discovered in: https://github.com/Kong/kong-operator/actions/runs/33498295805/job/99825546272?pr=5477#step:19:11534


```
=== NAME  TestPluginConfigPatch
    plugin_test.go:373: 
        	Error Trace:	/home/runner/work/kong-operator/kong-operator/test/integration/kic/plugin_test.go:373
        	Error:      	Condition never satisfied
        	Test:       	TestPluginConfigPatch
```

by splitting the ingress routes used in tests.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
