### PR TITLE
fix(ingress-controller): skip parentRefs of unsupported kinds instead of erroring

### DIFF
--- a/ingress-controller/internal/controllers/gateway/route_utils.go
+++ b/ingress-controller/internal/controllers/gateway/route_utils.go
@@ -62,6 +62,14 @@ func (g supportedGatewayWithCondition) GetSectionName() mo.Option[string] {
 
 // parentRefsForRoute provides a list of the parentRefs given a Gateway APIs route object
 // (e.g. HTTPRoute, TCPRoute, e.t.c.) which refer to the Gateway resource(s) which manage it.
+//
+// parentRefs pointing at a kind this controller cannot resolve (e.g. a ListenerSet, or any
+// Gateway API kind introduced after the version this controller is built against) are filtered
+// out rather than rejected: such a reference means the route is managed by some other
+// controller. Routes left with no supported parentRef are handled by getSupportedGatewayForRoute
+// returning ErrNoSupportedGateway, which callers already treat as "not ours". Returning an error
+// here instead makes reconciliation of a route this controller does not own fail permanently,
+// retrying forever without ever converging.
 func parentRefsForRoute[T gatewayapi.RouteT](route T) ([]gatewayapi.ParentReference, error) {
 	var refs []gatewayapi.ParentReference
 	switch r := (any)(route).(type) {
@@ -78,21 +86,30 @@ func parentRefsForRoute[T gatewayapi.RouteT](route T) ([]gatewayapi.ParentRefere
 	default:
 		return nil, fmt.Errorf("can't determine parent Gateway for unsupported route type %s", reflect.TypeOf(route))
 	}
+	// Filter into a fresh slice rather than in place: refs aliases the route's own
+	// Spec.ParentRefs, and the route comes from the shared cache.
+	supported := make([]gatewayapi.ParentReference, 0, len(refs))
 	for _, ref := range refs {
-		group := gatewayv1.GroupName
-		if ref.Group != nil && *ref.Group != "" {
-			group = string(*ref.Group)
-		}
-		kind := "Gateway"
-		if ref.Kind != nil && *ref.Kind != "" {
-			kind = string(*ref.Kind)
-		}
-		if group != gatewayv1.GroupName || kind != "Gateway" {
-			return nil, fmt.Errorf("unsupported parent kind %s/%s", group, kind)
+		if isSupportedParentRefKind(ref) {
+			supported = append(supported, ref)
 		}
 	}
+	return supported, nil
+}
 
-	return refs, nil
+// isSupportedParentRefKind reports whether a parentRef points at a core Gateway API Gateway,
+// the only parent kind this controller is able to resolve. Group and Kind are optional in the
+// Gateway API and default to gateway.networking.k8s.io and Gateway respectively.
+func isSupportedParentRefKind(ref gatewayapi.ParentReference) bool {
+	group := gatewayv1.GroupName
+	if ref.Group != nil && *ref.Group != "" {
+		group = string(*ref.Group)
+	}
+	kind := "Gateway"
+	if ref.Kind != nil && *ref.Kind != "" {
+		kind = string(*ref.Kind)
+	}
+	return group == gatewayv1.GroupName && kind == "Gateway"
 }
 
 // getSupportedGatewayForRoute will retrieve the Gateway and GatewayClass object for any

--- a/ingress-controller/internal/controllers/gateway/route_utils_test.go
+++ b/ingress-controller/internal/controllers/gateway/route_utils_test.go
@@ -1827,14 +1827,17 @@ func TestGetSupportedGatewayForRoute(t *testing.T) {
 			Group: &badGroup,
 		},
 	}
-	t.Run("invalid parentRef kind rejected", func(t *testing.T) {
+	t.Run("unsupported parentRef kind is skipped, not rejected", func(t *testing.T) {
 		fakeClient := fakeclient.
 			NewClientBuilder().
 			WithScheme(scheme.Scheme).
 			Build()
 
+		// A route whose only parent is of a kind this controller cannot resolve belongs to some
+		// other controller. It must resolve to "no supported gateway", which callers handle by
+		// dropping the route, rather than to a hard error that retries forever.
 		_, err := getSupportedGatewayForRoute(t.Context(), logr.Discard(), fakeClient, bustedParentHTTPRoute, controllers.OptionalNamespacedName{})
-		require.Equal(t, fmt.Errorf("unsupported parent kind %s/%s", string(badGroup), string(badKind)), err)
+		require.ErrorIs(t, err, ErrNoSupportedGateway)
 	})
 
 	t.Run("single Gateway", func(t *testing.T) {
@@ -3051,6 +3054,70 @@ func TestIsRouteAcceptedByListener(t *testing.T) {
 			ok, err := isRouteAcceptedByListener(ctx, fakeClient, tc.httpRoute, tc.gateway, 0, tc.httpRoute.Spec.ParentRefs[0])
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expectedValue, ok)
+		})
+	}
+}
+
+func TestParentRefsForRoute(t *testing.T) {
+	gatewayGroup := gatewayapi.Group(gatewayv1.GroupName)
+	gatewayKind := gatewayapi.Kind("Gateway")
+	listenerSetKind := gatewayapi.Kind("ListenerSet")
+	otherGroup := gatewayapi.Group("example.com")
+	otherKind := gatewayapi.Kind("Frobnicator")
+
+	routeWithParents := func(refs ...gatewayapi.ParentReference) *gatewayapi.HTTPRoute {
+		return &gatewayapi.HTTPRoute{
+			TypeMeta: gatewayapi.V1GatewayTypeMeta,
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      "httproute",
+				Namespace: "test-namespace",
+			},
+			Spec: gatewayapi.HTTPRouteSpec{
+				CommonRouteSpec: gatewayapi.CommonRouteSpec{ParentRefs: refs},
+			},
+		}
+	}
+
+	testCases := []struct {
+		name     string
+		route    *gatewayapi.HTTPRoute
+		expected []gatewayapi.ParentReference
+	}{
+		{
+			name:     "a Gateway parentRef is kept",
+			route:    routeWithParents(gatewayapi.ParentReference{Group: &gatewayGroup, Kind: &gatewayKind, Name: "gw"}),
+			expected: []gatewayapi.ParentReference{{Group: &gatewayGroup, Kind: &gatewayKind, Name: "gw"}},
+		},
+		{
+			name:     "an omitted Group and Kind default to a Gateway and are kept",
+			route:    routeWithParents(gatewayapi.ParentReference{Name: "gw"}),
+			expected: []gatewayapi.ParentReference{{Name: "gw"}},
+		},
+		{
+			name:     "a ListenerSet parentRef is dropped",
+			route:    routeWithParents(gatewayapi.ParentReference{Group: &gatewayGroup, Kind: &listenerSetKind, Name: "ls"}),
+			expected: []gatewayapi.ParentReference{},
+		},
+		{
+			name:     "a parentRef from an unrelated group is dropped",
+			route:    routeWithParents(gatewayapi.ParentReference{Group: &otherGroup, Kind: &otherKind, Name: "other"}),
+			expected: []gatewayapi.ParentReference{},
+		},
+		{
+			name: "an unsupported parentRef does not discard the supported ones alongside it",
+			route: routeWithParents(
+				gatewayapi.ParentReference{Group: &gatewayGroup, Kind: &listenerSetKind, Name: "ls"},
+				gatewayapi.ParentReference{Group: &gatewayGroup, Kind: &gatewayKind, Name: "gw"},
+			),
+			expected: []gatewayapi.ParentReference{{Group: &gatewayGroup, Kind: &gatewayKind, Name: "gw"}},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			refs, err := parentRefsForRoute(tc.route)
+			require.NoError(t, err)
+			require.Equal(t, tc.expected, refs)
 		})
 	}
 }


