### PR TITLE
test/e2e: fix flaky Seed-kafka-topics retry loop in eventgateway sni-routing

### DIFF
--- a/test/e2e/chainsaw/common/_step_templates/apply-assert-kafka-cluster.yaml
+++ b/test/e2e/chainsaw/common/_step_templates/apply-assert-kafka-cluster.yaml
@@ -116,6 +116,15 @@ spec:
                             -c /tmp/kraft.properties
                         fi
                         exec /opt/kafka/bin/kafka-server-start.sh /tmp/kraft.properties
+                    # Requests (no limits, to avoid OOM-killing the JVM under the
+                    # default ~1G heap) give each broker a guaranteed CPU/memory
+                    # floor so it isn't starved when the CI node is busy running
+                    # other tests, which previously made topic creation slow
+                    # enough to exhaust Seed-kafka-topics' retry budget.
+                    resources:
+                      requests:
+                        cpu: 250m
+                        memory: 768Mi
                     readinessProbe:
                       tcpSocket:
                         port: 9092

--- a/test/e2e/chainsaw/common/scripts/seed_topics.sh
+++ b/test/e2e/chainsaw/common/scripts/seed_topics.sh
@@ -20,4 +20,4 @@ cat "${SCRIPT_DIR}/seed_topics_inner.sh" | kubectl run "${POD_NAME}" \
   --rm -i --restart=Never \
   --env="KAFKA_BOOTSTRAP=${KAFKA_BOOTSTRAP}" \
   -n "${NAMESPACE}" \
-  --command -- sh -s 2>/dev/null | grep -v '^pod "'
+  --command -- sh -s 2>&1 | grep -v '^pod "'

--- a/test/e2e/chainsaw/common/scripts/seed_topics_inner.sh
+++ b/test/e2e/chainsaw/common/scripts/seed_topics_inner.sh
@@ -30,31 +30,30 @@ TOPICS="analytics_pageviews analytics_clicks analytics_orders \
         user_actions"
 
 ATTEMPT=0
+LAST_ERR=""
 while [ "${ATTEMPT}" -lt "${MAX_RETRIES}" ]; do
   ATTEMPT=$((ATTEMPT + 1))
 
-  ALL_OK=true
+  # List first and only create what's missing. Previously this created every
+  # topic on every attempt: once a topic already existed from an earlier
+  # (partially successful) attempt, kafkactl's create call for it failed with
+  # a "topic already exists" error, which the loop treated the same as a real
+  # failure. That permanently poisoned every subsequent attempt (the list
+  # verification below was only reached when ALL creates reported success),
+  # so a single transient failure on the first attempt guaranteed the loop
+  # burned through its entire retry budget and failed, no matter how quickly
+  # Kafka actually became ready.
+  LISTED=$(kafkactl -C /tmp/kafkactl.yml --context backend list topics 2>&1) || { LAST_ERR="list topics: ${LISTED}"; LISTED=""; }
+
+  MISSING=""
   for TOPIC in ${TOPICS}; do
-    if ! kafkactl -C /tmp/kafkactl.yml --context backend \
-        create topic "${TOPIC}" \
-        --partitions 3 --replication-factor 3 >/dev/null 2>&1; then
-      ALL_OK=false
+    if ! echo "${LISTED}" | grep -qF "${TOPIC}"; then
+      MISSING="${MISSING} ${TOPIC}"
     fi
   done
 
-  if [ "${ALL_OK}" = "true" ]; then
-    # Verify topics are visible.
-    LISTED=$(kafkactl -C /tmp/kafkactl.yml --context backend \
-      list topics 2>/dev/null || true)
-    MISSING=""
-    for TOPIC in ${TOPICS}; do
-      if ! echo "${LISTED}" | grep -qF "${TOPIC}"; then
-        MISSING="${MISSING} ${TOPIC}"
-      fi
-    done
-
-    if [ -z "${MISSING}" ]; then
-      cat <<EOF
+  if [ -z "${MISSING}" ]; then
+    cat <<EOF
 {
   "success": true,
   "message": "All topics created successfully",
@@ -62,17 +61,29 @@ while [ "${ATTEMPT}" -lt "${MAX_RETRIES}" ]; do
   "max_retries": ${MAX_RETRIES}
 }
 EOF
-      exit 0
-    fi
+    exit 0
   fi
+
+  for TOPIC in ${MISSING}; do
+    if ! OUT=$(kafkactl -C /tmp/kafkactl.yml --context backend \
+        create topic "${TOPIC}" \
+        --partitions 3 --replication-factor 3 2>&1); then
+      LAST_ERR="create ${TOPIC}: ${OUT}"
+    fi
+  done
 
   if [ "${ATTEMPT}" -lt "${MAX_RETRIES}" ]; then sleep "${RETRY_DELAY}"; fi
 done
 
+# Emit the last kafkactl error as JSON-escaped text so a future failure is
+# diagnosable instead of silently exhausting retries (see incident where this
+# ran for the full retry budget with no visible cause).
+ESCAPED_ERR=$(printf '%s' "${LAST_ERR}" | sed 's/\\/\\\\/g; s/"/\\"/g' | tr '\n' ' ')
 cat <<EOF
 {
   "success": false,
   "error": "Failed to create/verify all topics after ${MAX_RETRIES} attempts",
+  "last_error": "${ESCAPED_ERR}",
   "retry_attempt": ${ATTEMPT},
   "max_retries": ${MAX_RETRIES}
 }


### PR DESCRIPTION



**What this PR does / why we need it**:


The retry loop recreated all topics on every attempt, so once a topic already existed, kafkactl's "already exists" error was treated as a failure and permanently blocked the success path. List topics first and only create what's missing.

Fixes failure like: https://github.com/Kong/kong-operator/actions/runs/33587835015/job/100116265567

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
