### PR TITLE
ci: use renovate to bump gh actions in .github/actions/

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,7 +14,8 @@
     "custom.regex",
     "kustomize",
      "gomod",
-     "dockerfile"
+     "dockerfile",
+     "github-actions"
   ],
   "postUpdateOptions": [
     // Run `go mod tidy` after updating Go modules to ensure go.sum is updated and tidy up any indirect dependencies.
@@ -23,6 +24,13 @@
   ],
   "dockerfile": {
     "fileMatch": ["^Dockerfile$", "^debug\\.Dockerfile$"]
+  },
+  "github-actions": {
+    // Dependabot (.github/dependabot.yml) already updates action pins in
+    // .github/workflows/*. Scope Renovate's github-actions manager to
+    // composite actions under .github/actions/, whose nested `uses:` pins
+    // (e.g. jdx/mise-action in setup-mise/action.yml) Dependabot does not see.
+    "fileMatch": ["^\\.github/actions/.+/action\\.ya?ml$"]
   },
   "automerge": false,
   "separateMinorPatch": true,


### PR DESCRIPTION
**What this PR does / why we need it**:

Dependabot can't update GH actions in `.github/actions/` hence `jdx/mise-action` didn't get updated in `.github/actions/setup-mise/action.yml` and hence didn't get the update which performs retries (https://github.com/jdx/mise-action/issues/611#issuecomment-5540204707).

This PR introduces renovate rules to bump actions in that directory.

Tested locally:

```
               {
                 "depName": "jdx/mise-action",
                 "commitMessageTopic": "{{{depName}}} action",
                 "versioning": "github-actions",
                 "depType": "action",
                 "replaceString": "jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4",
                 "autoReplaceStringTemplate": "{{depName}}@{{#if newDigest}}{{newDigest}}{{#if newValue}} # {{newValue}}{{/if}}{{/if}}{{#unless newDigest}}{{newValue}}{{/unless}}",
                 "currentValue": "v4.2.4",
                 "currentDigest": "7e36c90d9ab29c415a2384db3006f3ec8a8cc654",
                 "datasource": "github-tags",
                 "updates": [
                   {
                     "bucket": "patch",
                     "newVersion": "v4.2.5",
                     "newValue": "v4.2.5",
                     "newDigest": "3c2e0cf82a5b2e5249f0d3635a4d83d0ae861518",
                     "releaseTimestamp": "2026-08-13T10:23:24.000Z",
                     "newVersionAgeInDays": 22,
                     "newMajor": 4,
                     "newMinor": 2,
                     "newPatch": 5,
                     "updateType": "patch",
                     "isBreaking": false,
                     "libYears": 0.032860318366311515,
                     "branchName": "renovate/jdx-mise-action-4.2.x"
                   },
                   {
                     "bucket": "minor",
                     "newVersion": "v4.3.0",
                     "newValue": "v4.3.0",
                     "newDigest": "c2a87611a18de5b3828c5652fe268e992400cb5c",
                     "releaseTimestamp": "2026-08-25T10:08:22.000Z",
                     "newVersionAgeInDays": 10,
                     "newMajor": 4,
                     "newMinor": 3,
                     "newPatch": 0,
                     "updateType": "minor",
                     "isBreaking": false,
                     "libYears": 0.06570842846270929,
                     "branchName": "renovate/jdx-mise-action-4.x"
                   }
                 ],
                 "packageName": "jdx/mise-action",
                 "warnings": [],
                 "sourceUrl": "https://github.com/jdx/mise-action",
                 "registryUrl": "https://github.com",
                 "mostRecentTimestamp": "2026-08-25T10:08:22.000Z",
                 "currentVersion": "v4.2.4",
                 "currentVersionTimestamp": "2026-08-01T10:32:01.000Z",
                 "currentVersionAgeInDays": 34,
                 "isSingleVersion": true,
                 "fixedVersion": "v4.2.4"
               },
```


**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
