### PR TITLE
fix: fix double delete in generic reconciler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -81,6 +81,10 @@
   This change will delete the combined Kong routes created for the matches with
   these filters in their parent rules and create new distinct ones.
  [#5521](https://github.com/Kong/kong-operator/pull/5521)
+- Konnect reconciler: release the cleanup finalizer with a non-optimistic merge
+  patch instead of an optimistic-locked update. A stale cached `resourceVersion`
+  could previously make that write conflict, which silently requeued the
+  reconcile and deleted the same entity from Konnect a second time.
 
 ## [v2.3.1]
 

--- a/controller/konnect/reconciler_generic.go
+++ b/controller/konnect/reconciler_generic.go
@@ -583,6 +583,12 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(ctx context.Context, ent TE
 			}, nil
 		}
 
+		// Snapshot before any finalizer is removed, so the merge patch below carries
+		// only the finalizer change and does not rely on an optimistic lock: the
+		// cached ent can have a stale resourceVersion, and a conflicting Update here
+		// would requeue and delete the entity from Konnect a second time.
+		old := ent.DeepCopyObject().(TEnt)
+
 		if controllerutil.RemoveFinalizer(ent, KonnectCleanupFinalizer) {
 			// If the Konnect ID was never persisted to the status (e.g. the status
 			// update failed after the entity was created in Konnect), try to recover
@@ -629,10 +635,7 @@ func (r *KonnectEntityReconciler[T, TEnt]) Reconcile(ctx context.Context, ent TE
 			controllerutil.RemoveFinalizer(ent, consts.KonnectGatewayControlPlaneFinalizer)
 		}
 
-		if err := r.Client.Update(ctx, ent); err != nil {
-			if apierrors.IsConflict(err) {
-				return ctrl.Result{Requeue: true}, nil
-			}
+		if err := r.Client.Patch(ctx, ent, client.MergeFrom(old)); err != nil {
 			if apierrors.IsNotFound(err) {
 				return ctrl.Result{}, nil
 			}

--- a/controller/konnect/reconciler_generic_delete_finalizer_test.go
+++ b/controller/konnect/reconciler_generic_delete_finalizer_test.go
@@ -1,0 +1,167 @@
+package konnect
+
+import (
+	"context"
+	"testing"
+
+	sdkkonnectops "github.com/Kong/sdk-konnect-go/models/operations"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/require"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+	"sigs.k8s.io/controller-runtime/pkg/client/interceptor"
+
+	commonv1alpha1 "github.com/kong/kong-operator/v2/api/common/v1alpha1"
+	konnectv1alpha1 "github.com/kong/kong-operator/v2/api/konnect/v1alpha1"
+	konnectv1alpha2 "github.com/kong/kong-operator/v2/api/konnect/v1alpha2"
+	"github.com/kong/kong-operator/v2/modules/manager/logging"
+	"github.com/kong/kong-operator/v2/modules/manager/scheme"
+	"github.com/kong/kong-operator/v2/test/mocks/metricsmocks"
+	"github.com/kong/kong-operator/v2/test/mocks/sdkmocks"
+)
+
+// TestReconcileDeleteDoesNotDoubleDeleteOnConflict is a regression test for a CI
+// flake in TestKonnectConfigStore: the manager's cached copy of an entity being
+// deleted can have a stale resourceVersion, so the finalizer-removal write can
+// conflict. Before the fix that used r.Client.Update, which returned a 409 on a
+// stale resourceVersion; the reconciler silently requeued and, on the next pass,
+// deleted the same entity from Konnect a second time. The fix removes the
+// finalizer with a non-optimistic merge patch instead, so a stale resourceVersion
+// no longer causes a duplicate Konnect delete.
+//
+// The interceptor below simulates that staleness deterministically: it forces
+// every r.Client.Update of the KonnectConfigStore to conflict, exactly as a real
+// stale-cache Update would. The deletion branch under test must not call Update
+// at all, so the interceptor should never fire.
+func TestReconcileDeleteDoesNotDoubleDeleteOnConflict(t *testing.T) {
+	const (
+		cpKonnectID = "cp-12345"
+		csKonnectID = "config-store-12345"
+	)
+
+	apiAuth := &konnectv1alpha1.KonnectAPIAuthConfiguration{
+		Name:      "api-auth",
+		Namespace: "default",
+		Spec: konnectv1alpha1.KonnectAPIAuthConfigurationSpec{
+			Type:      konnectv1alpha1.KonnectAPIAuthTypeToken,
+			Token:     "kpat_test",
+			ServerURL: sdkmocks.SDKServerURL,
+		},
+		Status: konnectv1alpha1.KonnectAPIAuthConfigurationStatus{
+			Conditions: []metav1.Condition{
+				{
+					Type:               konnectv1alpha1.KonnectEntityAPIAuthConfigurationValidConditionType,
+					Status:             metav1.ConditionTrue,
+					Reason:             konnectv1alpha1.KonnectEntityAPIAuthConfigurationReasonValid,
+					LastTransitionTime: metav1.Now(),
+				},
+			},
+		},
+	}
+
+	cp := &konnectv1alpha2.KonnectGatewayControlPlane{
+		Name:      "cp",
+		Namespace: "default",
+		Spec: konnectv1alpha2.KonnectGatewayControlPlaneSpec{
+			KonnectConfiguration: konnectv1alpha2.ControlPlaneKonnectConfiguration{
+				APIAuthConfigurationRef: konnectv1alpha2.ControlPlaneKonnectAPIAuthConfigurationRef{
+					Name: apiAuth.Name,
+				},
+			},
+		},
+		Status: konnectv1alpha2.KonnectGatewayControlPlaneStatus{
+			KonnectEntityStatus: konnectv1alpha2.KonnectEntityStatus{ID: cpKonnectID},
+			Conditions: []metav1.Condition{
+				{
+					Type:   konnectv1alpha1.KonnectEntityProgrammedConditionType,
+					Status: metav1.ConditionTrue,
+				},
+			},
+		},
+	}
+
+	configStore := &konnectv1alpha1.KonnectConfigStore{
+		Name:       "config-store",
+		Namespace:  "default",
+		Finalizers: []string{KonnectCleanupFinalizer},
+		Spec: konnectv1alpha1.KonnectConfigStoreSpec{
+			ControlPlaneRef: commonv1alpha1.ObjectRef{
+				Type:          commonv1alpha1.ObjectRefTypeNamespacedRef,
+				NamespacedRef: &commonv1alpha1.NamespacedRef{Name: cp.Name},
+			},
+		},
+		Status: konnectv1alpha1.KonnectConfigStoreStatus{
+			KonnectEntityStatus: konnectv1alpha1.KonnectEntityStatus{ID: csKonnectID},
+			ControlPlaneID:      &konnectv1alpha1.KonnectEntityRef{ID: cpKonnectID},
+		},
+	}
+	key := client.ObjectKeyFromObject(configStore)
+
+	cl := fake.NewClientBuilder().
+		WithScheme(scheme.Get()).
+		WithObjects(apiAuth, cp, configStore).
+		WithStatusSubresource(&konnectv1alpha1.KonnectConfigStore{}).
+		WithInterceptorFuncs(interceptor.Funcs{
+			// Simulate the informer cache lag that caused the CI flake: any
+			// finalizer-removal write on the entity being deleted conflicts, as
+			// if the manager's cached copy carried a stale resourceVersion.
+			Update: func(
+				ctx context.Context,
+				cl client.WithWatch,
+				obj client.Object,
+				opts ...client.UpdateOption,
+			) error {
+				if _, ok := obj.(*konnectv1alpha1.KonnectConfigStore); ok {
+					return apierrors.NewConflict(
+						schema.GroupResource{Group: "konnect.konghq.com", Resource: "konnectconfigstores"},
+						obj.GetName(), assert.AnError,
+					)
+				}
+				return cl.Update(ctx, obj, opts...)
+			},
+		}).
+		Build()
+
+	require.NoError(t, cl.Delete(t.Context(), configStore))
+
+	factory := sdkmocks.NewMockSDKFactory(t)
+	factory.SDK.ConfigStoresSDK.EXPECT().
+		DeleteConfigStore(mock.Anything, mock.MatchedBy(func(req sdkkonnectops.DeleteConfigStoreRequest) bool {
+			return req.ControlPlaneID == cpKonnectID && req.ConfigStoreID == csKonnectID
+		})).
+		Return(&sdkkonnectops.DeleteConfigStoreResponse{}, nil).
+		Once()
+
+	reconciler := NewKonnectEntityReconciler[konnectv1alpha1.KonnectConfigStore](
+		factory, logging.DevelopmentMode, cl,
+		WithMetricRecorder[konnectv1alpha1.KonnectConfigStore](&metricsmocks.MockRecorder{}),
+	)
+
+	// Drive Reconcile like a real controller would across several watch-triggered
+	// passes (each status patch here would trigger a fresh reconcile in
+	// production), re-reading the object from the client each time. Bounded to a
+	// generous number of passes; the loop exits early once the object is gone.
+	for range 6 {
+		var cur konnectv1alpha1.KonnectConfigStore
+		if err := cl.Get(t.Context(), key, &cur); apierrors.IsNotFound(err) {
+			break
+		} else {
+			require.NoError(t, err)
+		}
+
+		res, err := reconciler.Reconcile(t.Context(), &cur)
+		require.NoError(t, err)
+		assert.Equal(t, ctrl.Result{}, res, "deletion must not conflict-requeue")
+	}
+
+	var gone konnectv1alpha1.KonnectConfigStore
+	assert.True(t, apierrors.IsNotFound(cl.Get(t.Context(), key, &gone)),
+		"finalizer must be released so the object is deleted")
+
+	factory.SDK.ConfigStoresSDK.AssertExpectations(t)
+}

--- a/test/envtest/konnect-other/konnect_entities_konnectconfigstore_test.go
+++ b/test/envtest/konnect-other/konnect_entities_konnectconfigstore_test.go
@@ -90,6 +90,9 @@ func TestKonnectConfigStore(t *testing.T) {
 
 		envtest.EventuallyAssertSDKExpectations(t, sdk.ConfigStoresSDK, consts.WaitTime, consts.TickTime)
 
+		// No .Once() here: Konnect deletes are at-least-once (e.g. an operator
+		// restart between the Konnect call and the finalizer patch would repeat
+		// it), so the test only asserts what is sent, not how many times.
 		t.Log("Setting up SDK expectations on KonnectConfigStore deletion")
 		sdk.ConfigStoresSDK.EXPECT().
 			DeleteConfigStore(mock.Anything, mock.MatchedBy(func(req sdkkonnectops.DeleteConfigStoreRequest) bool {
@@ -97,8 +100,7 @@ func TestKonnectConfigStore(t *testing.T) {
 					req.ConfigStoreID == configStoreID &&
 					req.Force != nil && *req.Force == sdkkonnectops.ForceTrue
 			})).
-			Return(&sdkkonnectops.DeleteConfigStoreResponse{}, nil).
-			Once()
+			Return(&sdkkonnectops.DeleteConfigStoreResponse{}, nil)
 
 		t.Log("Deleting KonnectConfigStore")
 		require.NoError(t, clientNamespaced.Delete(ctx, configStore))
@@ -136,6 +138,7 @@ func TestKonnectConfigStore(t *testing.T) {
 
 		envtest.EventuallyAssertSDKExpectations(t, sdk.ConfigStoresSDK, consts.WaitTime, consts.TickTime)
 
+		// No .Once() here either, for the same at-least-once reason as above.
 		t.Log("Setting up SDK expectations on KonnectConfigStore deletion returning 404")
 		sdk.ConfigStoresSDK.EXPECT().
 			DeleteConfigStore(mock.Anything, mock.MatchedBy(func(req sdkkonnectops.DeleteConfigStoreRequest) bool {
@@ -144,8 +147,7 @@ func TestKonnectConfigStore(t *testing.T) {
 			Return(nil, &sdkkonnecterrs.SDKError{
 				StatusCode: 404,
 				Message:    "not found",
-			}).
-			Once()
+			})
 
 		t.Log("Deleting KonnectConfigStore")
 		require.NoError(t, clientNamespaced.Delete(ctx, configStore))


### PR DESCRIPTION
**What this PR does / why we need it**:

`controller/konnect/reconciler_generic.go`'s deletion branch, the finalizer removal was persisted with an optimistic-locked Update. The cached entity (from the manager's informer)
could have a stale resourceVersion, so the Update conflicted (409), the reconciler silently requeued, and the next pass repeated the whole delete — including a second call to Konnect's
`DeleteConfigStore`. That's what blew past the test's .Once() mock expectation and killed the controller worker goroutine, cascading into both subtest failures.

Changes:
  1. `controller/konnect/reconciler_generic.go` — snapshot the entity before removing finalizers, then release them with a non-optimistic client.Patch(ctx, ent, client.MergeFrom(old)) instead of
     Update. A stale cache can no longer produce a conflict on this write.
  2. `test/envtest/konnect-other/konnect_entities_konnectconfigstore_test.go` — dropped .Once() from both DeleteConfigStore expectations, since Konnect deletes are inherently at-least-once (e.g.
     across an operator restart), not exactly-once.
  3. New `controller/konnect/reconciler_generic_delete_finalizer_test.go` — a fake-client regression test that forces the finalizer-removal write to conflict (simulating the stale cache) and asserts
     exactly one delete call. I confirmed it's a faithful regression guard by temporarily reverting the reconciler fix — the test reproduced the exact CI failure — then restored the fix and
     confirmed green.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

Noticed in https://github.com/Kong/kong-operator/actions/runs/34329244207/job/102393759558#step:13:7830

```
    mock.go:361: 
        assert: mock: The method has been called over 1 times.
        	Either do one more Mock.On("DeleteConfigStore").Return(...), or remove extra call.
        	This call was unexpected:
        		DeleteConfigStore(*context.valueCtx,operations.DeleteConfigStoreRequest)
        		0: &context.valueCtx{Context:(*context.valueCtx)(0xc00aad9350), key:logr.contextKey{}, val:logr.Logger{sink:(*zapr.zapLogger)(0xc00aad93e0), level:0}}
        		1: operations.DeleteConfigStoreRequest{ControlPlaneID:"5c66399b-1c9f-4e4f-a243-126dcb060637", ConfigStoreID:"config-store-12345", Force:(*operations.Force)(0xc00e8376f0)}
        	at: [/home/runner/go/pkg/mod/github.com/!kong/sdk-konnect-go@v0.64.0/test/mocks/zz_generated.configstores_i.go:137 /home/runner/work/kong-operator/kong-operator/controller/konnect/ops/zz_generated_ops_konnect_configstore.go:78 /home/runner/work/kong-operator/kong-operator/controller/konnect/ops/zz_generated_ops_delete.go:70 /home/runner/work/kong-operator/kong-operator/controller/konnect/ops/ops.go:402 /home/runner/work/kong-operator/kong-operator/controller/konnect/reconciler_generic.go:592 /home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.24.1/pkg/reconcile/reconcile.go:169 /home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.24.1/pkg/internal/controller/controller.go:221 /home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.24.1/pkg/internal/controller/controller.go:478 /home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.24.1/pkg/internal/controller/controller.go:437 /home/runner/go/pkg/mod/sigs.k8s.io/controller-runtime@v0.24.1/pkg/internal/controller/controller.go:312 /opt/hostedtoolcache/go/1.27.1/x64/src/runtime/asm_amd64.s:1264]
--- PASS: TestKonnectCloudGatewayTransitGateway (34.71s)
    konnect_entities_konnectconfigstore_test.go:105: 
        	Error Trace:	/home/runner/work/kong-operator/kong-operator/test/helpers/eventually/doesnotexist.go:40
        	            				/opt/hostedtoolcache/go/1.27.1/x64/src/runtime/asm_amd64.s:1264
        	Error:      	Should be true
    konnect_entities_konnectconfigstore_test.go:105: 
        	Error Trace:	/home/runner/work/kong-operator/kong-operator/test/helpers/eventually/doesnotexist.go:37
        	            				/home/runner/work/kong-operator/kong-operator/test/envtest/konnect-other/konnect_entities_konnectconfigstore_test.go:105
        	Error:      	Condition never satisfied
        	Test:       	TestKonnectConfigStore/should_create_and_force-delete_KonnectConfigStore_successfully
        	Messages:   	*v1alpha1.KonnectConfigStore test-wfbh2/config-store-1e26cbc4-8641-4a0c-af64-81f2e06ed223 still exists
    konnect_entities_konnectconfigstore_test.go:106: Checking *mocks.MockConfigStoresSDK SDK expectations
--- FAIL: TestKonnectConfigStore/should_create_and_force-delete_KonnectConfigStore_successfully (23.71s)
=== RUN   TestKonnectConfigStore/should_release_the_cleanup_finalizer_when_the_config_store_is_already_gone_from_Konnect
    konnect_entities_konnectconfigstore_test.go:115: Setting up a watch for *v1alpha1.KonnectConfigStore events
    konnect_entities_konnectconfigstore_test.go:126: deployed new KonnectConfigStore test-wfbh2/config-store-29a2d6a3-168d-4885-a373-21ff7a624362 resource
    konnect_entities_konnectconfigstore_test.go:128: 
        	Error Trace:	/home/runner/work/kong-operator/kong-operator/test/helpers/watch.go:46
        	            				/home/runner/work/kong-operator/kong-operator/test/envtest/watch.go:87
        	            				/home/runner/work/kong-operator/kong-operator/test/envtest/konnect-other/konnect_entities_konnectconfigstore_test.go:128
        	Error:      	KonnectConfigStore didn't get Programmed status condition or Konnect ID
        	Test:       	TestKonnectConfigStore/should_release_the_cleanup_finalizer_when_the_config_store_is_already_gone_from_Konnect
--- FAIL: TestKonnectConfigStore/should_release_the_cleanup_finalizer_when_the_config_store_is_already_gone_from_Konnect (45.01s)
2026-09-09T08:33:35Z	INFO	controller-runtime.webhook	Shutting down webhook server with timeout of 1 minute
    controller.go:108: Test TestKonnectConfigStore failed: dumping controller logs
    controller.go:108: 2026-09-09T08:32:28Z	info	Starting EventSource	{"controller": "KonnectConfigStore", "controllerGroup": "konnect.konghq.com", "controllerKind": "KonnectConfigStore", "source": "kind source: *v1alpha1.KonnectConfigStore"}
    controller.go:108: 2026-09-09T08:32:28Z	info	Starting EventSource	{"controller": "KonnectConfigStore", "controllerGroup": "konnect.konghq.com", "controllerKind": "KonnectConfigStore", "source": "kind source: *v1alpha1.KongReferenceGrant"}
    controller.go:108: 2026-09-09T08:32:28Z	info	Starting EventSource	{"controller": "KonnectConfigStore", "controllerGroup": "konnect.konghq.com", "controllerKind": "KonnectConfigStore", "source": "kind source: *v1alpha2.KonnectGatewayControlPlane"}
    controller.go:108: 2026-09-09T08:32:29Z	info	Starting Controller	{"controller": "KonnectConfigStore", "controllerGroup": "konnect.konghq.com", "controllerKind": "KonnectConfigStore"}
    controller.go:108: 2026-09-09T08:32:29Z	info	Starting workers	{"controller": "KonnectConfigStore", "controllerGroup": "konnect.konghq.com", "controllerKind": "KonnectConfigStore", "worker count": 1}
    controller.go:108: 2026-09-09T08:33:35Z	info	Stopping and waiting for non leader election runnables
    controller.go:108: 2026-09-09T08:33:35Z	info	Stopping and waiting for warmup runnables
    controller.go:108: 2026-09-09T08:33:35Z	info	Stopping and waiting for leader election runnables
    controller.go:108: 2026-09-09T08:33:35Z	info	Shutdown signal received, waiting for all workers to finish	{"controller": "KonnectConfigStore", "controllerGroup": "konnect.konghq.com", "controllerKind": "KonnectConfigStore"}
    controller.go:108: 2026-09-09T08:33:35Z	info	All workers finished	{"controller": "KonnectConfigStore", "controllerGroup": "konnect.konghq.com", "controllerKind": "KonnectConfigStore"}
    controller.go:108: 2026-09-09T08:33:35Z	info	Stopping and waiting for caches
    controller.go:108: 2026-09-09T08:33:35Z	info	Stopping and waiting for webhooks
    controller.go:108: 2026-09-09T08:33:35Z	info	Stopping and waiting for HTTP servers
    controller.go:108: 2026-09-09T08:33:35Z	info	Wait completed, proceeding to shutdown the manager
    zz_generated.configstores_i.go:24: FAIL:	CreateConfigStore(string,string,string)
        		at: [/home/runner/go/pkg/mod/github.com/!kong/sdk-konnect-go@v0.64.0/test/mocks/zz_generated.configstores_i.go:87 /home/runner/work/kong-operator/kong-operator/test/envtest/konnect-other/konnect_entities_konnectconfigstore_test.go:118]
    zz_generated.configstores_i.go:24: FAIL: 2 out of 3 expectation(s) were met.
        	The code you are testing needs to make 1 more call(s).
        	at: [/home/runner/go/pkg/mod/github.com/!kong/sdk-konnect-go@v0.64.0/test/mocks/zz_generated.configstores_i.go:24 /opt/hostedtoolcache/go/1.27.1/x64/src/testing/testing.go:1460 /opt/hostedtoolcache/go/1.27.1/x64/src/testing/testing.go:1820 /opt/hostedtoolcache/go/1.27.1/x64/src/testing/testing.go:2187]
    konnect_entities_konnectconfigstore_test.go:31: stopping envtest environment for test TestKonnectConfigStore
--- FAIL: TestKonnectConfigStore (100.20s)
```

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
