### PR TITLE
chore(ci): name the login KSAI writes under

### DIFF
--- a/.github/workflows/ksai.yaml
+++ b/.github/workflows/ksai.yaml
@@ -57,7 +57,7 @@ jobs:
       github.event.pull_request.draft == true &&
       github.event.pull_request.user.type == 'Bot' &&
       github.event.pull_request.head.repo.full_name == github.repository)
-    uses: Kong/ksai-public/.github/workflows/ksai.yml@123d9ea4cef3fcb2f06e161307591f420e823ad2 # v3.40.12
+    uses: Kong/ksai-public/.github/workflows/ksai.yml@ae119b0ad79c2052b695033818dce373b3587f21 # v3.41.3
     permissions:
       contents: write      # checked out by every command, and pushed by one that changes code
       issues: write        # every command answers with a comment, and reacts to the one that asked
@@ -107,8 +107,12 @@ jobs:
       (github.event_name == 'pull_request_review' &&
       github.event.sender.type != 'Bot' &&
       github.event.review.state != 'commented'))
-    uses: Kong/ksai-public/.github/workflows/ksai-hold.yml@123d9ea4cef3fcb2f06e161307591f420e823ad2 # v3.40.12
+    uses: Kong/ksai-public/.github/workflows/ksai-hold.yml@ae119b0ad79c2052b695033818dce373b3587f21 # v3.41.3
     permissions:
       contents: read       # download the action this call runs, which lives in a private repository
       pull-requests: write # dismiss an approval from somebody who contributed to the pull request
       statuses: write      # report the check the ruleset makes required
+    with:
+      # The login `push_as_app: false` above makes KSAI commit under. A pull request carrying no
+      # commit of its own is reported green rather than held.
+      app_login: github-actions

--- a/.github/workflows/ksai.yaml
+++ b/.github/workflows/ksai.yaml
@@ -57,7 +57,7 @@ jobs:
       github.event.pull_request.draft == true &&
       github.event.pull_request.user.type == 'Bot' &&
       github.event.pull_request.head.repo.full_name == github.repository)
-    uses: Kong/ksai-public/.github/workflows/ksai.yml@ae119b0ad79c2052b695033818dce373b3587f21 # v3.41.3
+    uses: Kong/ksai-public/.github/workflows/ksai.yml@636df2e813cc067db029c857e410270943977e65 # v3.41.4
     permissions:
       contents: write      # checked out by every command, and pushed by one that changes code
       issues: write        # every command answers with a comment, and reacts to the one that asked
@@ -107,7 +107,7 @@ jobs:
       (github.event_name == 'pull_request_review' &&
       github.event.sender.type != 'Bot' &&
       github.event.review.state != 'commented'))
-    uses: Kong/ksai-public/.github/workflows/ksai-hold.yml@ae119b0ad79c2052b695033818dce373b3587f21 # v3.41.3
+    uses: Kong/ksai-public/.github/workflows/ksai-hold.yml@636df2e813cc067db029c857e410270943977e65 # v3.41.4
     permissions:
       contents: read       # download the action this call runs, which lives in a private repository
       pull-requests: write # dismiss an approval from somebody who contributed to the pull request


### PR DESCRIPTION
**What this PR does / why we need it**:

`KSAI / independent approval` is a required status on `main`, and it held every pull request, whoever wrote it. The gate could not tell a pull request KSAI had written from one it had never touched, so it withheld the author's own approval on all of them and a second reviewer was needed on work one person wrote alone.

`v3.41.3` added an `app_login` input naming the login this repository runs KSAI as. A pull request carrying no commit that login published is reported green; one that does is held as before. This repository sets `push_as_app: false`, so every KSAI write goes through `GITHUB_TOKEN` and lands as `github-actions[bot]`, which is the value passed.

Both `Kong/ksai-public` pins move from `v3.40.12` to `v3.41.4` in the same change.

**Which issue this PR fixes**

None.

**Special notes for your reviewer**:

The pin and the `with:` block move together or not at all: an input a caller passes that the pinned workflow does not declare is a startup failure with no log and no annotation. Nothing else in either workflow's input set changed between the two versions.

From `v3.41.1` the snapshot names its own actions through GitHub's `$/` self-repository form rather than a tag, so every hop inside the called workflows resolves at the commit pinned here. That form needs runner 2.336.0, which `ubuntu-latest` has.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes - not applicable, this changes CI only
