### PR TITLE
ci: fix renovate rule for ksai

### DIFF
--- a/.github/workflows/ksai.yaml
+++ b/.github/workflows/ksai.yaml
@@ -18,6 +18,7 @@ on:
     types: [created]
 
 env:
+  # renovate: datasource=github-tags depName=Kong/ksai extractVersion=^ksai/v(?<version>.+)$
   KSAI_REF: ksai/v3.28.0
 
 jobs:

--- a/renovate.json
+++ b/renovate.json
@@ -110,13 +110,13 @@
       ]
     },
     {
-      "description": "Match dependencies in .github/workflows/* that are properly annotated with `# renovate: datasource={} depName={}.`",
+      "description": "Match dependencies in .github/workflows/* that are properly annotated with `# renovate: datasource={} depName={} [packageName={}] [extractVersion={}] [versioning={}].` The value may carry a tag prefix (e.g. `ksai/v3.28.0`); only the version part is captured and rewritten.",
       "customType": "regex",
       "fileMatch": [
         "\\.github/workflows/.*\\.yaml$"
       ],
       "matchStrings": [
-        "# renovate: datasource=(?<datasource>.*?) depName=(?<depName>.*?)\\n.+:\\s*\"?(?<currentValue>[0-9]+\\.[0-9.]+)\"?\\n"
+        "#\\s+renovate:\\s+datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)(\\s+packageName=(?<packageName>\\S+))?(\\s+extractVersion=(?<extractVersion>\\S+))?(\\s+versioning=(?<versioning>\\S+))?[^\\n]*\\n[^\\n]*?:\\s*\"?[^\"\\s]*?v?(?<currentValue>[0-9]+\\.[0-9.]+)\"?"
       ]
     },
     {
@@ -146,39 +146,6 @@
       "matchStrings": [
         "#\\s+renovate:\\s+datasource=(?<datasource>.*?)\\s+depName=(?<depName>.*?)\\s+(packageName=(?<packageName>.*)\\s+)?(registryUrl=(?<registryUrl>.*)\\s+)?versioning=(?<versioning>.*?)\\n.+'(?<currentValue>.*?)'"
       ]
-    },
-    {
-      "description": "Bump CODEOWNERS_AUTHZ_REF in .github/workflows/muthur.yaml to the latest Kong/ksai codeowners-authz release",
-      "customType": "regex",
-      "fileMatch": ["^\\.github/workflows/muthur\\.yaml$"],
-      "matchStrings": ["CODEOWNERS_AUTHZ_REF:\\s*codeowners-authz/v(?<currentValue>[0-9.]+)"],
-      "depNameTemplate": "Kong/ksai/codeowners-authz",
-      "packageNameTemplate": "Kong/ksai",
-      "extractVersionTemplate": "^codeowners-authz/v(?<version>[0-9.]+)$",
-      "datasourceTemplate": "github-tags",
-      "versioningTemplate": "semver"
-    },
-    {
-      "description": "Bump AI_REVIEWER_FEDERATED_REF in .github/workflows/muthur.yaml to the latest Kong/ksai ai-reviewer-federated release",
-      "customType": "regex",
-      "fileMatch": ["^\\.github/workflows/muthur\\.yaml$"],
-      "matchStrings": ["AI_REVIEWER_FEDERATED_REF:\\s*ai-reviewer-federated/v(?<currentValue>[0-9.]+)"],
-      "depNameTemplate": "Kong/ksai/ai-reviewer-federated",
-      "packageNameTemplate": "Kong/ksai",
-      "extractVersionTemplate": "^ai-reviewer-federated/v(?<version>[0-9.]+)$",
-      "datasourceTemplate": "github-tags",
-      "versioningTemplate": "semver"
-    },
-    {
-      "description": "Bump KREVIEW_PLUGIN_REF in .github/workflows/muthur.yaml to the latest Kong/ksai kreview plugin release",
-      "customType": "regex",
-      "fileMatch": ["^\\.github/workflows/muthur\\.yaml$"],
-      "matchStrings": ["KREVIEW_PLUGIN_REF:\\s*plugins/kreview/v(?<currentValue>[0-9.]+)"],
-      "depNameTemplate": "Kong/ksai/plugins/kreview",
-      "packageNameTemplate": "Kong/ksai",
-      "extractVersionTemplate": "^plugins/kreview/v(?<version>[0-9.]+)$",
-      "datasourceTemplate": "github-tags",
-      "versioningTemplate": "semver"
     }
   ],
   "packageRules": [


### PR DESCRIPTION
**What this PR does / why we need it**:

Tested locally:

```
             "deps": [
               {
                 "depName": "Kong/ksai",
                 "currentValue": "3.28.0",
                 "datasource": "github-tags",
                 "extractVersion": "^ksai/v(?<version>.+)$",
                 "replaceString": "# renovate: datasource=github-tags depName=Kong/ksai extractVersion=^ksai/v(?<version>.+)$\n  KSAI_REF: ksai/v3.28.0",
                 "updates": [
                   {
                     "bucket": "patch",
                     "newVersion": "3.28.3",
                     "newValue": "3.28.3",
                     "releaseTimestamp": "2026-09-03T13:46:13.000Z",
                     "newVersionAgeInDays": 0,
                     "newMajor": 3,
                     "newMinor": 28,
                     "newPatch": 3,
                     "updateType": "patch",
                     "isBreaking": false,
                     "libYears": 0.0002484779299847793,
                     "branchName": "renovate/kong-ksai-3.28.x"
                   },
                   {
                     "bucket": "minor",
                     "newVersion": "3.31",
                     "newValue": "3.31",
                     "releaseTimestamp": "2026-09-04T09:26:31.000Z",
                     "newVersionAgeInDays": 0,
                     "newMajor": 3,
                     "newMinor": 31,
                     "newPatch": 0,
                     "updateType": "minor",
                     "isBreaking": false,
                     "libYears": 0.0024941019786910196,
                     "branchName": "renovate/kong-ksai-3.x"
                   }
                 ],
                 "packageName": "Kong/ksai",
                 "versioning": "semver-coerced",
                 "warnings": [],
                 "sourceUrl": "https://github.com/Kong/ksai",
                 "registryUrl": "https://github.com",
                 "mostRecentTimestamp": "2026-09-04T09:26:38.000Z",
                 "currentVersion": "3.28.0",
                 "currentVersionTimestamp": "2026-09-03T11:35:37.000Z",
                 "currentVersionAgeInDays": 0,
                 "isSingleVersion": true,
                 "fixedVersion": "3.28.0"
               }
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
