### PR TITLE
ci(ksai): name the gateway origin the public mirror leaves empty

### DIFF
--- a/.github/workflows/ksai.yaml
+++ b/.github/workflows/ksai.yaml
@@ -87,6 +87,7 @@ jobs:
       prev_remaining: ${{ inputs.prev_remaining }}
       allowed_models: "zai-org/GLM-5.3-Flash,claude-opus-5,claude-sonnet-5,claude-haiku-4-5"
       client_id: ${{ vars.GH_APP__KONG_READONLY__APP_ID }}
+      anthropic_base_url: ${{ vars.KSAI_ANTHROPIC_BASE_URL }}
     secrets:
       ksai_private_key: ${{ secrets.GH_APP__KONG_READONLY__PRIVATE_KEY }}
 


### PR DESCRIPTION
## Motivation

Every `/ksai` comment now fails in `run / gate` and no review starts:

```
Error: anthropic_base_url must start with https:// - the classifier this job runs is a model call
like any other, and empty takes it off Kong AI Gateway rather than falling back to Anthropic, got:
```

`Kong/ksai-public` is a generated snapshot of an internal repository, and the generator redacts Kong-internal hostnames on the way out. `anthropic_base_url` defaults to Kong's AI gateway, so the published copy carries that input with an empty default. The gate refuses an empty value rather than falling back to `api.anthropic.com`, because falling back would take the spend off the gateway where it is attributed. Of the 34 inputs the snapshot empties it is the only one that is then refused, so a caller pinned at the mirror has to name the origin itself.

## Implementation

- `anthropic_base_url` is passed to the `ksai` job as `${{ vars.KSAI_ANTHROPIC_BASE_URL }}`. A variable rather than a literal, so the hostname stays out of this public repository - writing it here would undo the redaction the snapshot exists to perform.
- Nothing else changes. The four federation identifiers stay as they are: they address a workspace, they are not credentials, and spend needs a GitHub OIDC token minted by a repository the team's federation rule already names
