### PR TITLE
tests: fix TestTelemetry's timeout

### DIFF
--- a/test/envtest/telemetry_test.go
+++ b/test/envtest/telemetry_test.go
@@ -46,9 +46,14 @@ func TestTelemetry(t *testing.T) {
 	createK8sObjectsForTelemetryTest(ctx, t, c)
 
 	t.Log("starting the controller manager")
+	// NOTE: the telemetry period also doubles as the per-report context deadline in
+	// kubernetes-telemetry's workflowsLoop (ctx, cancel := context.WithTimeout(ctx, m.period)).
+	// A provider that misses that deadline (e.g. k8s_provider, which makes two sequential API
+	// calls: discovery + node list) is silently dropped from the report rather than failing it.
+	// Keep this generous enough to avoid flakes under CI load.
 	_ = RunManager(ctx, t, envcfg, AdminAPIOptFns(),
 		WithDefaultEnvTestsConfig(envcfg),
-		WithTelemetry(ts.Endpoint(), 100*time.Millisecond),
+		WithTelemetry(ts.Endpoint(), time.Second),
 	)
 
 	dcl, err := discoveryclient.NewDiscoveryClientForConfig(envcfg)
@@ -58,7 +63,7 @@ func TestTelemetry(t *testing.T) {
 
 	t.Log("verifying that eventually we get an expected telemetry report")
 	const (
-		waitTime = 3 * time.Second
+		waitTime = 30 * time.Second
 		tickTime = 10 * time.Millisecond
 	)
 	require.Eventuallyf(t, func() bool {


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix failures like: https://github.com/Kong/kong-operator/actions/runs/33613190679/job/100193022758#step:13:3248

```
    telemetry_test.go:67: telemetry report mismatch (-want +got):
          strings.Join({
          	... // 271 identical bytes
          	"teuris=false;feature-sanitizekonnectconfigdumps=true;hn=runnervm",
          	"gx7h7;kv=3.4.1;rf=traditional;v=NOT_SET;k8s_arch=linux/amd64;k8s",
        - 	"_provider=UNKNOWN;k8s",
          	"v=v1.37.0;k8sv_semver=v1.37.0;k8s_gatewayclasses_count=2;k8s_gat",
          	"eways_count=4;k8s_grpcroutes_count=4;k8s_httproutes_count=4;k8s_",
          	... // 169 identical bytes
          }, "")
    asm_amd64.s:1771: received 722 bytes of telemetry report
I0902 09:26:46.219008    3359 warnings.go:107] "Warning: The v1alpha2 version of UDPRoute has been deprecated and will be removed in a future release of the API. Please upgrade to v1."
I0902 09:26:46.219158    3359 warnings.go:107] "Warning: The v1alpha2 version of TLSRoute has been deprecated and will be removed in a future release of the API. Please upgrade to v1."
I0902 09:26:46.219462    3359 warnings.go:107] "Warning: The v1alpha2 version of TCPRoute has been deprecated and will be removed in a future release of the API. Please upgrade to v1."
    telemetry_test.go:67: telemetry report mismatch (-want +got):
          strings.Join({
          	... // 271 identical bytes
          	"teuris=false;feature-sanitizekonnectconfigdumps=true;hn=runnervm",
          	"gx7h7;kv=3.4.1;rf=traditional;v=NOT_SET;k8s_arch=linux/amd64;k8s",
        - 	"_provider=UNKNOWN;k8s",
          	"v=v1.37.0;k8sv_semver=v1.37.0;k8s_gatewayclasses_count=2;k8s_gat",
          	"eways_count=4;k8s_grpcroutes_count=4;k8s_httproutes_count=4;k8s_",
          	... // 169 identical bytes
          }, "")
    telemetry_test.go:64: 
        	Error Trace:	/home/runner/work/kong-operator/kong-operator/test/envtest/telemetry_test.go:64
        	Error:      	Condition never satisfied
        	Test:       	TestTelemetry
        	Messages:   	telemetry report never matched expected value
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
