### PR TITLE
chore: use kube-api-linter fork temporarily

### DIFF
--- a/.mise.toml
+++ b/.mise.toml
@@ -73,7 +73,7 @@ version = "4.2.4"
 # Upstream issue: https://github.com/kubernetes-sigs/kube-api-linter/issues/260
 [tools."go:github.com/pmalek/kube-api-linter/cmd/golangci-lint-kube-api-linter"]
 # renovate: datasource=git-refs packageName=https://github.com/kubernetes-sigs/kube-api-linter.git
-version = "6b06cb05a11187aaccff49eb034d9c9d07c1c00e"
+version = "f6c98d29c0424bdfa52de5b80af681f602625383"
 
 [tools."yq"]
 # renovate: datasource=github-releases depName=mikefarah/yq

--- a/.mise.toml
+++ b/.mise.toml
@@ -68,9 +68,12 @@ macos-arm64 = { asset_pattern = "telepresence-darwin-arm64" }
 # renovate: datasource=github-releases depName=helm/helm
 version = "4.2.4"
 
-[tools."go:sigs.k8s.io/kube-api-linter/cmd/golangci-lint-kube-api-linter"]
+# NOTE: temporary override to work around:
+# export data version 4 is greater than maximum supported version 2
+# Upstream issue: https://github.com/kubernetes-sigs/kube-api-linter/issues/260
+[tools."go:github.com/pmalek/kube-api-linter/cmd/golangci-lint-kube-api-linter"]
 # renovate: datasource=git-refs packageName=https://github.com/kubernetes-sigs/kube-api-linter.git
-version = "092fe0c72997c3e7d6d78405211ed913e37a44e5"
+version = "6b06cb05a11187aaccff49eb034d9c9d07c1c00e"
 
 [tools."yq"]
 # renovate: datasource=github-releases depName=mikefarah/yq

--- a/Makefile
+++ b/Makefile
@@ -208,11 +208,14 @@ HELM = helm
 download.helm: mise ## Download helm locally if necessary.
 	$(MAKE) mise-install-global DEP_BIN=$(HELM) DEP_VER=aqua:helm/helm
 
-KUBE_API_LINTER_VERSION = $(shell $(YQ) -p toml -o yaml '.tools["go:sigs.k8s.io/kube-api-linter/cmd/golangci-lint-kube-api-linter"].version' < $(MISE_FILE))
-KUBE_API_LINTER = $(PROJECT_DIR)/bin/installs/go-sigs-k8s-io-kube-api-linter-cmd-golangci-lint-kube-api-linter/$(KUBE_API_LINTER_VERSION)/bin/golangci-lint-kube-api-linter
+# NOTE: temporary override to work around:
+# export data version 4 is greater than maximum supported version 2
+# Upstream issue: https://github.com/kubernetes-sigs/kube-api-linter/issues/260
+KUBE_API_LINTER_VERSION = $(shell $(YQ) -p toml -o yaml '.tools["go:github.com/pmalek/kube-api-linter/cmd/golangci-lint-kube-api-linter"].version' < $(MISE_FILE))
+KUBE_API_LINTER = $(PROJECT_DIR)/bin/installs/go-github-com-pmalek-kube-api-linter-cmd-golangci-lint-kube-api-linter/$(KUBE_API_LINTER_VERSION)/bin/golangci-lint-kube-api-linter
 .PHONY: download.kube-api-linter
 download.kube-api-linter: mise ## Download kube-api-linter locally if necessary.
-	$(MAKE) mise-install TOOL_BIN=$(KUBE_API_LINTER) DEP_VER=go:sigs.k8s.io/kube-api-linter/cmd/golangci-lint-kube-api-linter@$(KUBE_API_LINTER_VERSION)
+	$(MAKE) mise-install TOOL_BIN=$(KUBE_API_LINTER) DEP_VER=go:github.com/pmalek/kube-api-linter/cmd/golangci-lint-kube-api-linter@$(KUBE_API_LINTER_VERSION)
 
 CHAINSAW_VERSION = $(shell $(YQ) -p toml -o yaml '.tools["aqua:kyverno/chainsaw"].version' < $(MISE_FILE))
 CHAINSAW = $(PROJECT_DIR)/bin/installs/aqua-kyverno-chainsaw/$(CHAINSAW_VERSION)/chainsaw


### PR DESCRIPTION
**What this PR does / why we need it**:

When using go 1.27 and old version of kube-api-linter (092fe0c72997c3e7d6d78405211ed913e37a44e5) which is based on golangci-lint 2.5.0, sometimes we get:

```
export data version 4 is greater than maximum supported version 2
```

error.

This PR works around this by using a fork which bumps the golangci-lint dependency to 2.13.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

Upstream issue: https://github.com/kubernetes-sigs/kube-api-linter/issues/260

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
