### PR TITLE
fix(on-prem): keep tags stable when multiple secrets shares the same certificate content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,6 +134,11 @@
   redeploy, so config changes surfaced through the signal API alone were never
   picked up.
   [#5643](https://github.com/Kong/kong-operator/pull/5643)
+- On-prem gateway: keep tags of translated Kong certificate stable when multiple
+  `Secret`s have the same certificate content. The tags generated from the `Secret`
+  with the earlist creation timestamp is choosen, and the one with the lowest UID
+  when tie happens. This is align with choosing ID of the translated certificate.
+  [#5657](https://github.com/Kong/kong-operator/pull/5657)
 
 ## [v2.3.1]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -136,8 +136,9 @@
   [#5643](https://github.com/Kong/kong-operator/pull/5643)
 - On-prem gateway: keep tags of translated Kong certificate stable when multiple
   `Secret`s have the same certificate content. The tags generated from the `Secret`
-  with the earlist creation timestamp is choosen, and the one with the lowest UID
-  when tie happens. This is align with choosing ID of the translated certificate.
+  with the earliest creation timestamp are chosen, and the one with the lowest
+  UID when a tie happens.
+  This aligns with choosing ID of the translated certificate.
   [#5657](https://github.com/Kong/kong-operator/pull/5657)
 
 ## [v2.3.1]

--- a/ingress-controller/internal/dataplane/translator/translate_certs.go
+++ b/ingress-controller/internal/dataplane/translator/translate_certs.go
@@ -185,14 +185,16 @@ func mergeCerts(logger logr.Logger, certLists ...[]certWrapper) ([]kongstate.Cer
 				current = cw
 			} else {
 				// multiple Secrets that contain identical certificates are collapsed, because we only create one
-				// Kong resource for a given cert+key pair. however, because we reuse the Secret ID and creation time
-				// for the Kong resource equivalents, the selection of those needs to be deterministic to avoid
-				// pointless configuration updates
+				// Kong resource for a given cert+key pair. however, because we reuse the Secret ID, creation time,
+				// and tags for the Kong resource equivalents, the selection of those needs to be deterministic to
+				// avoid pointless configuration updates
 				if current.CreationTimestamp.After(cw.CreationTimestamp.Time) {
 					current.cert.ID = cw.cert.ID
+					current.cert.Tags = cw.cert.Tags
 					current.CreationTimestamp = cw.CreationTimestamp
 				} else if current.CreationTimestamp.Time.Equal(cw.CreationTimestamp.Time) && (current.cert.ID == nil || *current.cert.ID > *cw.cert.ID) {
 					current.cert.ID = cw.cert.ID
+					current.cert.Tags = cw.cert.Tags
 					current.CreationTimestamp = cw.CreationTimestamp
 				}
 			}

--- a/ingress-controller/internal/dataplane/translator/translate_certs_test.go
+++ b/ingress-controller/internal/dataplane/translator/translate_certs_test.go
@@ -3,10 +3,12 @@ package translator
 import (
 	"sort"
 	"testing"
+	"time"
 
 	"github.com/go-logr/logr"
 	"github.com/kong/go-kong/kong"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/kong/kong-operator/v2/ingress-controller/internal/dataplane/kongstate"
 	"github.com/kong/kong-operator/v2/test/helpers/certificate"
@@ -119,6 +121,181 @@ func TestMergeCerts(t *testing.T) {
 			idToMergedID: certIDToMergedCertID{
 				"certificate-1":   "certificate-1",
 				"certificate-1-1": "certificate-1",
+			},
+		},
+		{
+			// Regression test: the merged certificate's Tags must come from the same
+			// winning Secret as its ID (earliest CreationTimestamp), not from whichever
+			// certWrapper happened to be visited first while merging.
+			name: "tags follow the earliest-created winner when the loser is listed first",
+			certs: []certWrapper{
+				{
+					identifier:        string(crt1) + string(key1),
+					CreationTimestamp: metav1.NewTime(time.Unix(200, 0)),
+					cert: kong.Certificate{
+						ID:   new("certificate-2"),
+						Cert: new(string(crt1)),
+						Key:  new(string(key1)),
+						Tags: kong.StringSlice("tag-2"),
+					},
+					snis: []string{"foo.com"},
+				},
+				{
+					identifier:        string(crt1) + string(key1),
+					CreationTimestamp: metav1.NewTime(time.Unix(100, 0)),
+					cert: kong.Certificate{
+						ID:   new("certificate-1"),
+						Cert: new(string(crt1)),
+						Key:  new(string(key1)),
+						Tags: kong.StringSlice("tag-1"),
+					},
+					snis: []string{"baz.com"},
+				},
+			},
+			mergedCerts: []kongstate.Certificate{
+				{
+					ID:   new("certificate-1"),
+					Cert: new(string(crt1)),
+					Key:  new(string(key1)),
+					Tags: kong.StringSlice("tag-1"),
+					SNIs: kong.StringSlice("baz.com", "foo.com"),
+				},
+			},
+			idToMergedID: certIDToMergedCertID{
+				"certificate-1": "certificate-1",
+				"certificate-2": "certificate-1",
+			},
+		},
+		{
+			name: "tags follow the earliest-created winner when the winner is listed first",
+			certs: []certWrapper{
+				{
+					identifier:        string(crt1) + string(key1),
+					CreationTimestamp: metav1.NewTime(time.Unix(100, 0)),
+					cert: kong.Certificate{
+						ID:   new("certificate-1"),
+						Cert: new(string(crt1)),
+						Key:  new(string(key1)),
+						Tags: kong.StringSlice("tag-1"),
+					},
+					snis: []string{"baz.com"},
+				},
+				{
+					identifier:        string(crt1) + string(key1),
+					CreationTimestamp: metav1.NewTime(time.Unix(200, 0)),
+					cert: kong.Certificate{
+						ID:   new("certificate-2"),
+						Cert: new(string(crt1)),
+						Key:  new(string(key1)),
+						Tags: kong.StringSlice("tag-2"),
+					},
+					snis: []string{"foo.com"},
+				},
+			},
+			mergedCerts: []kongstate.Certificate{
+				{
+					ID:   new("certificate-1"),
+					Cert: new(string(crt1)),
+					Key:  new(string(key1)),
+					Tags: kong.StringSlice("tag-1"),
+					SNIs: kong.StringSlice("baz.com", "foo.com"),
+				},
+			},
+			idToMergedID: certIDToMergedCertID{
+				"certificate-1": "certificate-1",
+				"certificate-2": "certificate-1",
+			},
+		},
+		{
+			name: "tags follow the lowest ID when creation timestamps tie",
+			certs: []certWrapper{
+				{
+					identifier:        string(crt1) + string(key1),
+					CreationTimestamp: metav1.NewTime(time.Unix(100, 0)),
+					cert: kong.Certificate{
+						ID:   new("certificate-2"),
+						Cert: new(string(crt1)),
+						Key:  new(string(key1)),
+						Tags: kong.StringSlice("tag-2"),
+					},
+					snis: []string{"foo.com"},
+				},
+				{
+					identifier:        string(crt1) + string(key1),
+					CreationTimestamp: metav1.NewTime(time.Unix(100, 0)),
+					cert: kong.Certificate{
+						ID:   new("certificate-1"),
+						Cert: new(string(crt1)),
+						Key:  new(string(key1)),
+						Tags: kong.StringSlice("tag-1"),
+					},
+					snis: []string{"baz.com"},
+				},
+			},
+			mergedCerts: []kongstate.Certificate{
+				{
+					ID:   new("certificate-1"),
+					Cert: new(string(crt1)),
+					Key:  new(string(key1)),
+					Tags: kong.StringSlice("tag-1"),
+					SNIs: kong.StringSlice("baz.com", "foo.com"),
+				},
+			},
+			idToMergedID: certIDToMergedCertID{
+				"certificate-1": "certificate-1",
+				"certificate-2": "certificate-1",
+			},
+		},
+		{
+			name: "tags follow the earliest-created winner across multiple duplicates with winner in the middle",
+			certs: []certWrapper{
+				{
+					identifier:        string(crt1) + string(key1),
+					CreationTimestamp: metav1.NewTime(time.Unix(200, 0)),
+					cert: kong.Certificate{
+						ID:   new("certificate-2"),
+						Cert: new(string(crt1)),
+						Key:  new(string(key1)),
+						Tags: kong.StringSlice("tag-2"),
+					},
+					snis: []string{"foo.com"},
+				},
+				{
+					identifier:        string(crt1) + string(key1),
+					CreationTimestamp: metav1.NewTime(time.Unix(100, 0)),
+					cert: kong.Certificate{
+						ID:   new("certificate-1"),
+						Cert: new(string(crt1)),
+						Key:  new(string(key1)),
+						Tags: kong.StringSlice("tag-1"),
+					},
+					snis: []string{"baz.com"},
+				},
+				{
+					identifier:        string(crt1) + string(key1),
+					CreationTimestamp: metav1.NewTime(time.Unix(300, 0)),
+					cert: kong.Certificate{
+						ID:   new("certificate-3"),
+						Cert: new(string(crt1)),
+						Key:  new(string(key1)),
+						Tags: kong.StringSlice("tag-3"),
+					},
+					snis: []string{"qux.com"},
+				},
+			},
+			mergedCerts: []kongstate.Certificate{
+				{
+					ID:   new("certificate-1"),
+					Cert: new(string(crt1)),
+					Key:  new(string(key1)),
+					Tags: kong.StringSlice("tag-1"),
+					SNIs: kong.StringSlice("baz.com", "foo.com", "qux.com"),
+				},
+			},
+			idToMergedID: certIDToMergedCertID{
+				"certificate-1": "certificate-1",
+				"certificate-2": "certificate-1",
+				"certificate-3": "certificate-1",
 			},
 		},
 	}


### PR DESCRIPTION

**What this PR does / why we need it**:

Use the tags of the "winning" certificate in merging certificates to keep the tags stable. The tags comes from the  metadata of the`Secret` with the earlist creation timestamp (lowest UID if ties) to align with choosing ID of the Kong certificate.

**Which issue this PR fixes**

Fixes #5653  

**Special notes for your reviewer**:

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes
