### PR TITLE
chore(ci): set mise version in actions and bump it via renovate

### DIFF
--- a/.github/actions/setup-mise/action.yml
+++ b/.github/actions/setup-mise/action.yml
@@ -26,5 +26,7 @@ runs:
 
     - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
       with:
+        # renovate: datasource=github-releases depName=jdx/mise extractVersion=^v(?<version>.+)$
+        version: 2026.9.2
         install: ${{ inputs.install }}
         install_args: ${{ inputs.install_args }}

--- a/.github/workflows/conformance_tests_report.yaml
+++ b/.github/workflows/conformance_tests_report.yaml
@@ -47,6 +47,8 @@ jobs:
       # This will be able to be updated when we stop producing reports for older versions.
       - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
+          # renovate: datasource=github-tags depName=jdx/mise-action extractVersion=^v(?<version>.+)$
+          version: 2026.9.2
           install: false
 
       - name: Setup Golang

--- a/renovate.json
+++ b/renovate.json
@@ -118,10 +118,11 @@
       ]
     },
     {
-      "description": "Match dependencies in .github/workflows/* that are properly annotated with `# renovate: datasource={} depName={} [packageName={}] [extractVersion={}] [versioning={}].` The value may carry a tag prefix (e.g. `ksai/v3.28.0`); only the version part is captured and rewritten.",
+      "description": "Match dependencies in .github/workflows/* and .github/actions/*/action.yml that are properly annotated with `# renovate: datasource={} depName={} [packageName={}] [extractVersion={}] [versioning={}].` The value may carry a tag prefix (e.g. `ksai/v3.28.0`); only the version part is captured and rewritten.",
       "customType": "regex",
       "fileMatch": [
-        "\\.github/workflows/.*\\.yaml$"
+        "\\.github/workflows/.*\\.yaml$",
+        "\\.github/actions/.+/action\\.ya?ml$"
       ],
       "matchStrings": [
         "#\\s+renovate:\\s+datasource=(?<datasource>\\S+)\\s+depName=(?<depName>\\S+)(\\s+packageName=(?<packageName>\\S+))?(\\s+extractVersion=(?<extractVersion>\\S+))?(\\s+versioning=(?<versioning>\\S+))?[^\\n]*\\n[^\\n]*?:\\s*\"?[^\"\\s]*?v?(?<currentValue>[0-9]+\\.[0-9.]+)\"?"


### PR DESCRIPTION
**What this PR does / why we need it**:

Prevent failures like: https://github.com/Kong/kong-operator/actions/runs/34210243385/job/102009482258?pr=5595#step:5:104

Missing mise release for already published tag:

```
    Written by Roland McGrath and Ulrich Drepper.
    /usr/bin/curl -fsSL https://github.com/jdx/mise/releases/download/v2026.9.3/mise-v2026.9.3-linux-x64.tar.zst --output /tmp/mise-action-kv4D1J/mise-v2026.9.3-linux-x64.tar.zst
    curl: (22) The requested URL returned error: 404
    Warning: Download failed: The process '/usr/bin/curl' failed with exit code 22. Retrying in 2 seconds (1/5).
    /usr/bin/curl -fsSL https://github.com/jdx/mise/releases/download/v2026.9.3/mise-v2026.9.3-linux-x64.tar.zst --output /tmp/mise-action-kv4D1J/mise-v2026.9.3-linux-x64.tar.zst
    curl: (22) The requested URL returned error: 404
    Warning: Download failed: The process '/usr/bin/curl' failed with exit code 22. Retrying in 2 seconds (2/5).
    /usr/bin/curl -fsSL https://github.com/jdx/mise/releases/download/v2026.9.3/mise-v2026.9.3-linux-x64.tar.zst --output /tmp/mise-action-kv4D1J/mise-v2026.9.3-linux-x64.tar.zst
    curl: (22) The requested URL returned error: 404
    Warning: Download failed: The process '/usr/bin/curl' failed with exit code 22. Retrying in 2 seconds (3/5).
    /usr/bin/curl -fsSL https://github.com/jdx/mise/releases/download/v2026.9.3/mise-v2026.9.3-linux-x64.tar.zst --output /tmp/mise-action-kv4D1J/mise-v2026.9.3-linux-x64.tar.zst
    curl: (22) The requested URL returned error: 404
    Warning: Download failed: The process '/usr/bin/curl' failed with exit code 22. Retrying in 2 seconds (4/5).
    /usr/bin/curl -fsSL https://github.com/jdx/mise/releases/download/v2026.9.3/mise-v2026.9.3-linux-x64.tar.zst --output /tmp/mise-action-kv4D1J/mise-v2026.9.3-linux-x64.tar.zst
    curl: (22) The requested URL returned error: 404

```

by using a predefined version of mise (and bump it via renovate).

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
