### PR TITLE
chore: make checking for CRDs consistent

### DIFF
--- a/controller/dataplane/certificates/konnect.go
+++ b/controller/dataplane/certificates/konnect.go
@@ -51,8 +51,7 @@ var certificateGVR = schema.GroupVersionResource{
 // certificateCRDNotInstalled returns true if `certmanager.io/v1.certificates` CRD is not installed
 // so we can skip the processing of Konnect certificates when KonnectCertificateOptions is missing in DataPlane.
 func certificateCRDNotInstalled(logger logr.Logger, cl client.Client) bool {
-	checker := k8sutils.CRDChecker{Client: cl}
-	exist, err := checker.CRDExists(certificateGVR)
+	exist, err := k8sutils.CRDExists(cl.RESTMapper(), certificateGVR)
 	if err != nil {
 		log.Error(logger, err, "failed to check if certificate CRD installed")
 		return false

--- a/controller/gateway/controller.go
+++ b/controller/gateway/controller.go
@@ -152,14 +152,13 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) err
 		)
 	}
 
-	crdChecker := k8sutils.CRDChecker{Client: r.Client}
 	// Add TLSRoute watch only if TLSRoute CRD is present in the cluster, to avoid watching for a resource that doesn't exist and that would trigger reconciliation for all the Gateways on every event in the cluster.
 	tlsRouteGVR := schema.GroupVersionResource{
 		Group:    gatewayv1.GroupVersion.Group,
 		Version:  gatewayv1.GroupVersion.Version,
 		Resource: "tlsroutes",
 	}
-	tlsRouteExist, err := crdChecker.CRDExists(tlsRouteGVR)
+	tlsRouteExist, err := k8sutils.CRDExists(r.RESTMapper(), tlsRouteGVR)
 	if err != nil {
 		return fmt.Errorf("failed to check if TLSRoute CRD exists: %w", err)
 	}
@@ -178,7 +177,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) err
 		Version:  gatewayv1.GroupVersion.Version,
 		Resource: "grpcroutes",
 	}
-	grpcRouteExist, err := crdChecker.CRDExists(grpcRouteGVR)
+	grpcRouteExist, err := k8sutils.CRDExists(r.RESTMapper(), grpcRouteGVR)
 	if err != nil {
 		return fmt.Errorf("failed to check if GRPCRoute CRD exists: %w", err)
 	}
@@ -197,7 +196,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) err
 		Version:  gatewayv1.GroupVersion.Version,
 		Resource: "udproutes",
 	}
-	udpRouteExist, err := crdChecker.CRDExists(udpRouteGVR)
+	udpRouteExist, err := k8sutils.CRDExists(r.RESTMapper(), udpRouteGVR)
 	if err != nil {
 		return fmt.Errorf("failed to check if UDPRoute CRD exists: %w", err)
 	}
@@ -216,7 +215,7 @@ func (r *Reconciler) SetupWithManager(ctx context.Context, mgr ctrl.Manager) err
 		Version:  gatewayv1.GroupVersion.Version,
 		Resource: "tcproutes",
 	}
-	tcpRouteExist, err := crdChecker.CRDExists(tcpRouteGVR)
+	tcpRouteExist, err := k8sutils.CRDExists(r.RESTMapper(), tcpRouteGVR)
 	if err != nil {
 		return err
 	}

--- a/ingress-controller/internal/controllers/crds/dynamic_controller.go
+++ b/ingress-controller/internal/controllers/crds/dynamic_controller.go
@@ -17,8 +17,8 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/predicate"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
-	"github.com/kong/kong-operator/v2/ingress-controller/internal/controllers/utils"
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/logging"
+	k8sutils "github.com/kong/kong-operator/v2/pkg/utils/kubernetes"
 )
 
 // +kubebuilder:rbac:groups="apiextensions.k8s.io",resources=customresourcedefinitions,verbs=list;watch
