### PR TITLE
fix(ingress-controller): Split httproute match by path when they have PathPrefixRewrite filter or RequestRedirect filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -66,6 +66,8 @@
 - On-prem gateway: generate a distinct Kong route for each match when its parent
  `HTTPRoute` rule contains `ReplacePrefixMatch` typed `URLRewrite` filter or
  `requestRedirect` filter.
+  ** This change will delete the combined Kong routes created for the matches with
+  these filters in their parent rules and create new distinct ones.
  [#5521](https://github.com/Kong/kong-operator/pull/5521)
 
 ## [v2.3.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -64,7 +64,8 @@
 ### Fixes
 
 - On-prem gateway: generate a distinct Kong route for each match when its parent
- `HTTPRoute` rule contains `ReplacePrefixMatch` typed `URLRewrite` filter.
+ `HTTPRoute` rule contains `ReplacePrefixMatch` typed `URLRewrite` filter or
+ `requestRedirect` filter.
  [#5521](https://github.com/Kong/kong-operator/pull/5521)
 
 ## [v2.3.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,14 @@
 - [v0.1.1](#v011)
 - [v0.1.0](#v010)
 
+## Unreleased
+
+### Fixes
+
+- On-prem gateway: generate a distinct Kong route for each match when its parent
+ `HTTPRoute` rule contains `ReplacePrefixMatch` typed `URLRewrite` filter.
+ [#5521](https://github.com/Kong/kong-operator/pull/5521)
+
 ## [v2.3.0]
 
 > Release date: 2026-09-01

--- a/ingress-controller/internal/dataplane/translator/subtranslator/httproute.go
+++ b/ingress-controller/internal/dataplane/translator/subtranslator/httproute.go
@@ -472,6 +472,19 @@ func traditionalHTTPRouteMatchPriorityClass(match SplitHTTPRouteMatch) RoutePrio
 	return calculateHTTPRouteMatchPriorityTraits(match).EncodeToPriority() - httpRouteResourceKindPriority
 }
 
+// filtersContainURLRewriteReplacePrefixMatch reports whether filters contains a URLRewrite filter
+// with a ReplacePrefixMatch path modifier. The rewritten path for such a filter depends on which
+// prefix matched, so matches sharing this filter must never be consolidated into a single Kong
+// route/plugin.
+func filtersContainURLRewriteReplacePrefixMatch(filters []gatewayapi.HTTPRouteFilter) bool {
+	return lo.ContainsBy(filters, func(filter gatewayapi.HTTPRouteFilter) bool {
+		return filter.Type == gatewayapi.HTTPRouteFilterURLRewrite &&
+			filter.URLRewrite.Path != nil &&
+			filter.URLRewrite.Path.Type == gatewayapi.PrefixMatchHTTPPathModifier &&
+			filter.URLRewrite.Path.ReplacePrefixMatch != nil
+	})
+}
+
 // translateHTTPRouteRulesMetaToKongstateRoutes translate the matches and filters under the rules sharing the same backends
 // to list of kongstate.Route.
 func translateHTTPRouteRulesMetaToKongstateRoutes(
@@ -490,9 +503,16 @@ func translateHTTPRouteRulesMetaToKongstateRoutes(
 		filters := rulesWithSameFilter[0].Rule.Filters
 		// Group the matches for each rule. Then aggregate the matches eligible for the consolidation
 		// into a single match group.
+		//
+		// ReplacePrefixMatch's rewritten path depends on which prefix matched, so when it's present
+		// we must never fold matches from different rules together - keep every match in its own group.
+		keyFn := httpRouteMatchMeta.getKey
+		if filtersContainURLRewriteReplacePrefixMatch(filters) {
+			keyFn = httpRouteMatchMeta.getUniqueKey
+		}
 		matchGroups := make(map[string]httpRouteMatchMetaList)
 		for _, ruleMeta := range rulesWithSameFilter {
-			ruleMatchGroups := groupSliceByKeyFn(ruleMeta.matches(), httpRouteMatchMeta.getKey)
+			ruleMatchGroups := groupSliceByKeyFn(ruleMeta.matches(), keyFn)
 			for matchGroupKey, matchGroup := range ruleMatchGroups {
 				matchGroups[matchGroupKey] = append(matchGroups[matchGroupKey], matchGroup...)
 			}
@@ -904,6 +924,13 @@ func (m httpRouteMatchMeta) getKey() string {
 	return mustMarshalJSON(keySource)
 }
 
+// getUniqueKey computes a key that is unique to this particular HTTPRouteMatch, i.e. it never
+// collides with the key of any other httpRouteMatchMeta. It is used in place of getKey() when
+// matches must not be consolidated with any other match, regardless of how similar they are.
+func (m httpRouteMatchMeta) getUniqueKey() string {
+	return fmt.Sprintf("%s/%s.%d.%d", m.parentRoute.Namespace, m.parentRoute.Name, m.RuleNumber, m.MatchNumber)
+}
+
 type httpRouteMatchMetaList []httpRouteMatchMeta
 
 func (l httpRouteMatchMetaList) httpRouteMatches() (
@@ -1029,16 +1056,14 @@ func GenerateKongRoutesFromHTTPRouteMatches(
 	}
 
 	var path string
-	if hasURLRewriteWithReplacePrefixMatchFilter := lo.ContainsBy(filters, func(filter gatewayapi.HTTPRouteFilter) bool {
-		return filter.Type == gatewayapi.HTTPRouteFilterURLRewrite &&
-			filter.URLRewrite.Path != nil &&
-			filter.URLRewrite.Path.Type == gatewayapi.PrefixMatchHTTPPathModifier &&
-			filter.URLRewrite.Path.ReplacePrefixMatch != nil
-	}); hasURLRewriteWithReplacePrefixMatchFilter {
-		// In the case of URLRewrite with non-nil ReplacePrefixMatch, we rely on a CEL validation rule that disallows
-		// rules with multiple matches if the URLRewrite filter is present. We can be certain that if the filter is
-		// present, there is at most only one match. Based on that, we can determine the path from the first match.
-		// See: https://github.com/kubernetes-sigs/gateway-api/blob/29e68bffffb9af568e35545305d78d0001a1a0f7/apis/v1/httproute_types.go#L131
+	if filtersContainURLRewriteReplacePrefixMatch(filters) {
+		// In the case of URLRewrite with non-nil ReplacePrefixMatch, a CEL validation rule disallows
+		// rules with multiple matches if the URLRewrite filter is present (see:
+		// https://github.com/kubernetes-sigs/gateway-api/blob/29e68bffffb9af568e35545305d78d0001a1a0f7/apis/v1/httproute_types.go#L131),
+		// and translateHTTPRouteRulesMetaToKongstateRoutes additionally never consolidates matches from
+		// different rules when this filter is present (see filtersContainURLRewriteReplacePrefixMatch's
+		// usage there). So we can be certain that if the filter is present, there is at most only one
+		// match here, and can determine the path from it.
 		if len(matches) > 0 && matches[0].Path != nil && matches[0].Path.Value != nil {
 			path = *matches[0].Path.Value
 		}

--- a/ingress-controller/internal/dataplane/translator/subtranslator/httproute.go
+++ b/ingress-controller/internal/dataplane/translator/subtranslator/httproute.go
@@ -485,6 +485,17 @@ func filtersContainURLRewriteReplacePrefixMatch(filters []gatewayapi.HTTPRouteFi
 	})
 }
 
+// filtersContainRequestRedirect reports whether filters contains a RequestRedirect filter. A
+// RequestRedirect's generated plugin (e.g. its Location header, when no path override is set)
+// generally depends on which match fired, so matches sharing this filter must never be
+// consolidated into a single Kong route/plugin either - see getRoutesFromMatches, which already
+// builds one independent route per match for this reason.
+func filtersContainRequestRedirect(filters []gatewayapi.HTTPRouteFilter) bool {
+	return lo.ContainsBy(filters, func(filter gatewayapi.HTTPRouteFilter) bool {
+		return filter.Type == gatewayapi.HTTPRouteFilterRequestRedirect
+	})
+}
+
 // translateHTTPRouteRulesMetaToKongstateRoutes translate the matches and filters under the rules sharing the same backends
 // to list of kongstate.Route.
 func translateHTTPRouteRulesMetaToKongstateRoutes(
@@ -504,10 +515,11 @@ func translateHTTPRouteRulesMetaToKongstateRoutes(
 		// Group the matches for each rule. Then aggregate the matches eligible for the consolidation
 		// into a single match group.
 		//
-		// ReplacePrefixMatch's rewritten path depends on which prefix matched, so when it's present
-		// we must never fold matches from different rules together - keep every match in its own group.
+		// ReplacePrefixMatch's rewritten path, and RequestRedirect's generated plugin, both depend on
+		// which match fired, so when either is present we must never fold matches from different
+		// rules together - keep every match in its own group.
 		keyFn := httpRouteMatchMeta.getKey
-		if filtersContainURLRewriteReplacePrefixMatch(filters) {
+		if filtersContainURLRewriteReplacePrefixMatch(filters) || filtersContainRequestRedirect(filters) {
 			keyFn = httpRouteMatchMeta.getUniqueKey
 		}
 		matchGroups := make(map[string]httpRouteMatchMetaList)
@@ -1046,9 +1058,7 @@ func GenerateKongRoutesFromHTTPRouteMatches(
 
 	// Check if the route has a RequestRedirect or URLRewrite with non-nil ReplacePrefixMatch - if it does, we need to
 	// generate a route for each match as the path is used to modify routes and generate plugins.
-	hasRedirectFilter := lo.ContainsBy(filters, func(filter gatewayapi.HTTPRouteFilter) bool {
-		return filter.Type == gatewayapi.HTTPRouteFilterRequestRedirect
-	})
+	hasRedirectFilter := filtersContainRequestRedirect(filters)
 
 	routes, err := getRoutesFromMatches(matches, &r, filters, tags, hasRedirectFilter, options.SupportRedirectPlugin)
 	if err != nil {
@@ -1171,26 +1181,37 @@ func getRoutesFromMatches(
 ) ([]kongstate.Route, error) {
 	seenMethods := make(map[string]struct{})
 	routes := make([]kongstate.Route, 0)
+	// baseRoute is a clean snapshot of route's state as passed in, before any match-specific
+	// mutation below. It's used to build an independent kongstate.Route per match when
+	// hasRedirectFilter (see below), instead of mutating the single shared *route across matches.
+	baseRoute := *route
+	baseRouteName := lo.FromPtr(baseRoute.Name)
 
-	for _, match := range matches {
+	for i, match := range matches {
 		// if the rule specifies the redirectFilter, we cannot put all the paths under the same route,
-		// as the kong plugin needs to know the exact path to use to perform redirection.
+		// as the kong plugin needs to know the exact path to use to perform redirection. Each match
+		// therefore gets its own independent kongstate.Route, built from a fresh copy of baseRoute,
+		// rather than sharing (and accumulating onto) the single *route passed in.
 		if hasRedirectFilter {
-			matchRoute := route
+			matchRoute := baseRoute
+			if len(matches) > 1 {
+				// Kong route names (and the IDs generated from them) must be unique. Only disambiguate
+				// when there's more than one independent route to build from this call, so the common
+				// single-match case keeps its existing name (and thus Kong route ID) unchanged.
+				matchRoute.Name = new(fmt.Sprintf("%s.%d", baseRouteName, i))
+			}
+
 			// configure path matching information about the route if paths matching was defined
 			// Kong automatically infers whether or not a path is a regular expression and uses a prefix match by
 			// default if it is not. For those types, we use the path value as-is and let Kong determine the type.
 			// For exact matches, we transform the path into a regular expression that terminates after the value
-			addPathsFromHTTPRouteMatch(matchRoute, match)
+			addPathsFromHTTPRouteMatch(&matchRoute, match)
 
-			// configure method matching information about the route if method
-			// matching was defined.
+			// configure method matching information about the route if method matching was defined.
+			// Since matchRoute is independent per match, there's no need to deduplicate methods
+			// across matches here (unlike the non-redirect branch below).
 			if match.Method != nil {
-				method := string(*match.Method)
-				if _, ok := seenMethods[method]; !ok {
-					matchRoute.Methods = append(matchRoute.Methods, new(string(*match.Method)))
-					seenMethods[method] = struct{}{}
-				}
+				matchRoute.Methods = append(matchRoute.Methods, new(string(*match.Method)))
 			}
 			path := ""
 			if match.Path != nil && match.Path.Value != nil {
@@ -1202,11 +1223,11 @@ func getRoutesFromMatches(
 				expressionsRouterEnabled:  false,
 				redirectKongPluginEnabled: supportRedirectPlugin,
 			}
-			if err := setRoutePlugins(matchRoute, filters, path, tags, setPluginsOptions); err != nil {
+			if err := setRoutePlugins(&matchRoute, filters, path, tags, setPluginsOptions); err != nil {
 				return nil, err
 			}
 
-			routes = append(routes, *route)
+			routes = append(routes, matchRoute)
 		} else {
 			// Configure path matching information about the route if paths matching was defined
 			// Kong automatically infers whether or not a path is a regular expression and uses a prefix match by

--- a/ingress-controller/internal/dataplane/translator/subtranslator/httproute_test.go
+++ b/ingress-controller/internal/dataplane/translator/subtranslator/httproute_test.go
@@ -2151,6 +2151,188 @@ func TestTranslateHTTPRouteRulesMetaToKongstateRoutesKeepsMatchesWithDifferentPa
 	require.Equal(t, []kong.Plugin{expectedReplacePlugin}, route2.Plugins)
 }
 
+// TestGenerateKongRoutesFromHTTPRouteMatchesBuildsIndependentRoutesPerMatchForRequestRedirect calls
+// GenerateKongRoutesFromHTTPRouteMatches directly with 2 matches sharing a RequestRedirect filter,
+// bypassing translateHTTPRouteRulesMetaToKongstateRoutes' match-grouping entirely. This proves
+// getRoutesFromMatches builds independent per-match routes on its own (root-cause fix), rather than
+// relying solely on the grouping phase never handing it more than one match at a time.
+//
+// Before the fix, getRoutesFromMatches mutated a single shared *kongstate.Route across matches
+// (`matchRoute := route` only copied the pointer), so each successively-appended route accumulated
+// the Paths and Plugins of every match processed before it, and all shared the same Name (and thus
+// the same Kong route ID, since Route IDs are derived from Name).
+func TestGenerateKongRoutesFromHTTPRouteMatchesBuildsIndependentRoutesPerMatchForRequestRedirect(t *testing.T) {
+	matches := []gatewayapi.HTTPRouteMatch{
+		builder.NewHTTPRouteMatch().WithPathPrefix("/path-1").Build(),
+		builder.NewHTTPRouteMatch().WithPathPrefix("/path-2").Build(),
+	}
+	filters := []gatewayapi.HTTPRouteFilter{
+		{
+			Type: gatewayapi.HTTPRouteFilterRequestRedirect,
+			RequestRedirect: &gatewayapi.HTTPRequestRedirectFilter{
+				Hostname:   (*gatewayapi.PreciseHostname)(new("example.org")),
+				StatusCode: new(302),
+			},
+		},
+	}
+
+	routes, err := GenerateKongRoutesFromHTTPRouteMatches(
+		"httproute.default.httproute-1.0.0",
+		matches,
+		filters,
+		util.K8sObjectInfo{},
+		nil,
+		nil,
+		nil,
+		TranslateHTTPRouteRulesToKongRouteOptions{},
+	)
+	require.NoError(t, err)
+	require.Len(t, routes, 2)
+
+	pluginsForPath := func(path string) []kong.Plugin {
+		return []kong.Plugin{
+			{
+				Name: new("request-termination"),
+				Config: kong.Configuration{
+					"status_code": new(302),
+				},
+			},
+			{
+				Name: new("response-transformer"),
+				Config: kong.Configuration{
+					"add": TransformerPluginConfig{
+						Headers: []Header{
+							NewHeader("Location", "http://example.org"+path),
+						},
+					},
+				},
+			},
+		}
+	}
+
+	require.Equal(t, "httproute.default.httproute-1.0.0.0", *routes[0].Name)
+	require.Equal(t, kong.StringSlice("~/path-1$", "/path-1/"), routes[0].Paths)
+	require.Equal(t, pluginsForPath("/path-1"), routes[0].Plugins)
+
+	require.Equal(t, "httproute.default.httproute-1.0.0.1", *routes[1].Name)
+	require.Equal(t, kong.StringSlice("~/path-2$", "/path-2/"), routes[1].Paths)
+	require.Equal(t, pluginsForPath("/path-2"), routes[1].Plugins)
+}
+
+// TestTranslateHTTPRouteRulesMetaToKongstateRoutesKeepsMatchesSeparateWhenRequestRedirectIsPresent
+// mirrors the URLRewrite/ReplacePrefixMatch regression test above: two rules sharing backendRefs
+// and the exact same RequestRedirect filter, but with different match path prefixes, must never be
+// consolidated into a single Kong route/plugin. Unlike ReplacePrefixMatch, Gateway API's CEL rules
+// don't cap RequestRedirect (without a ReplacePrefixMatch path override) to one match per rule, so
+// this scenario is reachable both across rules (as tested here) and within a single rule's own
+// multiple matches - getUniqueKey's per-(rule,match) keying handles both the same way.
+func TestTranslateHTTPRouteRulesMetaToKongstateRoutesKeepsMatchesSeparateWhenRequestRedirectIsPresent(t *testing.T) {
+	httpRoute := &gatewayapi.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "httproute-1",
+		},
+	}
+	requestRedirectFilters := []gatewayapi.HTTPRouteFilter{
+		{
+			Type: gatewayapi.HTTPRouteFilterRequestRedirect,
+			RequestRedirect: &gatewayapi.HTTPRequestRedirectFilter{
+				Hostname:   (*gatewayapi.PreciseHostname)(new("example.org")),
+				StatusCode: new(302),
+			},
+		},
+	}
+	rulesMeta := []httpRouteRuleMeta{
+		{
+			Rule: gatewayapi.HTTPRouteRule{
+				BackendRefs: builder.NewHTTPBackendRef("service-1").ToSlice(),
+				Filters:     requestRedirectFilters,
+				Matches: []gatewayapi.HTTPRouteMatch{
+					builder.NewHTTPRouteMatch().WithPathPrefix("/path-1").Build(),
+				},
+			},
+			RuleNumber:  0,
+			parentRoute: httpRoute,
+		},
+		{
+			Rule: gatewayapi.HTTPRouteRule{
+				BackendRefs: builder.NewHTTPBackendRef("service-1").ToSlice(),
+				Filters:     requestRedirectFilters,
+				Matches: []gatewayapi.HTTPRouteMatch{
+					builder.NewHTTPRouteMatch().WithPathPrefix("/path-2").Build(),
+				},
+			},
+			RuleNumber:  1,
+			parentRoute: httpRoute,
+		},
+	}
+	matchesWithPriorities := []SplitHTTPRouteMatchToKongRoutePriority{
+		{
+			Match: SplitHTTPRouteMatch{
+				Source:     httpRoute,
+				RuleIndex:  0,
+				MatchIndex: 0,
+			},
+			Priority: 1,
+		},
+		{
+			Match: SplitHTTPRouteMatch{
+				Source:     httpRoute,
+				RuleIndex:  1,
+				MatchIndex: 0,
+			},
+			Priority: 1,
+		},
+	}
+
+	routes, err := translateHTTPRouteRulesMetaToKongstateRoutes(
+		rulesMeta,
+		matchesWithPriorities,
+		TranslateHTTPRouteRulesToKongRouteOptions{},
+	)
+	require.NoError(t, err)
+	require.Len(t, routes, 2)
+
+	routesByName := make(map[string]kongstate.Route, len(routes))
+	for _, route := range routes {
+		routesByName[*route.Name] = route
+	}
+
+	pluginsForPath := func(path string) []kong.Plugin {
+		return []kong.Plugin{
+			{
+				Name: new("request-termination"),
+				Config: kong.Configuration{
+					"status_code": new(302),
+				},
+				Tags: util.GenerateTagsForObject(httpRoute),
+			},
+			{
+				Name: new("response-transformer"),
+				Config: kong.Configuration{
+					"add": TransformerPluginConfig{
+						Headers: []Header{
+							NewHeader("Location", "http://example.org"+path),
+						},
+					},
+				},
+				Tags: util.GenerateTagsForObject(httpRoute),
+			},
+		}
+	}
+
+	// getUniqueKey splits these into singleton groups (one match per GenerateKongRoutesFromHTTPRouteMatches
+	// call), so getRoutesFromMatches never needs to disambiguate a Name here - each keeps its
+	// original, unsuffixed name.
+	route1 := routesByName["httproute.default.httproute-1.0.0"]
+	require.Equal(t, kong.StringSlice("~/path-1$", "/path-1/"), route1.Paths)
+	require.Equal(t, pluginsForPath("/path-1"), route1.Plugins)
+
+	route2 := routesByName["httproute.default.httproute-1.1.0"]
+	require.Equal(t, kong.StringSlice("~/path-2$", "/path-2/"), route2.Paths)
+	require.Equal(t, pluginsForPath("/path-2"), route2.Plugins)
+}
+
 func TestTranslateHTTPRouteRulesMetaToKongstateRoutesSplitsHeaderOnlyMatchesFromPathMatches(t *testing.T) {
 	httpRoute := &gatewayapi.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{

--- a/ingress-controller/internal/dataplane/translator/subtranslator/httproute_test.go
+++ b/ingress-controller/internal/dataplane/translator/subtranslator/httproute_test.go
@@ -2051,6 +2051,106 @@ func TestTranslateHTTPRouteRulesMetaToKongstateRoutesConsolidatesMatchesWithMaxR
 	require.Equal(t, kong.StringSlice("~/very-long$", "~/bar$", "/bar/"), route.Paths)
 }
 
+func TestTranslateHTTPRouteRulesMetaToKongstateRoutesKeepsMatchesWithDifferentPathsSeparateWhenURLRewriteReplacePrefixMatchIsPresent(t *testing.T) {
+	httpRoute := &gatewayapi.HTTPRoute{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: "default",
+			Name:      "httproute-1",
+		},
+	}
+	urlRewriteFilters := []gatewayapi.HTTPRouteFilter{
+		{
+			Type: gatewayapi.HTTPRouteFilterURLRewrite,
+			URLRewrite: &gatewayapi.HTTPURLRewriteFilter{
+				Path: &gatewayapi.HTTPPathModifier{
+					Type:               gatewayapi.PrefixMatchHTTPPathModifier,
+					ReplacePrefixMatch: new("/anything"),
+				},
+			},
+		},
+	}
+	// Two rules sharing the same backendRefs and the exact same URLRewrite/ReplacePrefixMatch
+	// filter, but with different match path prefixes. Before the fix, both rules' matches were
+	// consolidated into a single Kong route/plugin, so only the first rule's path prefix worked
+	// and the second 404'd.
+	rulesMeta := []httpRouteRuleMeta{
+		{
+			Rule: gatewayapi.HTTPRouteRule{
+				BackendRefs: builder.NewHTTPBackendRef("service-1").ToSlice(),
+				Filters:     urlRewriteFilters,
+				Matches: []gatewayapi.HTTPRouteMatch{
+					builder.NewHTTPRouteMatch().WithPathPrefix("/path-1").Build(),
+				},
+			},
+			RuleNumber:  0,
+			parentRoute: httpRoute,
+		},
+		{
+			Rule: gatewayapi.HTTPRouteRule{
+				BackendRefs: builder.NewHTTPBackendRef("service-1").ToSlice(),
+				Filters:     urlRewriteFilters,
+				Matches: []gatewayapi.HTTPRouteMatch{
+					builder.NewHTTPRouteMatch().WithPathPrefix("/path-2").Build(),
+				},
+			},
+			RuleNumber:  1,
+			parentRoute: httpRoute,
+		},
+	}
+	matchesWithPriorities := []SplitHTTPRouteMatchToKongRoutePriority{
+		{
+			Match: SplitHTTPRouteMatch{
+				Source:     httpRoute,
+				RuleIndex:  0,
+				MatchIndex: 0,
+			},
+			Priority: 1,
+		},
+		{
+			Match: SplitHTTPRouteMatch{
+				Source:     httpRoute,
+				RuleIndex:  1,
+				MatchIndex: 0,
+			},
+			Priority: 1,
+		},
+	}
+
+	routes, err := translateHTTPRouteRulesMetaToKongstateRoutes(
+		rulesMeta,
+		matchesWithPriorities,
+		TranslateHTTPRouteRulesToKongRouteOptions{},
+	)
+	require.NoError(t, err)
+	// The two rules' matches must never be consolidated into a single Kong route: each carries a
+	// different path prefix that the shared URLRewrite/ReplacePrefixMatch filter must rewrite
+	// independently, which Kong cannot express as a single route + single plugin instance.
+	require.Len(t, routes, 2)
+
+	routesByName := make(map[string]kongstate.Route, len(routes))
+	for _, route := range routes {
+		routesByName[*route.Name] = route
+	}
+
+	expectedReplacePlugin := kong.Plugin{
+		Name: new("request-transformer"),
+		Config: kong.Configuration{
+			"replace": TransformerPluginReplaceConfig{
+				URI: "/anything$(uri_captures[1])",
+			},
+		},
+		Tags: util.GenerateTagsForObject(httpRoute),
+	}
+
+	route1 := routesByName["httproute.default.httproute-1.0.0"]
+	require.Equal(t, kong.StringSlice("~/path-1$", "~/path-1(/.*)"), route1.Paths)
+	require.Equal(t, []kong.Plugin{expectedReplacePlugin}, route1.Plugins)
+
+	route2 := routesByName["httproute.default.httproute-1.1.0"]
+	require.Equal(t, kong.StringSlice("~/path-2$", "~/path-2(/.*)"), route2.Paths)
+	require.Equal(t, []kong.Plugin{expectedReplacePlugin}, route2.Plugins)
+}
+
 func TestTranslateHTTPRouteRulesMetaToKongstateRoutesSplitsHeaderOnlyMatchesFromPathMatches(t *testing.T) {
 	httpRoute := &gatewayapi.HTTPRoute{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
**What this PR does / why we need it**:

Use `getUniqueKey` that splitting different paths to merge matches in `HTTPRoute` for translating, when it has `PathPrefixRewrite` filter or `RequestRedirect` filter. 
The pre-existing code is already spliting routes for `RequestRedirect` filter but it used pointer to the base route so the routes are not generated correctly. The PR fixes it.

**Which issue this PR fixes**

Fixes #5475 

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
