### PR TITLE
chore(refactor): consistent way of handling sanitization

### DIFF
--- a/controller/hybridgateway/route/status_test.go
+++ b/controller/hybridgateway/route/status_test.go
@@ -200,8 +200,9 @@ func Test_isParentRefEqual(t *testing.T) {
 		{
 			name: "Group nil vs set",
 			a: func() gwtypes.ParentReference {
-				r := gwtypes.ParentReference{Name: name}
-				r.Group = groupPtr("g")
+				r := gwtypes.ParentReference{
+					Name:  name,
+					Group: groupPtr("g")}
 				return r
 			}(),
 			b:    gwtypes.ParentReference{Name: name},
@@ -211,8 +212,8 @@ func Test_isParentRefEqual(t *testing.T) {
 			name: "Group set vs nil",
 			a:    gwtypes.ParentReference{Name: name},
 			b: func() gwtypes.ParentReference {
-				r := gwtypes.ParentReference{Name: name}
-				r.Group = groupPtr("g")
+				r := gwtypes.ParentReference{Name: name,
+					Group: groupPtr("g")}
 				return r
 			}(),
 			want: false,
@@ -220,8 +221,8 @@ func Test_isParentRefEqual(t *testing.T) {
 		{
 			name: "Kind nil vs set",
 			a: func() gwtypes.ParentReference {
-				r := gwtypes.ParentReference{Name: name}
-				r.Kind = kindPtr("k")
+				r := gwtypes.ParentReference{Name: name,
+					Kind: kindPtr("k")}
 				return r
 			}(),
 			b:    gwtypes.ParentReference{Name: name},
@@ -231,8 +232,8 @@ func Test_isParentRefEqual(t *testing.T) {
 			name: "Kind set vs nil",
 			a:    gwtypes.ParentReference{Name: name},
 			b: func() gwtypes.ParentReference {
-				r := gwtypes.ParentReference{Name: name}
-				r.Kind = kindPtr("k")
+				r := gwtypes.ParentReference{Name: name,
+					Kind: kindPtr("k")}
 				return r
 			}(),
 			want: false,
@@ -240,8 +241,8 @@ func Test_isParentRefEqual(t *testing.T) {
 		{
 			name: "Namespace nil vs set",
 			a: func() gwtypes.ParentReference {
-				r := gwtypes.ParentReference{Name: name}
-				r.Namespace = nsPtr("ns")
+				r := gwtypes.ParentReference{Name: name,
+					Namespace: nsPtr("ns")}
 				return r
 			}(),
 			b:    gwtypes.ParentReference{Name: name},
@@ -251,8 +252,8 @@ func Test_isParentRefEqual(t *testing.T) {
 			name: "Namespace set vs nil",
 			a:    gwtypes.ParentReference{Name: name},
 			b: func() gwtypes.ParentReference {
-				r := gwtypes.ParentReference{Name: name}
-				r.Namespace = nsPtr("ns")
+				r := gwtypes.ParentReference{Name: name,
+					Namespace: nsPtr("ns")}
 				return r
 			}(),
 			want: false,
@@ -260,8 +261,8 @@ func Test_isParentRefEqual(t *testing.T) {
 		{
 			name: "SectionName nil vs set",
 			a: func() gwtypes.ParentReference {
-				r := gwtypes.ParentReference{Name: name}
-				r.SectionName = sectionPtr("sec")
+				r := gwtypes.ParentReference{Name: name,
+					SectionName: sectionPtr("sec")}
 				return r
 			}(),
 			b:    gwtypes.ParentReference{Name: name},
@@ -271,8 +272,8 @@ func Test_isParentRefEqual(t *testing.T) {
 			name: "SectionName set vs nil",
 			a:    gwtypes.ParentReference{Name: name},
 			b: func() gwtypes.ParentReference {
-				r := gwtypes.ParentReference{Name: name}
-				r.SectionName = sectionPtr("sec")
+				r := gwtypes.ParentReference{Name: name,
+					SectionName: sectionPtr("sec")}
 				return r
 			}(),
 			want: false,
@@ -280,8 +281,8 @@ func Test_isParentRefEqual(t *testing.T) {
 		{
 			name: "Port nil vs set",
 			a: func() gwtypes.ParentReference {
-				r := gwtypes.ParentReference{Name: name}
-				r.Port = new(int32(1))
+				r := gwtypes.ParentReference{Name: name,
+					Port: new(int32(1))}
 				return r
 			}(),
 			b:    gwtypes.ParentReference{Name: name},
@@ -291,8 +292,8 @@ func Test_isParentRefEqual(t *testing.T) {
 			name: "Port set vs nil",
 			a:    gwtypes.ParentReference{Name: name},
 			b: func() gwtypes.ParentReference {
-				r := gwtypes.ParentReference{Name: name}
-				r.Port = new(int32(1))
+				r := gwtypes.ParentReference{Name: name,
+					Port: new(int32(1))}
 				return r
 			}(),
 			want: false,

--- a/ingress-controller/internal/dataplane/kongstate/consumer.go
+++ b/ingress-controller/internal/dataplane/kongstate/consumer.go
@@ -43,42 +43,23 @@ func (c *Consumer) SanitizedCopy(uuidGenerator util.UUIDGenerator) Consumer {
 				return c.SanitizedCopy(uuidGenerator)
 			})
 		}(),
-		HMACAuths: func() []*HMACAuth {
-			if c.HMACAuths == nil {
-				return nil
-			}
-			return lo.Map(c.HMACAuths, func(c *HMACAuth, _ int) *HMACAuth {
-				return c.SanitizedCopy()
-			})
-		}(),
-		JWTAuths: func() []*JWTAuth {
-			if c.JWTAuths == nil {
-				return nil
-			}
-			return lo.Map(c.JWTAuths, func(c *JWTAuth, _ int) *JWTAuth {
-				return c.SanitizedCopy()
-			})
-		}(),
-		BasicAuths: func() []*BasicAuth {
-			if c.BasicAuths == nil {
-				return nil
-			}
-			return lo.Map(c.BasicAuths, func(c *BasicAuth, _ int) *BasicAuth {
-				return c.SanitizedCopy()
-			})
-		}(),
-		Oauth2Creds: func() []*Oauth2Credential {
-			if c.Oauth2Creds == nil {
-				return nil
-			}
-			return lo.Map(c.Oauth2Creds, func(c *Oauth2Credential, _ int) *Oauth2Credential {
-				return c.SanitizedCopy()
-			})
-		}(),
+		HMACAuths:       sanitize(c.HMACAuths),
+		JWTAuths:        sanitize(c.JWTAuths),
+		BasicAuths:      sanitize(c.BasicAuths),
+		Oauth2Creds:     sanitize(c.Oauth2Creds),
+		MTLSAuths:       sanitize(c.MTLSAuths),
 		ACLGroups:       c.ACLGroups,
-		MTLSAuths:       c.MTLSAuths,
 		K8sKongConsumer: c.K8sKongConsumer,
 	}
+}
+
+func sanitize[T interface{ SanitizedCopy() T }](items []T) []T {
+	if items == nil {
+		return nil
+	}
+	return lo.Map(items, func(item T, _ int) T {
+		return item.SanitizedCopy()
+	})
 }
 
 func (c *Consumer) SetCredential(credType string, credConfig any, tags []*string) (any, error) {

--- a/ingress-controller/internal/dataplane/kongstate/consumer_test.go
+++ b/ingress-controller/internal/dataplane/kongstate/consumer_test.go
@@ -32,22 +32,26 @@ func TestConsumer_SanitizedCopy(t *testing.T) {
 				Plugins: []kong.Plugin{{ID: new("1")}},
 				KeyAuths: []*KeyAuth{
 					{
-						ID: new("1"), Key: new("secret"),
+						ID:  new("1"),
+						Key: new("secret"),
 					},
 				},
 				HMACAuths: []*HMACAuth{
 					{
-						ID: new("1"), Secret: new("secret"),
+						ID:     new("1"),
+						Secret: new("secret"),
 					},
 				},
 				JWTAuths: []*JWTAuth{
 					{
-						ID: new("1"), Secret: new("secret"),
+						ID:     new("1"),
+						Secret: new("secret"),
 					},
 				},
 				BasicAuths: []*BasicAuth{
 					{
-						ID: new("1"), Password: new("secret"),
+						ID:       new("1"),
+						Password: new("secret"),
 					},
 				},
 				ACLGroups: []*ACLGroup{
@@ -57,12 +61,17 @@ func TestConsumer_SanitizedCopy(t *testing.T) {
 				},
 				Oauth2Creds: []*Oauth2Credential{
 					{
-						ID: new("1"), ClientSecret: new("secret"),
+						ID:           new("1"),
+						ClientSecret: new("secret"),
 					},
 				},
 				MTLSAuths: []*MTLSAuth{
 					{
-						ID: new("1"), SubjectName: new("foo@example.com"),
+
+						ID:            new("1"),
+						SubjectName:   new("foo@example.com"),
+						Consumer:      &kong.Consumer{Username: new("foo")},
+						CACertificate: &kong.CACertificate{Cert: new("ca-cert-data")},
 					},
 				},
 				K8sKongConsumer: configurationv1.KongConsumer{Username: "foo"},

--- a/ingress-controller/internal/dataplane/kongstate/credentials.go
+++ b/ingress-controller/internal/dataplane/kongstate/credentials.go
@@ -243,6 +243,17 @@ func (c *Oauth2Credential) SanitizedCopy() *Oauth2Credential {
 	}
 }
 
+// SanitizedCopy returns a shallow copy with sensitive values redacted best-effort.
+func (c *MTLSAuth) SanitizedCopy() *MTLSAuth {
+	return &MTLSAuth{
+		// Consumer and CACertificate fields omitted.
+		CreatedAt:   c.CreatedAt,
+		ID:          c.ID,
+		SubjectName: c.SubjectName,
+		Tags:        c.Tags,
+	}
+}
+
 func decodeCredential(credConfig any,
 	credStructPointer any,
 ) error {

--- a/ingress-controller/internal/dataplane/kongstate/credentials_test.go
+++ b/ingress-controller/internal/dataplane/kongstate/credentials_test.go
@@ -222,3 +222,38 @@ func TestOauth2Credential_SanitizedCopy(t *testing.T) {
 		})
 	}
 }
+
+func TestMTLSAuth_SanitizedCopy(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		in   MTLSAuth
+		want MTLSAuth
+	}{
+		{
+			name: "omits Consumer and CACertificate, keeps the rest",
+			in: MTLSAuth{
+				MTLSAuth: kong.MTLSAuth{
+					Consumer:      &kong.Consumer{Username: new("foo")},
+					CreatedAt:     new(1),
+					ID:            new("2"),
+					SubjectName:   new("foo@example.com"),
+					CACertificate: &kong.CACertificate{Cert: new("ca-cert-data")},
+					Tags:          []*string{new("3.1"), new("3.2")},
+				},
+			},
+			want: MTLSAuth{
+				MTLSAuth: kong.MTLSAuth{
+					CreatedAt:   new(1),
+					ID:          new("2"),
+					SubjectName: new("foo@example.com"),
+					Tags:        []*string{new("3.1"), new("3.2")},
+				},
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			got := *tt.in.SanitizedCopy()
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}

--- a/ingress-controller/internal/dataplane/kongstate/kongstate.go
+++ b/ingress-controller/internal/dataplane/kongstate/kongstate.go
@@ -88,14 +88,7 @@ func (ks *KongState) SanitizedCopy(uuidGenerator util.UUIDGenerator) *KongState 
 				return c.SanitizedCopy(uuidGenerator)
 			})
 		}(),
-		Licenses: func() []License {
-			if ks.Licenses == nil {
-				return nil
-			}
-			return lo.Map(ks.Licenses, func(l License, _ int) License {
-				return l.SanitizedCopy()
-			})
-		}(),
+		Licenses:       sanitize(ks.Licenses),
 		ConsumerGroups: ks.ConsumerGroups,
 		Vaults:         ks.Vaults,
 		CustomEntities: ks.CustomEntities,


### PR DESCRIPTION
**What this PR does / why we need it**:

Currently, there is no leak of confidential data in the dump for `MTLSAuths`, but keeping the same path for it as for any other type (dedicated method `Sanitize()`) that drops redundant fields which are not needed (becasue there already included in other parts of the dump) is beneficial for keeping code consistent for all supported types and avoiding potential leakage in the future. 

**Which issue this PR fixes**

Suggestion from [the report](https://github.com/Kong/kong-operator/security/advisories/GHSA-88hg-2mhq-rxr6)