@@ -43,7 +43,13 @@ type DynamicCRDController struct {
 }
 
 func (r *DynamicCRDController) SetupWithManager(mgr ctrl.Manager) error {
-	if r.allRequiredCRDsInstalled() {
+	// A lookup failure here is not fatal: fall through to the CustomResourceDefinition
+	// watch below, which will retry once the apiserver is reachable again.
+	installed, err := r.allRequiredCRDsInstalled()
+	if err != nil {
+		r.Log.Error(err, "Failed to check whether the required CustomResourceDefinitions are installed, falling back to watching them")
+	}
+	if installed {
 		r.Log.V(logging.DebugLevel).Info("All required CustomResourceDefinitions are installed, skipping DynamicCRDController set up")
 		return r.setupController(mgr)
 	}
@@ -70,7 +76,11 @@ func (r *DynamicCRDController) Reconcile(ctx context.Context, crd *apiextensions
 
 	log.V(logging.DebugLevel).Info("Processing CustomResourceDefinition", "name", crd.Name)
 
-	if !r.allRequiredCRDsInstalled() {
+	installed, err := r.allRequiredCRDsInstalled()
+	if err != nil {
+		return ctrl.Result{}, err
+	}
+	if !installed {
 		log.V(logging.DebugLevel).Info("Still not all required CustomResourceDefinitions are installed, waiting")
 		return ctrl.Result{}, nil
 	}
@@ -91,10 +101,14 @@ func (r *DynamicCRDController) SetLogger(logger logr.Logger) {
 	r.Log = logger
 }
 
-func (r *DynamicCRDController) allRequiredCRDsInstalled() bool {
-	return lo.EveryBy(r.RequiredCRDs, func(gvr schema.GroupVersionResource) bool {
-		return utils.CRDExists(r.Manager.GetClient().RESTMapper(), gvr)
-	})
+func (r *DynamicCRDController) allRequiredCRDsInstalled() (bool, error) {
+	for _, gvr := range r.RequiredCRDs {
+		exists, err := k8sutils.CRDExists(r.Manager.GetClient().RESTMapper(), gvr)
+		if err != nil || !exists {
+			return false, err
+		}
+	}
+	return true, nil
 }
 
 func (r *DynamicCRDController) isOneOfRequiredCRDs(obj client.Object) bool {

--- a/ingress-controller/internal/controllers/gateway/gateway_controller.go
+++ b/ingress-controller/internal/controllers/gateway/gateway_controller.go
@@ -87,7 +87,11 @@ func (r *GatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// when reconciling Gateways.
 	// Once the GatewayReconciler is set up without ReferenceGrant, there's no possibility to enable
 	// ReferenceGrant handling again in this reconciler at runtime.
-	r.referenceGrantVersion, r.enableReferenceGrant = ctrlutils.DetectReferenceGrantVersion(mgr.GetRESTMapper())
+	gv, ok, err := ctrlutils.DetectReferenceGrantVersion(mgr.GetRESTMapper())
+	if err != nil {
+		return fmt.Errorf("failed to detect the ReferenceGrant API version: %w", err)
+	}
+	r.referenceGrantVersion, r.enableReferenceGrant = gv, ok
 	if !r.enableReferenceGrant {
 		r.Log.Error(nil, "Neither v1 nor v1beta1 ReferenceGrant CRD found; cross-namespace references will be rejected")
 	}

--- a/ingress-controller/internal/controllers/gateway/httproute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/httproute_controller.go
@@ -74,7 +74,11 @@ func (r *HTTPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// when reconciling HTTPRoutes.
 	// Once the HTTPRouteReconciler is set up without ReferenceGrant, there's no possibility to enable
 	// ReferenceGrant handling again in this reconciler at runtime.
-	r.referenceGrantVersion, r.enableReferenceGrant = ctrlutils.DetectReferenceGrantVersion(mgr.GetRESTMapper())
+	gv, ok, err := ctrlutils.DetectReferenceGrantVersion(mgr.GetRESTMapper())
+	if err != nil {
+		return fmt.Errorf("failed to detect the ReferenceGrant API version: %w", err)
+	}
+	r.referenceGrantVersion, r.enableReferenceGrant = gv, ok
 	if !r.enableReferenceGrant {
 		r.Log.Error(nil, "Neither v1 nor v1beta1 ReferenceGrant CRD found; cross-namespace references will be rejected")
 	}

--- a/ingress-controller/internal/controllers/gateway/referencegrant_controller.go
+++ b/ingress-controller/internal/controllers/gateway/referencegrant_controller.go
@@ -52,7 +52,10 @@ type ReferenceGrantReconciler struct {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ReferenceGrantReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	gv, ok := ctrlutils.DetectReferenceGrantVersion(mgr.GetRESTMapper())
+	gv, ok, err := ctrlutils.DetectReferenceGrantVersion(mgr.GetRESTMapper())
+	if err != nil {
+		return fmt.Errorf("failed to detect the ReferenceGrant API version: %w", err)
+	}
 	if !ok {
 		return fmt.Errorf("neither v1 nor v1beta1 ReferenceGrant CRD found")
 	}

--- a/ingress-controller/internal/controllers/gateway/tcproute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/tcproute_controller.go
@@ -68,7 +68,11 @@ func (r *TCPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// when reconciling TCPRoutes.
 	// Once the TCPRouteReconciler is set up without ReferenceGrant, there's no possibility to enable
 	// ReferenceGrant handling again in this reconciler at runtime.
-	r.referenceGrantVersion, r.enableReferenceGrant = ctrlutils.DetectReferenceGrantVersion(mgr.GetRESTMapper())
+	gv, ok, err := ctrlutils.DetectReferenceGrantVersion(mgr.GetRESTMapper())
+	if err != nil {
+		return fmt.Errorf("failed to detect the ReferenceGrant API version: %w", err)
+	}
+	r.referenceGrantVersion, r.enableReferenceGrant = gv, ok
 	if !r.enableReferenceGrant {
 		r.Log.Error(nil, "Neither v1 nor v1beta1 ReferenceGrant CRD found; cross-namespace references will be rejected")
 	}

--- a/ingress-controller/internal/controllers/gateway/tlsroute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/tlsroute_controller.go
@@ -68,7 +68,11 @@ func (r *TLSRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// when reconciling TLSRoutes.
 	// Once the TLSRouteReconciler is set up without ReferenceGrant, there's no possibility to enable
 	// ReferenceGrant handling again in this reconciler at runtime.
-	r.referenceGrantVersion, r.enableReferenceGrant = ctrlutils.DetectReferenceGrantVersion(mgr.GetRESTMapper())
+	gv, ok, err := ctrlutils.DetectReferenceGrantVersion(mgr.GetRESTMapper())
+	if err != nil {
+		return fmt.Errorf("failed to detect the ReferenceGrant API version: %w", err)
+	}
+	r.referenceGrantVersion, r.enableReferenceGrant = gv, ok
 	if !r.enableReferenceGrant {
 		r.Log.Error(nil, "Neither v1 nor v1beta1 ReferenceGrant CRD found; cross-namespace references will be rejected")
 	}

--- a/ingress-controller/internal/controllers/gateway/udproute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/udproute_controller.go
@@ -68,7 +68,11 @@ func (r *UDPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	// when reconciling UDPRoutes.
 	// Once the UDPRouteReconciler is set up without ReferenceGrant, there's no possibility to enable
 	// ReferenceGrant handling again in this reconciler at runtime.
-	r.referenceGrantVersion, r.enableReferenceGrant = ctrlutils.DetectReferenceGrantVersion(mgr.GetRESTMapper())
+	gv, ok, err := ctrlutils.DetectReferenceGrantVersion(mgr.GetRESTMapper())
+	if err != nil {
+		return fmt.Errorf("failed to detect the ReferenceGrant API version: %w", err)
+	}
+	r.referenceGrantVersion, r.enableReferenceGrant = gv, ok
 	if !r.enableReferenceGrant {
 		r.Log.Error(nil, "Neither v1 nor v1beta1 ReferenceGrant CRD found; cross-namespace references will be rejected")
 	}

--- a/ingress-controller/internal/controllers/utils/ingress_predicates.go
+++ b/ingress-controller/internal/controllers/utils/ingress_predicates.go
@@ -12,6 +12,7 @@ import (
 
 	configurationv1alpha1 "github.com/kong/kong-operator/v2/api/configuration/v1alpha1"
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/annotations"
+	k8sutils "github.com/kong/kong-operator/v2/pkg/utils/kubernetes"
 )
 
 const defaultIngressClassAnnotation = "ingressclass.kubernetes.io/is-default-class"
@@ -77,35 +78,23 @@ func IsIngressClassEmpty(obj client.Object) bool {
 	}
 }
 
-// CRDExists returns false if CRD does not exist.
-func CRDExists(restMapper meta.RESTMapper, gvr schema.GroupVersionResource) bool {
-	if _, err := restMapper.KindsFor(gvr); err == nil {
-		return true
-	} else if meta.IsNoMatchError(err) {
-		// The RESTMapper may have stale cached discovery data. Reset() forces it to
-		// re-discover resources, allowing it to find CRDs installed after initialization.
-		// meta.RESTMapper doesn't include Reset(), but some implementations (e.g. DynamicRESTMapper) do.
-		if resettable, ok := restMapper.(interface{ Reset() }); ok {
-			resettable.Reset()
-			_, err = restMapper.KindsFor(gvr)
-			return err == nil
-		}
-	}
-	return false
-}
-
 // DetectReferenceGrantVersion returns the GroupVersion of whichever ReferenceGrant
 // API version is served by the cluster, preferring v1 and falling back to v1beta1
 // (ReferenceGrant was promoted from v1beta1 to v1 in gateway-api v1.5.0; older
-// clusters only serve v1beta1). ok is false if neither is installed.
-func DetectReferenceGrantVersion(restMapper meta.RESTMapper) (gv schema.GroupVersion, ok bool) {
-	v1GV := schema.GroupVersion(gatewayv1.GroupVersion)
-	if CRDExists(restMapper, v1GV.WithResource("referencegrants")) {
-		return v1GV, true
+// clusters only serve v1beta1). ok is false if neither is installed. An error is
+// returned when the lookup itself failed.
+func DetectReferenceGrantVersion(restMapper meta.RESTMapper) (gv schema.GroupVersion, ok bool, err error) {
+	for _, gv := range []schema.GroupVersion{
+		schema.GroupVersion(gatewayv1.GroupVersion),
+		schema.GroupVersion(gatewayv1beta1.GroupVersion),
+	} {
+		exists, err := k8sutils.CRDExists(restMapper, gv.WithResource("referencegrants"))
+		if err != nil {
+			return schema.GroupVersion{}, false, err
+		}
+		if exists {
+			return gv, true, nil
+		}
 	}
-	v1beta1GV := schema.GroupVersion(gatewayv1beta1.GroupVersion)
-	if CRDExists(restMapper, v1beta1GV.WithResource("referencegrants")) {
-		return v1beta1GV, true
-	}
-	return schema.GroupVersion{}, false
+	return schema.GroupVersion{}, false, nil
 }

--- a/ingress-controller/internal/controllers/utils/referencegrant_version_test.go
+++ b/ingress-controller/internal/controllers/utils/referencegrant_version_test.go
@@ -1,6 +1,7 @@
 package utils
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -23,13 +24,33 @@ func restMapperWithReferenceGrant(gvs ...schema.GroupVersion) meta.RESTMapper {
 	return mapper
 }
 
+type erroringRESTMapper struct {
+	meta.RESTMapper
+}
+
+func (erroringRESTMapper) KindFor(schema.GroupVersionResource) (schema.GroupVersionKind, error) {
+	return schema.GroupVersionKind{}, errors.New("discovery is unavailable")
+}
+
+func (erroringRESTMapper) KindsFor(schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
+	return nil, errors.New("discovery is unavailable")
+}
+
 func TestDetectReferenceGrantVersion(t *testing.T) {
 	tests := []struct {
-		name       string
-		mapper     meta.RESTMapper
-		expectedGV schema.GroupVersion
-		expectedOK bool
+		name        string
+		mapper      meta.RESTMapper
+		expectedGV  schema.GroupVersion
+		expectedOK  bool
+		expectedErr bool
 	}{
+		{
+			name:        "lookup failure is reported as an error",
+			mapper:      erroringRESTMapper{RESTMapper: meta.NewDefaultRESTMapper(nil)},
+			expectedGV:  schema.GroupVersion{},
+			expectedOK:  false,
+			expectedErr: true,
+		},
 		{
 			name:       "only v1 is served",
 			mapper:     restMapperWithReferenceGrant(v1GroupVersion),
@@ -58,7 +79,12 @@ func TestDetectReferenceGrantVersion(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			gv, ok := DetectReferenceGrantVersion(tc.mapper)
+			gv, ok, err := DetectReferenceGrantVersion(tc.mapper)
+			if tc.expectedErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+			}
 			require.Equal(t, tc.expectedOK, ok)
 			require.Equal(t, tc.expectedGV, gv)
 		})

--- a/ingress-controller/internal/manager/controllerdef.go
+++ b/ingress-controller/internal/manager/controllerdef.go
@@ -2,6 +2,7 @@ package manager
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -19,6 +20,7 @@ import (
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/dataplane"
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/util/kubernetes/object/status"
 	managercfg "github.com/kong/kong-operator/v2/ingress-controller/pkg/manager/config"
+	k8sutils "github.com/kong/kong-operator/v2/pkg/utils/kubernetes"
 )
 
 // -----------------------------------------------------------------------------
@@ -65,14 +67,29 @@ func setupControllers(
 	featureGates managercfg.FeatureGates,
 	kongAdminAPIEndpointsNotifier configuration.EndpointsNotifier,
 	adminAPIsDiscoverer configuration.AdminAPIsDiscoverer,
-) []ControllerDef {
+) ([]ControllerDef, error) {
 	// Resolve which ReferenceGrant API version (v1 or v1beta1) is served by the
 	// cluster, so the ReferenceGrant DynamicCRDController waits on the version
 	// that's actually installed. Default to v1 (the GA version) as the
 	// wait-target if the CRD isn't installed yet at all.
-	referenceGrantGV, referenceGrantFound := utils.DetectReferenceGrantVersion(mgr.GetRESTMapper())
+	referenceGrantGV, referenceGrantFound, err := utils.DetectReferenceGrantVersion(mgr.GetRESTMapper())
+	if err != nil {
+		return nil, fmt.Errorf("failed to detect the ReferenceGrant API version: %w", err)
+	}
 	if !referenceGrantFound {
 		referenceGrantGV = schema.GroupVersion(gatewayv1.GroupVersion)
+	}
+
+	// HTTPRoute presence is resolved once here: the KongUpstreamPolicy controller
+	// watches HTTPRoutes to set ancestor status, and cannot pick that up later at
+	// runtime.
+	httpRouteExists, err := k8sutils.CRDExists(mgr.GetRESTMapper(), schema.GroupVersionResource{
+		Group:    gatewayv1.GroupVersion.Group,
+		Version:  gatewayv1.GroupVersion.Version,
+		Resource: "httproutes",
+	})
+	if err != nil {
+		return nil, fmt.Errorf("failed to check whether the HTTPRoute CRD is installed: %w", err)
 	}
 
 	controllers := []ControllerDef{
@@ -246,18 +263,14 @@ func setupControllers(
 		{
 			Enabled: c.KongUpstreamPolicyEnabled,
 			Controller: &configuration.KongUpstreamPolicyReconciler{
-				Client:                   mgr.GetClient(),
-				Log:                      ctrl.LoggerFrom(ctx).WithName("controllers").WithName("KongUpstreamPolicy"),
-				Scheme:                   mgr.GetScheme(),
-				DataplaneClient:          dataplaneClient,
-				CacheSyncTimeout:         c.CacheSyncTimeout,
-				KongServiceFacadeEnabled: featureGates.Enabled(managercfg.KongServiceFacadeFeature) && c.KongServiceFacadeEnabled,
-				StatusQueue:              kubernetesStatusQueue,
-				HTTPRouteEnabled: utils.CRDExists(mgr.GetRESTMapper(), schema.GroupVersionResource{
-					Group:    gatewayv1.GroupVersion.Group,
-					Version:  gatewayv1.GroupVersion.Version,
-					Resource: "httproutes",
-				}),
+				Client:                     mgr.GetClient(),
+				Log:                        ctrl.LoggerFrom(ctx).WithName("controllers").WithName("KongUpstreamPolicy"),
+				Scheme:                     mgr.GetScheme(),
+				DataplaneClient:            dataplaneClient,
+				CacheSyncTimeout:           c.CacheSyncTimeout,
+				KongServiceFacadeEnabled:   featureGates.Enabled(managercfg.KongServiceFacadeFeature) && c.KongServiceFacadeEnabled,
+				StatusQueue:                kubernetesStatusQueue,
+				HTTPRouteEnabled:           httpRouteExists,
 				IngressClassName:           c.IngressClassName,
 				DisableIngressClassLookups: !c.IngressClassNetV1Enabled,
 			},
@@ -492,7 +505,7 @@ func setupControllers(
 		},
 	}
 
-	return controllers
+	return controllers, nil
 }
 
 // baseGatewayCRDs returns a slice of base CRDs required for running all the Gateway API controllers.

--- a/ingress-controller/internal/manager/run.go
+++ b/ingress-controller/internal/manager/run.go
@@ -318,7 +318,7 @@ func New(
 	)
 
 	setupLog.Info("Starting enabled Controllers")
-	controllers := setupControllers(
+	controllers, err := setupControllers(
 		ctx,
 		mgr,
 		dataplaneClient,
@@ -330,6 +330,9 @@ func New(
 		clientsManager,
 		adminAPIsDiscoverer,
 	)
+	if err != nil {
+		return nil, fmt.Errorf("unable to set up controllers: %w", err)
+	}
 	for _, c := range controllers {
 		if err := c.MaybeSetupWithManager(mgr); err != nil {
 			return nil, fmt.Errorf("unable to create controller %q: %w", c.Name(), err)

--- a/internal/telemetry/telemetry.go
+++ b/internal/telemetry/telemetry.go
@@ -128,17 +128,17 @@ func createManager(
 	}
 	// Add cluster state workflow
 	{
-		checker := k8sutils.CRDChecker{Client: cl}
+		restMapper := cl.RESTMapper()
 
-		cpExists, err := checker.CRDExists(gwtypes.ControlPlaneGVR())
+		cpExists, err := k8sutils.CRDExists(restMapper, gwtypes.ControlPlaneGVR())
 		if err != nil {
 			log.Info("failed to check if controlplane CRD exists", "error", err)
 		}
-		aiGatewayExists, err := checker.CRDExists(operatorv1alpha1.AIGatewayGVR())
+		aiGatewayExists, err := k8sutils.CRDExists(restMapper, operatorv1alpha1.AIGatewayGVR())
 		if err != nil {
 			log.Info("failed to check if aigateway CRD exists", "error", err)
 		}
-		dpExists, err := checker.CRDExists(operatorv1beta1.DataPlaneGVR())
+		dpExists, err := k8sutils.CRDExists(restMapper, operatorv1beta1.DataPlaneGVR())
 		if err != nil {
 			log.Info("failed to check if dataplane CRD exists", "error", err)
 		}

--- a/modules/manager/controller_setup.go
+++ b/modules/manager/controller_setup.go
@@ -97,9 +97,10 @@ func (c *ControllerDef) MaybeSetupWithManager(ctx context.Context, mgr ctrl.Mana
 func SetupCacheIndexes(ctx context.Context, mgr manager.Manager, cfg Config) error {
 	var indexOptions []index.Option
 
-	crdChecker := k8sutils.CRDChecker{
-		Client: mgr.GetClient(),
+	crdChecker := func(gvr schema.GroupVersionResource) (bool, error) {
+		return k8sutils.CRDExists(mgr.GetClient().RESTMapper(), gvr)
 	}
+
 	tlsRouteGVR := schema.GroupVersionResource{
 		Group:    gatewayv1.GroupVersion.Group,
 		Version:  gatewayv1.GroupVersion.Version,
@@ -138,28 +139,28 @@ func SetupCacheIndexes(ctx context.Context, mgr manager.Manager, cfg Config) err
 			index.OptionsForGateway(),
 			index.OptionsForHTTPRoute(),
 		)
-		hasTLSRoute, err := crdChecker.CRDExists(tlsRouteGVR)
+		hasTLSRoute, err := crdChecker(tlsRouteGVR)
 		if err != nil {
 			return fmt.Errorf("failed to check existence of CRD %s: %w", tlsRouteGVR.String(), err)
 		}
 		if hasTLSRoute {
 			indexOptions = slices.Concat(indexOptions, index.OptionsForTLSRoute())
 		}
-		hasTCPRoute, err := crdChecker.CRDExists(tcpRouteGVR)
+		hasTCPRoute, err := crdChecker(tcpRouteGVR)
 		if err != nil {
 			return fmt.Errorf("failed to check existence of CRD %s: %w", tcpRouteGVR.String(), err)
 		}
 		if hasTCPRoute {
 			indexOptions = slices.Concat(indexOptions, index.OptionsForTCPRoute())
 		}
-		hasUDPRoute, err := crdChecker.CRDExists(udpRouteGVR)
+		hasUDPRoute, err := crdChecker(udpRouteGVR)
 		if err != nil {
 			return fmt.Errorf("failed to check existence of CRD %s: %w", udpRouteGVR.String(), err)
 		}
 		if hasUDPRoute {
 			indexOptions = slices.Concat(indexOptions, index.OptionsForUDPRoute())
 		}
-		hasGRPCRoute, err := crdChecker.CRDExists(grpcRouteGVR)
+		hasGRPCRoute, err := crdChecker(grpcRouteGVR)
 		if err != nil {
 			return fmt.Errorf("failed to check existence of CRD %s: %w", grpcRouteGVR.String(), err)
 		}
@@ -568,9 +569,10 @@ func requiredCRDChecks(c *Config) []requiredCRDCheck {
 	}
 }
 
-type crdExistenceChecker interface {
-	CRDExists(schema.GroupVersionResource) (bool, error)
-}
+// crdExistenceChecker reports whether a resource is served by the apiserver. It
+// is a parameter of ensureRequiredCRDs so that tests can substitute a fixed set
+// of installed CRDs for real discovery.
+type crdExistenceChecker func(schema.GroupVersionResource) (bool, error)
 
 func ensureRequiredCRDs(c *Config, checker crdExistenceChecker) error {
 	for _, check := range requiredCRDChecks(c) {
@@ -579,7 +581,7 @@ func ensureRequiredCRDs(c *Config, checker crdExistenceChecker) error {
 		}
 
 		for _, gvr := range check.gvrs {
-			if ok, err := checker.CRDExists(gvr); err != nil {
+			if ok, err := checker(gvr); err != nil {
 				return err
 			} else if !ok {
 				return fmt.Errorf("missing a required CRD: %v", gvr)
@@ -589,7 +591,7 @@ func ensureRequiredCRDs(c *Config, checker crdExistenceChecker) error {
 		for _, gvrGroup := range check.anyOfGVRs {
 			found := false
 			for _, gvr := range gvrGroup {
-				ok, err := checker.CRDExists(gvr)
+				ok, err := checker(gvr)
 				if err != nil {
 					return err
 				}
@@ -612,8 +614,10 @@ func SetupControllers(mgr manager.Manager, c *Config, cpsMgr *multiinstance.Mana
 	// metricRecorder is the recorder used to record custom metrics in the controller manager's metrics server.
 	metricRecorder := metrics.NewGlobalCtrlRuntimeMetricsRecorder()
 
-	checker := k8sutils.CRDChecker{Client: mgr.GetClient()}
-	if err := ensureRequiredCRDs(c, checker); err != nil {
+	crdExists := func(gvr schema.GroupVersionResource) (bool, error) {
+		return k8sutils.CRDExists(mgr.GetClient().RESTMapper(), gvr)
+	}
+	if err := ensureRequiredCRDs(c, crdExists); err != nil {
 		return nil, err
 	}
 
@@ -1008,28 +1012,28 @@ func SetupControllers(mgr manager.Manager, c *Config, cpsMgr *multiinstance.Mana
 			Version:  gatewayv1.GroupVersion.Version,
 			Resource: "grpcroutes",
 		}
-		hasTLSRoute, err := checker.CRDExists(tlsRouteGVR)
+		hasTLSRoute, err := crdExists(tlsRouteGVR)
 		if err != nil {
 			return nil, fmt.Errorf("failed to check existence of CRD %s: %w", tlsRouteGVR.String(), err)
 		}
 		if hasTLSRoute {
 			controllers = append(controllers, newGatewayAPIHybridController[gwtypes.TLSRoute](mgr, c.FQDNModeEnabled, c.ClusterDomain, ssaProvider))
 		}
-		hasTCPRoute, err := checker.CRDExists(tcpRouteGVR)
+		hasTCPRoute, err := crdExists(tcpRouteGVR)
 		if err != nil {
 			return nil, fmt.Errorf("failed to check existence of CRD %s: %w", tcpRouteGVR.String(), err)
 		}
 		if hasTCPRoute {
 			controllers = append(controllers, newGatewayAPIHybridController[gwtypes.TCPRoute](mgr, c.FQDNModeEnabled, c.ClusterDomain, ssaProvider))
 		}
-		hasGRPCRoute, err := checker.CRDExists(grpcRouteGVR)
+		hasGRPCRoute, err := crdExists(grpcRouteGVR)
 		if err != nil {
 			return nil, fmt.Errorf("failed to check existence of CRD %s: %w", grpcRouteGVR.String(), err)
 		}
 		if hasGRPCRoute {
 			controllers = append(controllers, newGatewayAPIHybridController[gwtypes.GRPCRoute](mgr, c.FQDNModeEnabled, c.ClusterDomain, ssaProvider))
 		}
-		hasUDPRoute, err := checker.CRDExists(udpRouteGVR)
+		hasUDPRoute, err := crdExists(udpRouteGVR)
 		if err != nil {
 			return nil, fmt.Errorf("failed to check existence of CRD %s: %w", udpRouteGVR.String(), err)
 		}

--- a/modules/manager/controller_setup_crd_checks_test.go
+++ b/modules/manager/controller_setup_crd_checks_test.go
@@ -1,6 +1,7 @@
 package manager
 
 import (
+	"slices"
 	"testing"
 
 	"github.com/stretchr/testify/require"
@@ -13,13 +14,11 @@ import (
 	gwtypes "github.com/kong/kong-operator/v2/internal/types"
 )
 
-type fakeCRDChecker struct {
-	missing map[schema.GroupVersionResource]struct{}
-}
-
-func (f *fakeCRDChecker) CRDExists(gvr schema.GroupVersionResource) (bool, error) {
-	_, missing := f.missing[gvr]
-	return !missing, nil
+// crdCheckerMissing reports every CRD as installed except the given ones.
+func crdCheckerMissing(missing ...schema.GroupVersionResource) crdExistenceChecker {
+	return func(gvr schema.GroupVersionResource) (bool, error) {
+		return !slices.Contains(missing, gvr), nil
+	}
 }
 
 func defaultConfigWithDisabledControllers() Config {
@@ -43,11 +42,7 @@ func TestEnsureRequiredCRDsChecksGatewayConfigurationForGatewayController(t *tes
 	cfg.GatewayControllerEnabled = true
 
 	missingGVR := gwtypes.GatewayConfigurationGVR()
-	checker := &fakeCRDChecker{
-		missing: map[schema.GroupVersionResource]struct{}{
-			missingGVR: {},
-		},
-	}
+	checker := crdCheckerMissing(missingGVR)
 
 	err := ensureRequiredCRDs(&cfg, checker)
 	require.Error(t, err)
@@ -65,11 +60,7 @@ func TestEnsureRequiredCRDsChecksWatchNamespaceGrantForControlPlaneController(t 
 		Version:  operatorv1alpha1.SchemeGroupVersion.Version,
 		Resource: "watchnamespacegrants",
 	}
-	checker := &fakeCRDChecker{
-		missing: map[schema.GroupVersionResource]struct{}{
-			missingGVR: {},
-		},
-	}
+	checker := crdCheckerMissing(missingGVR)
 
 	err := ensureRequiredCRDs(&cfg, checker)
 	require.Error(t, err)
@@ -87,11 +78,7 @@ func TestEnsureRequiredCRDsChecksDataPlaneMetricsExtensionForControlPlaneExtensi
 		Version:  operatorv1alpha1.SchemeGroupVersion.Version,
 		Resource: "dataplanemetricsextensions",
 	}
-	checker := &fakeCRDChecker{
-		missing: map[schema.GroupVersionResource]struct{}{
-			missingGVR: {},
-		},
-	}
+	checker := crdCheckerMissing(missingGVR)
 
 	err := ensureRequiredCRDs(&cfg, checker)
 	require.Error(t, err)
@@ -109,11 +96,7 @@ func TestEnsureRequiredCRDsChecksKonnectCloudGatewayTransitGatewayForKonnectCont
 		Version:  konnectv1alpha1.SchemeGroupVersion.Version,
 		Resource: "konnectcloudgatewaytransitgateways",
 	}
-	checker := &fakeCRDChecker{
-		missing: map[schema.GroupVersionResource]struct{}{
-			missingGVR: {},
-		},
-	}
+	checker := crdCheckerMissing(missingGVR)
 
 	err := ensureRequiredCRDs(&cfg, checker)
 	require.Error(t, err)
@@ -131,11 +114,7 @@ func TestEnsureRequiredCRDsChecksKegDataPlaneForKEGDataPlaneController(t *testin
 		Version:  eventgatewayv1alpha1.SchemeGroupVersion.Version,
 		Resource: "kegdataplanes",
 	}
-	checker := &fakeCRDChecker{
-		missing: map[schema.GroupVersionResource]struct{}{
-			missingGVR: {},
-		},
-	}
+	checker := crdCheckerMissing(missingGVR)
 
 	err := ensureRequiredCRDs(&cfg, checker)
 	require.Error(t, err)
@@ -148,16 +127,14 @@ func TestEnsureRequiredCRDsSkipsDisabledControllerChecks(t *testing.T) {
 	cfg := defaultConfigWithDisabledControllers()
 
 	skippedGVR := gwtypes.GatewayConfigurationGVR()
-	checker := &fakeCRDChecker{
-		missing: map[schema.GroupVersionResource]struct{}{
-			skippedGVR: {},
-			{
-				Group:    configurationv1alpha1.SchemeGroupVersion.Group,
-				Version:  configurationv1alpha1.SchemeGroupVersion.Version,
-				Resource: "kongreferencegrants",
-			}: {},
+	checker := crdCheckerMissing(
+		skippedGVR,
+		schema.GroupVersionResource{
+			Group:    configurationv1alpha1.SchemeGroupVersion.Group,
+			Version:  configurationv1alpha1.SchemeGroupVersion.Version,
+			Resource: "kongreferencegrants",
 		},
-	}
+	)
 
 	err := ensureRequiredCRDs(&cfg, checker)
 	require.NoError(t, err)

--- a/modules/manager/controller_setup_test.go
+++ b/modules/manager/controller_setup_test.go
@@ -1,10 +1,13 @@
 package manager_test
 
 import (
+	"net/http"
 	"reflect"
 	"testing"
 
 	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/api/meta"
+	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
 	ctrlmgr "sigs.k8s.io/controller-runtime/pkg/manager"
@@ -13,11 +16,26 @@ import (
 	testutils "github.com/kong/kong-operator/v2/pkg/utils/test"
 )
 
+type allKindsRESTMapper struct {
+	meta.RESTMapper
+}
+
+func (allKindsRESTMapper) KindFor(gvr schema.GroupVersionResource) (schema.GroupVersionKind, error) {
+	return gvr.GroupVersion().WithKind(gvr.Resource), nil
+}
+
 func TestSetupControllers(t *testing.T) {
 	t.Parallel()
 
 	// Actual values of parameters are not important for this test.
-	mgr, err := ctrl.NewManager(&rest.Config{}, ctrlmgr.Options{})
+	// A RESTMapper that resolves everything is supplied because there is no
+	// apiserver here: without it, SetupControllers' CRD checks fail with a
+	// discovery error rather than finding the CRDs installed.
+	mgr, err := ctrl.NewManager(&rest.Config{}, ctrlmgr.Options{
+		MapperProvider: func(*rest.Config, *http.Client) (meta.RESTMapper, error) {
+			return allKindsRESTMapper{RESTMapper: meta.NewDefaultRESTMapper(nil)}, nil
+		},
+	})
 	require.NoError(t, err)
 	cfg := testutils.DefaultControllerConfigForTests()
 	controllerDefs, err := manager.SetupControllers(mgr, &cfg, nil, nil)

--- a/pkg/utils/kubernetes/crd.go
+++ b/pkg/utils/kubernetes/crd.go
@@ -9,18 +9,11 @@ import (
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// CRDChecker verifies whether the resource type defined by GVR is supported by the k8s apiserver.
-type CRDChecker struct {
-	Client client.Client
-}
-
 // CRDExists returns true if the apiserver supports the specified group/version/resource.
-func (c CRDChecker) CRDExists(gvr schema.GroupVersionResource) (bool, error) {
-	_, err := c.Client.RESTMapper().KindFor(gvr)
-
+func CRDExists(r meta.RESTMapper, gvr schema.GroupVersionResource) (bool, error) {
+	_, err := r.KindFor(gvr)
 	if meta.IsNoMatchError(err) {
 		return false, nil
 	}
@@ -48,6 +41,13 @@ func (c CRDChecker) CRDExists(gvr schema.GroupVersionResource) (bool, error) {
 
 		// Otherwise it's a different error, report a missing CRD.
 		return false, err
+	}
+
+	// Any other error leaves the existence of the CRD unknown: reporting it as
+	// installed would let callers set up watches for a type the apiserver may
+	// not serve.
+	if err != nil {
+		return false, fmt.Errorf("unexpected error when looking up CRD (%v): %w", gvr, err)
 	}
 
 	return true, nil

--- a/pkg/utils/kubernetes/crd_test.go
+++ b/pkg/utils/kubernetes/crd_test.go
@@ -1,18 +1,28 @@
 package kubernetes
 
 import (
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
-	fakectrlruntimeclient "sigs.k8s.io/controller-runtime/pkg/client/fake"
 	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
 
 	operatorv1beta1 "github.com/kong/kong-operator/v2/api/gateway-operator/v1beta1"
 )
 
-func TestCRDChecker(t *testing.T) {
+var errDiscoveryUnavailable = errors.New("discovery is unavailable")
+
+type erroringRESTMapper struct {
+	meta.RESTMapper
+}
+
+func (erroringRESTMapper) KindFor(schema.GroupVersionResource) (schema.GroupVersionKind, error) {
+	return schema.GroupVersionKind{}, errDiscoveryUnavailable
+}
+
+func TestCRDExists(t *testing.T) {
 	testcases := []struct {
 		name        string
 		restMapper  func() meta.RESTMapper
@@ -57,7 +67,7 @@ func TestCRDChecker(t *testing.T) {
 					Kind:    "Gateway",
 				}, meta.RESTScopeNamespace)
 
-				return meta.NewDefaultRESTMapper(nil)
+				return restMapper
 			},
 			CRD: schema.GroupVersionResource{
 				Group:   gatewayv1.GroupVersion.Group,
@@ -66,7 +76,7 @@ func TestCRDChecker(t *testing.T) {
 				// Ref: https://github.com/kubernetes/client-go/issues/1082
 				Resource: "gatewaies",
 			},
-			expected:    false,
+			expected:    true,
 			expectedErr: nil,
 		},
 		{
@@ -84,17 +94,20 @@ func TestCRDChecker(t *testing.T) {
 			expected:    false,
 			expectedErr: nil,
 		},
+		{
+			name: "returns an error when the lookup itself fails",
+			restMapper: func() meta.RESTMapper {
+				return erroringRESTMapper{RESTMapper: meta.NewDefaultRESTMapper(nil)}
+			},
+			CRD:         operatorv1beta1.DataPlaneGVR(),
+			expected:    false,
+			expectedErr: errDiscoveryUnavailable,
+		},
 	}
 
 	for _, tc := range testcases {
 		t.Run(tc.name, func(t *testing.T) {
-			fakeClient := fakectrlruntimeclient.
-				NewClientBuilder().
-				WithRESTMapper(tc.restMapper()).
-				Build()
-
-			checker := CRDChecker{Client: fakeClient}
-			ok, err := checker.CRDExists(tc.CRD)
+			ok, err := CRDExists(tc.restMapper(), tc.CRD)
 
 			if tc.expectedErr != nil {
 				require.Error(t, err)
@@ -121,34 +134,22 @@ func BenchmarkCRDExists(b *testing.B) {
 			Kind:    "DataPlane",
 		}, meta.RESTScopeNamespace)
 
-		fakeClient := fakectrlruntimeclient.
-			NewClientBuilder().
-			WithRESTMapper(restMapper).
-			Build()
-
-		checker := CRDChecker{Client: fakeClient}
 		gvr := operatorv1beta1.DataPlaneGVR()
 
 		b.ResetTimer()
 		for b.Loop() {
-			_, _ = checker.CRDExists(gvr)
+			_, _ = CRDExists(restMapper, gvr)
 		}
 	})
 
 	b.Run("CRD_not_found", func(b *testing.B) {
 		restMapper := meta.NewDefaultRESTMapper(nil)
 
-		fakeClient := fakectrlruntimeclient.
-			NewClientBuilder().
-			WithRESTMapper(restMapper).
-			Build()
-
-		checker := CRDChecker{Client: fakeClient}
 		gvr := operatorv1beta1.DataPlaneGVR()
 
 		b.ResetTimer()
 		for b.Loop() {
-			_, _ = checker.CRDExists(gvr)
+			_, _ = CRDExists(restMapper, gvr)
 		}
 	})
 }


### PR DESCRIPTION
**What this PR does / why we need it**:

Checking for CRDs is not consistent across the codebase. Two duplicated helpers basically do the same thing, so let's have a single one in a shared package

**Which issue this PR fixes**

Yak shaving (opportunistic cleanup) for [FTI-7942](https://konghq.atlassian.net/browse/FTI-7942)


[FTI-7942]: https://konghq.atlassian.net/browse/FTI-7942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