### PR DESCRIPTION
Same fix as Kong/kubernetes-ingress-controller#8079, applied here because this is where new development lands per KIC's README. Reported as Kong/kubernetes-ingress-controller#8078.

### What this changes

`parentRefsForRoute` rejects a whole route as soon as one `parentRef` names a kind other than a core Gateway API `Gateway`:

```go
if group != gatewayv1.GroupName || kind != "Gateway" {
    return nil, fmt.Errorf("unsupported parent kind %s/%s", group, kind)
}
```

That runs *before* `getSupportedGatewayForRoute` compares the parent's `GatewayClass.spec.controllerName` against `GetControllerName()`, so a route owned by a different Gateway API implementation never reaches the "not mine, skip it" path — even though that path exists and is used for every other not-mine case (missing Gateway, missing GatewayClass, foreign `controllerName`, all `continue`).

Because such a route is never going to change, the reconcile error repeats on controller-runtime's backoff forever. We hit this on a cluster where Envoy Gateway owns an `HTTPRoute` parented to a `ListenerSet`, in a namespace the Kong controller also watches:

```
error controllers.HTTPRoute Reconciler error {"error": "unsupported parent kind gateway.networking.k8s.io/ListenerSet"}
```

This filters unsupported parentRefs out instead. A route left with no supported parentRef resolves to `ErrNoSupportedGateway`, which every route controller already handles — it clears any stale status and drops the object from the dataplane cache, returning no error. That is exactly the right outcome for a route owned by another controller, and it needs no new error handling.

It also fixes a smaller thing: the old code `return`ed on the first bad ref, so a route combining an unsupported parent with a legitimate `Gateway` parent was discarded whole. Filtering keeps the `Gateway` one.

The filter allocates a new slice rather than removing in place (e.g. `slices.DeleteFunc`) on purpose: `refs` aliases the route's own `Spec.ParentRefs`, and the route comes from the shared informer cache, so in-place removal would mutate a cached object.

### Relationship to #4046

This is **not** ListenerSet support and does not implement any part of #4046. The controller does not need to understand `ListenerSet` here — it only needs to not error out on routes that reference one. The fix is generic to any parent kind the controller cannot resolve.

It is worth noting that `ListenerSet` reaches many more clusters than it used to: it graduated to the **standard** channel as `gateway.networking.k8s.io/v1` in Gateway API v1.5.0 and is still standard in v1.6.1, so users no longer have to opt into the experimental bundle to have the CRD present — and therefore to have routes that reference it.

### Testing

- The existing `invalid parentRef kind rejected` case now asserts `ErrNoSupportedGateway` rather than the raw error, and is renamed to match the new semantics.
- New `TestParentRefsForRoute` covers: a `Gateway` ref kept; omitted Group/Kind defaulted and kept; a `ListenerSet` ref dropped; an unrelated group dropped; and an unsupported ref not discarding a supported one alongside it.

`go test ./ingress-controller/internal/controllers/gateway/...` passes.

### Note

I left `CHANGELOG.md` alone — there is no `Unreleased` section to append to and it looks maintainer-curated at release time. Happy to add an entry wherever you'd like it.
