### PR TITLE
chore: move OwnedObjectPreDeleteHook to pkg/utils/kubernetes/reduce

### DIFF
--- a/controller/dataplane/bluegreen_controller.go
+++ b/controller/dataplane/bluegreen_controller.go
@@ -28,7 +28,6 @@ import (
 	kcfgkonnect "github.com/kong/kong-operator/v2/api/konnect"
 	ctrlconsts "github.com/kong/kong-operator/v2/controller/consts"
 	"github.com/kong/kong-operator/v2/controller/pkg/address"
-	"github.com/kong/kong-operator/v2/controller/pkg/dataplane"
 	"github.com/kong/kong-operator/v2/controller/pkg/extensions"
 	extensionserrors "github.com/kong/kong-operator/v2/controller/pkg/extensions/errors"
 	extensionskonnect "github.com/kong/kong-operator/v2/controller/pkg/extensions/konnect"
@@ -38,6 +37,7 @@ import (
 	"github.com/kong/kong-operator/v2/pkg/consts"
 	"github.com/kong/kong-operator/v2/pkg/ipfamily"
 	k8sutils "github.com/kong/kong-operator/v2/pkg/utils/kubernetes"
+	k8sreduce "github.com/kong/kong-operator/v2/pkg/utils/kubernetes/reduce"
 	k8sresources "github.com/kong/kong-operator/v2/pkg/utils/kubernetes/resources"
 )
 
@@ -609,7 +609,7 @@ func (r *BlueGreenReconciler) reduceLiveDeployments(
 			"deployment", client.ObjectKeyFromObject(&deployment),
 		)
 
-		if err := dataplane.OwnedObjectPreDeleteHook(ctx, r.Client, &deployment); err != nil {
+		if err := k8sreduce.OwnedObjectPreDeleteHook(ctx, r.Client, &deployment); err != nil {
 			return fmt.Errorf("failed executing pre delete hook: %w", err)
 		}
 		if err := r.Delete(ctx, &deployment); err != nil {

--- a/controller/dataplane/bluegreen_controller_test.go
+++ b/controller/dataplane/bluegreen_controller_test.go
@@ -18,10 +18,10 @@ import (
 
 	operatorv1beta1 "github.com/kong/kong-operator/v2/api/gateway-operator/v1beta1"
 	"github.com/kong/kong-operator/v2/controller/pkg/builder"
-	"github.com/kong/kong-operator/v2/controller/pkg/dataplane"
 	"github.com/kong/kong-operator/v2/controller/pkg/op"
 	"github.com/kong/kong-operator/v2/pkg/consts"
 	k8sutils "github.com/kong/kong-operator/v2/pkg/utils/kubernetes"
+	k8sreduce "github.com/kong/kong-operator/v2/pkg/utils/kubernetes/reduce"
 	k8sresources "github.com/kong/kong-operator/v2/pkg/utils/kubernetes/resources"
 )
 
@@ -147,7 +147,7 @@ func TestEnsurePreviewIngressService(t *testing.T) {
 			).WithIngressServiceType(corev1.ServiceTypeLoadBalancer).
 				WithPromotionStrategy(operatorv1beta1.AutomaticPromotion).Build(),
 			existingServiceModifier: func(t *testing.T, ctx context.Context, cl client.Client, svc *corev1.Service) {
-				require.NoError(t, dataplane.OwnedObjectPreDeleteHook(ctx, cl, svc))
+				require.NoError(t, k8sreduce.OwnedObjectPreDeleteHook(ctx, cl, svc))
 				require.NoError(t, cl.Delete(ctx, svc))
 			},
 			expectedCreatedOrUpdated: op.Created,

--- a/controller/dataplane/owned_deployment.go
+++ b/controller/dataplane/owned_deployment.go
@@ -17,7 +17,6 @@ import (
 
 	operatorv1beta1 "github.com/kong/kong-operator/v2/api/gateway-operator/v1beta1"
 	"github.com/kong/kong-operator/v2/controller/dataplane/certificates"
-	dataplanepkg "github.com/kong/kong-operator/v2/controller/pkg/dataplane"
 	"github.com/kong/kong-operator/v2/controller/pkg/log"
 	"github.com/kong/kong-operator/v2/controller/pkg/op"
 	"github.com/kong/kong-operator/v2/controller/pkg/patch"
@@ -284,7 +283,7 @@ func listOrReduceDataPlaneDeployments(
 
 	count := len(deployments)
 	if count > 1 {
-		if err := k8sreduce.ReduceDeployments(ctx, cl, deployments, dataplanepkg.OwnedObjectPreDeleteHook); err != nil {
+		if err := k8sreduce.ReduceDeployments(ctx, cl, deployments, k8sreduce.OwnedObjectPreDeleteHook); err != nil {
 			return false, nil, err
 		}
 		return true, nil, errors.New("number of deployments reduced")

--- a/controller/dataplane/owned_resources.go
+++ b/controller/dataplane/owned_resources.go
@@ -19,7 +19,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
 	operatorv1beta1 "github.com/kong/kong-operator/v2/api/gateway-operator/v1beta1"
-	"github.com/kong/kong-operator/v2/controller/pkg/dataplane"
 	"github.com/kong/kong-operator/v2/controller/pkg/op"
 	"github.com/kong/kong-operator/v2/controller/pkg/patch"
 	"github.com/kong/kong-operator/v2/controller/pkg/secrets"
@@ -226,7 +225,7 @@ func ensureAdminServiceForDataPlane(
 
 	count := len(services)
 	if count > 1 {
-		if err := k8sreduce.ReduceServices(ctx, cl, services, dataplane.OwnedObjectPreDeleteHook); err != nil {
+		if err := k8sreduce.ReduceServices(ctx, cl, services, k8sreduce.OwnedObjectPreDeleteHook); err != nil {
 			return op.Noop, nil, err
 		}
 		return op.Noop, nil, errors.New("number of DataPlane Admin API services reduced")
@@ -304,13 +303,13 @@ func ensureIngressServiceForDataPlane(
 	count := len(services)
 	if serviceName := k8sresources.GetDataPlaneIngressServiceName(dataPlane); serviceName != "" {
 		if count > 1 || (count == 1 && services[0].Name != serviceName) {
-			if err := k8sreduce.ReduceServicesByName(ctx, cl, services, serviceName, dataplane.OwnedObjectPreDeleteHook); err != nil {
+			if err := k8sreduce.ReduceServicesByName(ctx, cl, services, serviceName, k8sreduce.OwnedObjectPreDeleteHook); err != nil {
 				return op.Noop, nil, err
 			}
 			return op.Noop, nil, errors.New("DataPlane ingress services with different names reduced")
 		}
 	} else if count > 1 {
-		if err := k8sreduce.ReduceServices(ctx, cl, services, dataplane.OwnedObjectPreDeleteHook); err != nil {
+		if err := k8sreduce.ReduceServices(ctx, cl, services, k8sreduce.OwnedObjectPreDeleteHook); err != nil {
 			return op.Noop, nil, err
 		}
 		return op.Noop, nil, errors.New("number of DataPlane ingress services reduced")

--- a/controller/dataplane/owned_resources_test.go
+++ b/controller/dataplane/owned_resources_test.go
@@ -15,10 +15,10 @@ import (
 
 	operatorv1beta1 "github.com/kong/kong-operator/v2/api/gateway-operator/v1beta1"
 	"github.com/kong/kong-operator/v2/controller/pkg/builder"
-	"github.com/kong/kong-operator/v2/controller/pkg/dataplane"
 	"github.com/kong/kong-operator/v2/controller/pkg/op"
 	"github.com/kong/kong-operator/v2/pkg/consts"
 	k8sutils "github.com/kong/kong-operator/v2/pkg/utils/kubernetes"
+	k8sreduce "github.com/kong/kong-operator/v2/pkg/utils/kubernetes/reduce"
 	k8sresources "github.com/kong/kong-operator/v2/pkg/utils/kubernetes/resources"
 )
 
@@ -46,7 +46,7 @@ func TestEnsureIngressServiceForDataPlane(t *testing.T) {
 				WithIngressServiceType(corev1.ServiceTypeLoadBalancer).
 				Build(),
 			existingServiceModifier: func(t *testing.T, ctx context.Context, c client.Client, svc *corev1.Service) {
-				require.NoError(t, dataplane.OwnedObjectPreDeleteHook(ctx, c, svc))
+				require.NoError(t, k8sreduce.OwnedObjectPreDeleteHook(ctx, c, svc))
 				require.NoError(t, c.Delete(ctx, svc))
 			},
 			expectedCreatedOrUpdated: op.Created,
@@ -277,7 +277,7 @@ func TestEnsureIngressServiceForDataPlane(t *testing.T) {
 				WithIngressServiceType(corev1.ServiceTypeLoadBalancer).
 				Build(),
 			existingServiceModifier: func(t *testing.T, ctx context.Context, c client.Client, svc *corev1.Service) {
-				require.NoError(t, dataplane.OwnedObjectPreDeleteHook(ctx, c, svc))
+				require.NoError(t, k8sreduce.OwnedObjectPreDeleteHook(ctx, c, svc))
 				require.NoError(t, c.Delete(ctx, svc))
 			},
 			expectedCreatedOrUpdated: op.Created,

--- a/controller/pkg/secrets/cert.go
+++ b/controller/pkg/secrets/cert.go
@@ -30,7 +30,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 
 	operatorv1beta1 "github.com/kong/kong-operator/v2/api/gateway-operator/v1beta1"
-	"github.com/kong/kong-operator/v2/controller/pkg/dataplane"
 	"github.com/kong/kong-operator/v2/controller/pkg/op"
 	"github.com/kong/kong-operator/v2/modules/manager/logging"
 	"github.com/kong/kong-operator/v2/pkg/consts"
@@ -274,7 +273,7 @@ func getPreDeleteHooks[T interface {
 ) []k8sreduce.PreDeleteHook {
 	switch any(obj).(type) {
 	case *operatorv1beta1.DataPlane:
-		return []k8sreduce.PreDeleteHook{dataplane.OwnedObjectPreDeleteHook}
+		return []k8sreduce.PreDeleteHook{k8sreduce.OwnedObjectPreDeleteHook}
 	default:
 		return nil
 	}

--- a/pkg/utils/kubernetes/reduce/pre_delete_hook.go
+++ b/pkg/utils/kubernetes/reduce/pre_delete_hook.go
@@ -1,4 +1,4 @@
-package dataplane
+package reduce
 
 import (
 	"context"


### PR DESCRIPTION
**What this PR does / why we need it**:

Moves `OwnedObjectPreDeleteHook` from `controller/pkg/dataplane` to `pkg/utils/kubernetes/reduce`, where the `PreDeleteHook` type it implements is already defined. Its only consumers are the generic resource-reduction machinery and `controller/pkg/secrets`, so the helper belongs there.

The move also unblocks the follow-up layers in this stack: the upcoming shared specialized-DataPlane reconciler package (`controller/pkg/dataplane`) must not be imported by `controller/pkg/secrets`, or tests would hit an import cycle.

Pure move plus import updates (7 files, +13/-16). No behavior change.

**Which issue this PR fixes**

Part of #4842 

**Special notes for your reviewer**:


**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

~- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes~