### PR TITLE
tests: fix TestKonnectGatewayControlPlane_CrossNamespaceRefNotPermitted

### DIFF
--- a/test/envtest/konnect-api-gw/konnect_entities_gatewaycontrolplane_test.go
+++ b/test/envtest/konnect-api-gw/konnect_entities_gatewaycontrolplane_test.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"net/url"
 	"testing"
-	"time"
 
 	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
@@ -27,6 +26,7 @@ import (
 	"github.com/kong/kong-operator/v2/modules/manager/logging"
 	"github.com/kong/kong-operator/v2/modules/manager/scheme"
 	"github.com/kong/kong-operator/v2/test/envtest"
+	"github.com/kong/kong-operator/v2/test/envtest/consts"
 	"github.com/kong/kong-operator/v2/test/helpers/deploy"
 	"github.com/kong/kong-operator/v2/test/mocks/metricsmocks"
 	"github.com/kong/kong-operator/v2/test/mocks/sdkmocks"
@@ -974,6 +974,13 @@ func TestKonnectGatewayControlPlane_CrossNamespaceRefNotPermitted(t *testing.T) 
 		konnect.NewKonnectEntityReconciler(factory, logging.DevelopmentMode, cl,
 			konnect.WithMetricRecorder[konnectv1alpha2.KonnectGatewayControlPlane](&metricsmocks.MockRecorder{})))
 
+	// Wait for the manager's cache to finish its initial sync before proceeding.
+	// StartReconcilers only launches mgr.Start(ctx) in a goroutine and returns
+	// immediately, so without this the controller's workers can start seconds
+	// after this point on a loaded machine, and the EventuallyWithT assertion
+	// below would run - and expire - before the reconciler has run even once.
+	require.True(t, mgr.GetCache().WaitForCacheSync(ctx), "manager caches failed to sync")
+
 	// Create two namespaces: one for the CP, one for the auth config target.
 	cpNs := deploy.Namespace(t, ctx, cl)
 	authNs := deploy.Namespace(t, ctx, cl)
@@ -1021,5 +1028,5 @@ func TestKonnectGatewayControlPlane_CrossNamespaceRefNotPermitted(t *testing.T) 
 			),
 			"Programmed condition reason should indicate ConditionWithStatusFalseExists",
 		)
-	}, 10*time.Second, 200*time.Millisecond)
+	}, consts.WaitTime, consts.TickTime)
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Fix failures like: https://github.com/Kong/kong-operator/actions/runs/34142249211/job/101806649977?pr=5583#step:13:5453

```
    kongplugincleanupfinalizer_test.go:59: Setting up a watch for *v1alpha1.KongService events
    konnect_entities_gatewaycontrolplane_test.go:996: 
        	Error Trace:	/home/runner/work/kong-operator/kong-operator/test/envtest/konnect-api-gw/konnect_entities_gatewaycontrolplane_test.go:1008
        	            				/opt/hostedtoolcache/go/1.26.6/x64/src/runtime/asm_amd64.s:1771
        	Error:      	Should be true
        	Messages:   	APIAuthResolvedRef condition should be False with RefNotPermitted reason
    konnect_entities_gatewaycontrolplane_test.go:996: 
        	Error Trace:	/home/runner/work/kong-operator/kong-operator/test/envtest/konnect-api-gw/konnect_entities_gatewaycontrolplane_test.go:1014
        	            				/opt/hostedtoolcache/go/1.26.6/x64/src/runtime/asm_amd64.s:1771
        	Error:      	Should be true
        	Messages:   	Programmed condition should be set to False when cross-namespace ref is not permitted
    konnect_entities_gatewaycontrolplane_test.go:996: 
        	Error Trace:	/home/runner/work/kong-operator/kong-operator/test/envtest/konnect-api-gw/konnect_entities_gatewaycontrolplane_test.go:1017
        	            				/opt/hostedtoolcache/go/1.26.6/x64/src/runtime/asm_amd64.s:1771
        	Error:      	Should be true
        	Messages:   	Programmed condition reason should indicate ConditionWithStatusFalseExists
    konnect_entities_gatewaycontrolplane_test.go:996: 
        	Error Trace:	/home/runner/work/kong-operator/kong-operator/test/envtest/konnect-api-gw/konnect_entities_gatewaycontrolplane_test.go:996
        	Error:      	Condition never satisfied
        	Test:       	TestKonnectGatewayControlPlane_CrossNamespaceRefNotPermitted
```

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
