### PR TITLE
ci(tests): save debug snapshots for chainsaw tests also when jobs are cancelled

### DIFF
--- a/.github/workflows/__e2e_chainsaw_tests.yaml
+++ b/.github/workflows/__e2e_chainsaw_tests.yaml
@@ -112,7 +112,7 @@ jobs:
         make test.e2e.chainsaw
 
     - name: Upload debug snapshots as artifacts
-      if: always() && steps.chainsaw-tests.outcome == 'failure'
+      if: always() && steps.chainsaw-tests.outcome != 'success'
       uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
       with:
         name: chainsaw-debug-snapshots-${{ matrix.suite }}-${{ github.run_id }}
@@ -121,7 +121,7 @@ jobs:
         retention-days: 3
 
     - name: Clean up debug snapshots
-      if: always() && steps.chainsaw-tests.outcome == 'failure'
+      if: always() && steps.chainsaw-tests.outcome != 'success'
       env:
         SUITE: ${{ matrix.suite }}
       run: rm -rf "/tmp/chainsaw/$SUITE"


### PR DESCRIPTION
**What this PR does / why we need it**:

When chainsaw tests are cancelled, debug snapshots are not collected e.g. https://github.com/Kong/kong-operator/actions/runs/34448600682/job/102779802444?pr=5637#step:15:85. This PR fixes it.

**Which issue this PR fixes**

Fixes #

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [ ] the `CHANGELOG.md` release notes have been updated to reflect significant changes
