### PR TITLE
fix(gateway): namespace-qualify the Konnect Control Plane name under static naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -75,6 +75,15 @@
   ** This change will delete the combined Kong routes created for the matches with
   these filters in their parent rules and create new distinct ones.
  [#5521](https://github.com/Kong/kong-operator/pull/5521)
+- Gateway: When using `gateway-operator.konghq.com/static-naming: "true"`, the name of
+  the Control Plane created in Konnect is now qualified with the Gateway's namespace
+  (`<namespace>-<gateway-name>`), preventing HTTP 409 conflicts between Gateways sharing
+  a name across namespaces in the same Konnect organization. The Kubernetes
+  `KonnectGatewayControlPlane` resource name is unchanged and still matches the Gateway's
+  name. Control Planes already created in Konnect are not renamed.
+  Note: Gateways with the same namespace and name deployed to multiple clusters sharing a
+  Konnect organization still conflict; use `spec.konnect.mirror` for that scenario.
+  [#4079](https://github.com/Kong/kong-operator/issues/4079)
 
 ## [v2.3.0]
 

--- a/controller/gateway/controller_reconciler_utils.go
+++ b/controller/gateway/controller_reconciler_utils.go
@@ -136,7 +136,7 @@ func (r *Reconciler) createKonnectGatewayControlPlane(
 
 	if gatewayConfig.Spec.Konnect.Mirror == nil {
 		kgcp.Spec.CreateControlPlaneRequest = &sdkkonnectcomp.CreateControlPlaneRequest{
-			Name: kgcpName,
+			Name: konnectControlPlaneName(gateway, kgcpName),
 		}
 	} else {
 		kgcp.Spec.Mirror = &konnectv1alpha2.MirrorSpec{
@@ -1861,18 +1861,38 @@ func areConditionsEqual(cond1, cond2 metav1.Condition) bool {
 // For the name, there are two behaviors:
 //   - If the Gateway has the GatewayStaticNamingAnnotation set to "true", the object's
 //     name is set to exactly match the Gateway's name (static naming).
-//   - Otherwise, the object's generateName is set to "<gateway-name>-", where
-//     a random suffix is appended in the same manner as by Kubernetes for
-//     the GenerateName field (dynamic naming).
+//   - Otherwise, the object's name is set to "<gateway-name>-<suffix>", where the
+//     random suffix is generated client side in the same manner as by Kubernetes
+//     for the GenerateName field (dynamic naming).
 //
 // This function is typically used to ensure that objects created for a Gateway follow
 // the appropriate naming convention based on the Gateway's annotations.
 func setObjectNamespaceName(gateway *gwtypes.Gateway, obj client.Object) (generatedName string) {
 	obj.SetNamespace(gateway.Namespace)
-	if gateway.Annotations != nil && gateway.Annotations[consts.GatewayStaticNamingAnnotation] == "true" {
+	if hasStaticNaming(gateway) {
 		obj.SetName(gateway.Name)
 	} else {
 		obj.SetName(k8sutils.GenerateName(fmt.Sprintf("%s-", gateway.Name)))
 	}
 	return obj.GetName()
+}
+
+// hasStaticNaming reports whether the Gateway opts into static naming of its owned resources.
+func hasStaticNaming(gateway *gwtypes.Gateway) bool {
+	return gateway.Annotations != nil &&
+		gateway.Annotations[consts.GatewayStaticNamingAnnotation] == "true"
+}
+
+// konnectControlPlaneName returns the name to use for the Control Plane created in Konnect.
+//
+// The Kubernetes name and the Konnect name have different uniqueness scopes:
+// (namespace, kind, name) versus (org_id, name). Under static naming the Kubernetes name is
+// the unqualified Gateway name, which is not unique within a Konnect organization, so the
+// namespace is prepended. Under dynamic naming the Kubernetes name already carries a random
+// suffix and is used as is, preserving the behavior introduced in #3357.
+func konnectControlPlaneName(gateway *gwtypes.Gateway, kgcpName string) string {
+	if hasStaticNaming(gateway) {
+		return fmt.Sprintf("%s-%s", gateway.Namespace, gateway.Name)
+	}
+	return kgcpName
 }

--- a/controller/gateway/controller_reconciler_utils_test.go
+++ b/controller/gateway/controller_reconciler_utils_test.go
@@ -6,6 +6,7 @@ import (
 	"net/http"
 	"testing"
 
+	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	corev1 "k8s.io/api/core/v1"
@@ -5368,6 +5369,13 @@ func TestSetAcceptedAndAttachedRoutes(t *testing.T) {
 func TestEnforceKonnectGatewayControlPlaneSpec(t *testing.T) {
 	ns := func(s string) *string { return &s }
 
+	// legacyKonnectName is the name a Control Plane created before the #4079 fix carries:
+	// the unqualified Gateway name, not "<namespace>-<gateway-name>". Every case below seeds
+	// it and asserts it survives, because enforceKonnectGatewayControlPlaneSpec must never
+	// touch spec.createControlPlaneRequest.name. If it ever did, every Control Plane already
+	// created in Konnect would be silently renamed on the first reconcile after an upgrade.
+	const legacyKonnectName = "test-kgcp"
+
 	authRef := konnectv1alpha2.ControlPlaneKonnectAPIAuthConfigurationRef{
 		Name:      "my-auth",
 		Namespace: ns("my-ns"),
@@ -5385,6 +5393,9 @@ func TestEnforceKonnectGatewayControlPlaneSpec(t *testing.T) {
 				Namespace: "default",
 				Name:      "test-kgcp",
 			},
+		}
+		kgcp.Spec.CreateControlPlaneRequest = &sdkkonnectcomp.CreateControlPlaneRequest{
+			Name: legacyKonnectName,
 		}
 		kgcp.Spec.KonnectConfiguration.APIAuthConfigurationRef = currentAuthRef
 		if programmed {
@@ -5509,6 +5520,147 @@ func TestEnforceKonnectGatewayControlPlaneSpec(t *testing.T) {
 			var got konnectv1alpha2.KonnectGatewayControlPlane
 			require.NoError(t, fakeClient.Get(ctx, client.ObjectKeyFromObject(tt.kgcp), &got))
 			assert.Equal(t, tt.wantAuthRef, got.Spec.KonnectConfiguration.APIAuthConfigurationRef)
+
+			// The Konnect-side name is write-once at creation time and must never be
+			// reconciled, whether or not the authRef was patched.
+			require.NotNil(t, got.Spec.CreateControlPlaneRequest)
+			assert.Equal(t, legacyKonnectName, got.Spec.CreateControlPlaneRequest.Name,
+				"spec.createControlPlaneRequest.name must not be modified on an existing KonnectGatewayControlPlane")
+		})
+	}
+}
+
+func TestHasStaticNaming(t *testing.T) {
+	testCases := []struct {
+		name        string
+		annotations map[string]string
+		expected    bool
+	}{
+		{
+			name:        "annotation set to true",
+			annotations: map[string]string{consts.GatewayStaticNamingAnnotation: "true"},
+			expected:    true,
+		},
+		{
+			name:        "annotation set to false",
+			annotations: map[string]string{consts.GatewayStaticNamingAnnotation: "false"},
+			expected:    false,
+		},
+		{
+			name:        "annotation absent",
+			annotations: map[string]string{"some-other": "annotation"},
+			expected:    false,
+		},
+		{
+			name:        "annotations map is nil",
+			annotations: nil,
+			expected:    false,
+		},
+		{
+			name:        "annotation set to True is not opting in",
+			annotations: map[string]string{consts.GatewayStaticNamingAnnotation: "True"},
+			expected:    false,
+		},
+		{
+			name:        "annotation set to 1 is not opting in",
+			annotations: map[string]string{consts.GatewayStaticNamingAnnotation: "1"},
+			expected:    false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gateway := &gwtypes.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:   "staging",
+					Name:        "edge-gw",
+					Annotations: tc.annotations,
+				},
+			}
+			assert.Equal(t, tc.expected, hasStaticNaming(gateway))
+		})
+	}
+}
+
+// TestKonnectControlPlaneName covers the derivation of the Konnect-side Control Plane name.
+//
+// The Kubernetes name and the Konnect name have different uniqueness scopes:
+// (namespace, kind, name) versus (org_id, name). Under static naming the Kubernetes name is
+// the unqualified Gateway name, so the Konnect name must be qualified with the namespace to
+// avoid HTTP 409 conflicts between same-named Gateways in different namespaces (#4079). Under
+// dynamic naming the two names must stay identical, which is the invariant from #3357.
+func TestKonnectControlPlaneName(t *testing.T) {
+	testCases := []struct {
+		name        string
+		annotations map[string]string
+		// staticNaming says whether the Gateway opts in. When false, the Konnect name must
+		// equal the generated Kubernetes name, which carries a random suffix and therefore
+		// cannot be asserted as a literal.
+		staticNaming        bool
+		expectedKonnectName string
+	}{
+		{
+			name:                "static naming qualifies the Konnect name with the namespace",
+			annotations:         map[string]string{consts.GatewayStaticNamingAnnotation: "true"},
+			staticNaming:        true,
+			expectedKonnectName: "staging-edge-gw",
+		},
+		{
+			name:         "annotation set to false leaves the dynamic name untouched",
+			annotations:  map[string]string{consts.GatewayStaticNamingAnnotation: "false"},
+			staticNaming: false,
+		},
+		{
+			name:         "annotation absent leaves the dynamic name untouched",
+			annotations:  map[string]string{"some-other": "annotation"},
+			staticNaming: false,
+		},
+		{
+			name:         "nil annotations map leaves the dynamic name untouched",
+			annotations:  nil,
+			staticNaming: false,
+		},
+		{
+			name:         "annotation set to True is not opting in",
+			annotations:  map[string]string{consts.GatewayStaticNamingAnnotation: "True"},
+			staticNaming: false,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			gateway := &gwtypes.Gateway{
+				ObjectMeta: metav1.ObjectMeta{
+					Namespace:   "staging",
+					Name:        "edge-gw",
+					Annotations: tc.annotations,
+				},
+			}
+
+			// Derive the Kubernetes name exactly as createKonnectGatewayControlPlane does.
+			kgcp := &konnectv1alpha2.KonnectGatewayControlPlane{}
+			kgcpName := setObjectNamespaceName(gateway, kgcp)
+			konnectName := konnectControlPlaneName(gateway, kgcpName)
+
+			assert.Equal(t, gateway.Namespace, kgcp.Namespace)
+
+			if tc.staticNaming {
+				// The Kubernetes name stays unqualified: that is the point of the annotation.
+				assert.Equal(t, gateway.Name, kgcp.Name)
+				assert.Equal(t, tc.expectedKonnectName, konnectName)
+				assert.NotEqual(t, kgcpName, konnectName,
+					"under static naming the Konnect name must differ from the Kubernetes name")
+				return
+			}
+
+			// Dynamic naming: the generated name carries a random suffix, so assert the
+			// relationship between the two names rather than a literal value.
+			assert.Equal(t, kgcpName, konnectName,
+				"under dynamic naming the Konnect name must equal the Kubernetes name (#3357)")
+			assert.NotEqual(t, gateway.Name, kgcpName,
+				"the dynamic Kubernetes name must carry a random suffix")
+			assert.NotEqual(t, gateway.Namespace+"-"+gateway.Name, konnectName,
+				"the dynamic Konnect name must not be qualified with the namespace")
 		})
 	}
 }

--- a/pkg/consts/consts.go
+++ b/pkg/consts/consts.go
@@ -89,6 +89,11 @@ const (
 	// GatewayStaticNamingAnnotation indicates that the gateway uses static naming for its resources.
 	// This means that the DataPlane, ControlPlane and KonnectGatewayControlPlane resources
 	// are named as the Gateway resource.
+	//
+	// NOTE: this applies to Kubernetes resource names only. The Control Plane created in
+	// Konnect is named "<namespace>-<gateway-name>", because Konnect enforces uniqueness on
+	// (org_id, name) across the whole organization, where the unqualified Gateway name is not
+	// unique.
 	GatewayStaticNamingAnnotation = OperatorAnnotationPrefix + "static-naming"
 
 	// CertExpiresAtAnnotation is the annotation used to store the certificate expiration time

--- a/test/e2e/chainsaw/gateway/konnect-dynamic-naming/01-gatewayconfiguration.yaml
+++ b/test/e2e/chainsaw/gateway/konnect-dynamic-naming/01-gatewayconfiguration.yaml
@@ -1,0 +1,29 @@
+# Konnect-backed GatewayConfiguration and GatewayClass with a same-namespace authRef.
+apiVersion: gateway-operator.konghq.com/v2beta1
+kind: GatewayConfiguration
+metadata:
+  name: (join('-', [($test_name), 'gateway-configuration']))
+  namespace: ($namespace)
+spec:
+  konnect:
+    authRef:
+      name: (join('-', [($test_name), 'konnect-api-auth']))
+  dataPlaneOptions:
+    deployment:
+      podTemplateSpec:
+        spec:
+          containers:
+            - name: proxy
+              image: ($gateway_image)
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: (join('-', [($test_name), 'gateway-class']))
+spec:
+  controllerName: konghq.com/gateway-operator
+  parametersRef:
+    group: gateway-operator.konghq.com
+    kind: GatewayConfiguration
+    name: (join('-', [($test_name), 'gateway-configuration']))
+    namespace: ($namespace)

--- a/test/e2e/chainsaw/gateway/konnect-dynamic-naming/02-assert-gatewayclass.yaml
+++ b/test/e2e/chainsaw/gateway/konnect-dynamic-naming/02-assert-gatewayclass.yaml
@@ -1,0 +1,8 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: (join('-', [($test_name), 'gateway-class']))
+status:
+  (conditions[?type == 'Accepted']):
+    - status: 'True'
+      reason: Accepted

--- a/test/e2e/chainsaw/gateway/konnect-dynamic-naming/03-gateway.yaml
+++ b/test/e2e/chainsaw/gateway/konnect-dynamic-naming/03-gateway.yaml
@@ -1,0 +1,13 @@
+# A Gateway WITHOUT the static-naming annotation, so its owned resources get the default
+# dynamic naming: "<gateway-name>-<random suffix>".
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ($gateway_name)
+  namespace: ($namespace)
+spec:
+  gatewayClassName: (join('-', [($test_name), 'gateway-class']))
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: ($listener_http_port)

--- a/test/e2e/chainsaw/gateway/konnect-dynamic-naming/04-assert-kgcp.yaml
+++ b/test/e2e/chainsaw/gateway/konnect-dynamic-naming/04-assert-kgcp.yaml
@@ -1,0 +1,17 @@
+# The Gateway-owned KonnectGatewayControlPlane is programmed in Konnect.
+#
+# Its name is generated, so it cannot be addressed by name: match on the labels the
+# operator applies to Gateway-owned objects instead. The naming invariants themselves are
+# checked by the following step, which needs to compare two fields against each other.
+apiVersion: konnect.konghq.com/v1alpha2
+kind: KonnectGatewayControlPlane
+metadata:
+  namespace: ($namespace)
+  labels:
+    gateway-operator.konghq.com/managed-by: gateway
+    gateway.networking.k8s.io/gateway-name: ($gateway_name)
+status:
+  (conditions[?type == 'Programmed']):
+    - status: 'True'
+      reason: Programmed
+  (id != null): true

--- a/test/e2e/chainsaw/gateway/konnect-dynamic-naming/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/gateway/konnect-dynamic-naming/chainsaw-test.yaml
@@ -1,0 +1,170 @@
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: gateway-konnect-dynamic-naming
+spec:
+  description: |
+    Non-regression lock for the default (dynamic) naming path of Gateway-owned
+    KonnectGatewayControlPlanes.
+
+    Without the static-naming annotation the operator generates
+    "<gateway-name>-<random suffix>" for the Kubernetes resource and uses that same string
+    as the Konnect Control Plane name, which is the invariant introduced in #3357. The fix
+    for #4079 qualifies the Konnect name with the namespace only under static naming; this
+    test makes sure the dynamic path is not changed by accident.
+  bindings:
+    - name: test_name
+      value: ($namespace)
+    - name: konnect_token
+      value: (env('KONNECT_TOKEN'))
+    - name: konnect_url
+      value: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
+    - name: gateway_image
+      value: (env('GATEWAY_IMAGE'))
+    # A short literal rather than the usual "<test_name>-gateway": the assertions below
+    # compare the generated name against the namespace, and a name that already embeds the
+    # namespace would make those comparisons meaningless.
+    - name: gateway_name
+      value: edge-gw
+    - name: listener_http_port
+      value: 80
+    - name: auth_secret_name
+      value: (join('-', [($test_name), 'konnect-auth-secret']))
+    - name: auth_secret_namespace
+      value: ($namespace)
+    - name: konnect_auth_name
+      value: (join('-', [($test_name), 'konnect-api-auth']))
+    - name: konnect_auth_namespace
+      value: ($namespace)
+
+  steps:
+    - name: 01-create-auth-secret
+      description: Create the Secret holding the Konnect token.
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAuthSecret.yaml
+
+    - name: 02-create-konnect-api-auth
+      description: Create the KonnectAPIAuthConfiguration.
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration-secretref.yaml
+
+    - name: 03-create-gateway-configuration
+      description: |
+        Create the Konnect-backed GatewayConfiguration and GatewayClass. These are local
+        files rather than the shared templates because the shared
+        apply-assert-gatewayConfiguration.yaml always emits an explicit authRef.namespace,
+        which would require a KongReferenceGrant this test does not need.
+      try:
+        - apply:
+            file: 01-gatewayconfiguration.yaml
+        - assert:
+            file: 02-assert-gatewayclass.yaml
+
+    - name: 04-create-gateway
+      description: Create a Gateway without the static-naming annotation.
+      try:
+        - apply:
+            file: 03-gateway.yaml
+
+    - name: 05-assert-konnect-control-plane-programmed
+      description: The Gateway-owned KonnectGatewayControlPlane reaches Programmed in Konnect.
+      try:
+        - assert:
+            file: 04-assert-kgcp.yaml
+
+    - name: 06-assert-dynamic-naming-invariants
+      description: |
+        The Konnect name equals the generated Kubernetes name (#3357) and is not qualified
+        with the namespace. This is a script rather than an assertion tree because it
+        compares two fields of the same resource against each other, and the expected
+        values are not known up front: the name carries a random suffix.
+
+        The preceding step already waited for the resource, so a single read is enough --
+        chainsaw runs a script exactly once, with no retry.
+      try:
+        - script:
+            env:
+              - name: NAMESPACE
+                value: ($namespace)
+              - name: GATEWAY_NAME
+                value: ($gateway_name)
+            content: |
+              set -euo pipefail
+
+              SELECTOR="gateway-operator.konghq.com/managed-by=gateway,gateway.networking.k8s.io/gateway-name=${GATEWAY_NAME}"
+
+              K8S_NAME=$(kubectl get konnectgatewaycontrolplanes.konnect.konghq.com \
+                -n "${NAMESPACE}" -l "${SELECTOR}" \
+                -o jsonpath='{.items[0].metadata.name}')
+              KONNECT_NAME=$(kubectl get konnectgatewaycontrolplanes.konnect.konghq.com \
+                -n "${NAMESPACE}" -l "${SELECTOR}" \
+                -o jsonpath='{.items[0].spec.createControlPlaneRequest.name}')
+
+              echo "kubernetes name: ${K8S_NAME}"
+              echo "konnect name:    ${KONNECT_NAME}"
+
+              if [ -z "${K8S_NAME}" ] || [ -z "${KONNECT_NAME}" ]; then
+                echo "FAIL: could not read both names from the KonnectGatewayControlPlane" >&2
+                exit 1
+              fi
+
+              # Invariant from #3357: on the dynamic path the two names are the same string.
+              if [ "${K8S_NAME}" != "${KONNECT_NAME}" ]; then
+                echo "FAIL: the Konnect name must equal the Kubernetes name on the dynamic naming path (#3357)" >&2
+                exit 1
+              fi
+
+              # The #4079 fix must qualify the Konnect name with the namespace ONLY under
+              # static naming.
+              if [ "${KONNECT_NAME}" = "${NAMESPACE}-${GATEWAY_NAME}" ]; then
+                echo "FAIL: the dynamic Konnect name must not be qualified with the namespace" >&2
+                exit 1
+              fi
+
+              # Dynamic naming appends a random suffix, so the bare Gateway name is wrong.
+              if [ "${K8S_NAME}" = "${GATEWAY_NAME}" ]; then
+                echo "FAIL: the dynamic Kubernetes name must carry a random suffix" >&2
+                exit 1
+              fi
+
+    - name: 07-cleanup
+      description: |
+        Delete the Gateway and wait for its Konnect-backed children to be gone before
+        chainsaw tears the namespace down, so the operator can still authenticate to
+        Konnect while deprovisioning. The error operation succeeds only when nothing
+        matches, so it doubles as "wait until gone".
+      timeouts:
+        delete: 120s
+        error: 120s
+      try:
+        - delete:
+            ref:
+              apiVersion: gateway.networking.k8s.io/v1
+              kind: Gateway
+              name: ($gateway_name)
+              namespace: ($namespace)
+        - error:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              metadata:
+                namespace: ($namespace)
+        - error:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectExtension
+              metadata:
+                namespace: ($namespace)
+
+  catch:
+    - description: Capture debug snapshot
+      script:
+        env:
+          - name: TEST_NAME
+            value: gateway-konnect-dynamic-naming
+          - name: NAMESPACE
+            value: ($namespace)
+          - name: OPERATOR_NAMESPACE
+            value: kong-system
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh

--- a/test/e2e/chainsaw/gateway/konnect-static-naming-cross-namespace/01-gatewayconfiguration-staging.yaml
+++ b/test/e2e/chainsaw/gateway/konnect-static-naming-cross-namespace/01-gatewayconfiguration-staging.yaml
@@ -1,0 +1,32 @@
+# Konnect-backed GatewayConfiguration and GatewayClass for the "staging" environment.
+# The KonnectAPIAuthConfiguration lives in the same namespace, so authRef carries no
+# namespace and no KongReferenceGrant is needed.
+apiVersion: gateway-operator.konghq.com/v2beta1
+kind: GatewayConfiguration
+metadata:
+  name: (join('-', [($test_name), 'staging-gateway-configuration']))
+  namespace: ($staging_namespace)
+spec:
+  konnect:
+    authRef:
+      name: (join('-', [($test_name), 'staging-konnect-api-auth']))
+  dataPlaneOptions:
+    deployment:
+      podTemplateSpec:
+        spec:
+          containers:
+            - name: proxy
+              image: ($gateway_image)
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  # Cluster-scoped, so it must be unique across concurrent test runs.
+  name: (join('-', [($test_name), 'staging-gateway-class']))
+spec:
+  controllerName: konghq.com/gateway-operator
+  parametersRef:
+    group: gateway-operator.konghq.com
+    kind: GatewayConfiguration
+    name: (join('-', [($test_name), 'staging-gateway-configuration']))
+    namespace: ($staging_namespace)

--- a/test/e2e/chainsaw/gateway/konnect-static-naming-cross-namespace/02-assert-gatewayclass-staging.yaml
+++ b/test/e2e/chainsaw/gateway/konnect-static-naming-cross-namespace/02-assert-gatewayclass-staging.yaml
@@ -1,0 +1,8 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: (join('-', [($test_name), 'staging-gateway-class']))
+status:
+  (conditions[?type == 'Accepted']):
+    - status: 'True'
+      reason: Accepted

--- a/test/e2e/chainsaw/gateway/konnect-static-naming-cross-namespace/03-gateway-staging.yaml
+++ b/test/e2e/chainsaw/gateway/konnect-static-naming-cross-namespace/03-gateway-staging.yaml
@@ -1,0 +1,16 @@
+# Gateway in the "staging" namespace with static naming enabled.
+# Its name is deliberately identical to the Gateway created in the "production"
+# namespace: that is the condition that triggers the Konnect 409 of #4079.
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ($gateway_name)
+  namespace: ($staging_namespace)
+  annotations:
+    gateway-operator.konghq.com/static-naming: "true"
+spec:
+  gatewayClassName: (join('-', [($test_name), 'staging-gateway-class']))
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: ($listener_http_port)

--- a/test/e2e/chainsaw/gateway/konnect-static-naming-cross-namespace/04-assert-kgcp-staging.yaml
+++ b/test/e2e/chainsaw/gateway/konnect-static-naming-cross-namespace/04-assert-kgcp-staging.yaml
@@ -1,0 +1,17 @@
+# The Kubernetes resource name is the unqualified Gateway name (that is what static
+# naming means), while the name requested from Konnect is qualified with the namespace.
+apiVersion: konnect.konghq.com/v1alpha2
+kind: KonnectGatewayControlPlane
+metadata:
+  name: ($gateway_name)
+  namespace: ($staging_namespace)
+spec:
+  createControlPlaneRequest:
+    name: (join('-', [($staging_namespace), ($gateway_name)]))
+status:
+  # Programmed=True plus a non-null Konnect ID is what proves the Control Plane was
+  # actually created in Konnect, rather than merely requested.
+  (conditions[?type == 'Programmed']):
+    - status: 'True'
+      reason: Programmed
+  (id != null): true

--- a/test/e2e/chainsaw/gateway/konnect-static-naming-cross-namespace/05-gatewayconfiguration-production.yaml
+++ b/test/e2e/chainsaw/gateway/konnect-static-naming-cross-namespace/05-gatewayconfiguration-production.yaml
@@ -1,0 +1,29 @@
+# Same shape as the staging environment, in a second namespace.
+apiVersion: gateway-operator.konghq.com/v2beta1
+kind: GatewayConfiguration
+metadata:
+  name: (join('-', [($test_name), 'production-gateway-configuration']))
+  namespace: ($production_namespace)
+spec:
+  konnect:
+    authRef:
+      name: (join('-', [($test_name), 'production-konnect-api-auth']))
+  dataPlaneOptions:
+    deployment:
+      podTemplateSpec:
+        spec:
+          containers:
+            - name: proxy
+              image: ($gateway_image)
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: (join('-', [($test_name), 'production-gateway-class']))
+spec:
+  controllerName: konghq.com/gateway-operator
+  parametersRef:
+    group: gateway-operator.konghq.com
+    kind: GatewayConfiguration
+    name: (join('-', [($test_name), 'production-gateway-configuration']))
+    namespace: ($production_namespace)

--- a/test/e2e/chainsaw/gateway/konnect-static-naming-cross-namespace/06-assert-gatewayclass-production.yaml
+++ b/test/e2e/chainsaw/gateway/konnect-static-naming-cross-namespace/06-assert-gatewayclass-production.yaml
@@ -1,0 +1,8 @@
+apiVersion: gateway.networking.k8s.io/v1
+kind: GatewayClass
+metadata:
+  name: (join('-', [($test_name), 'production-gateway-class']))
+status:
+  (conditions[?type == 'Accepted']):
+    - status: 'True'
+      reason: Accepted

--- a/test/e2e/chainsaw/gateway/konnect-static-naming-cross-namespace/07-gateway-production.yaml
+++ b/test/e2e/chainsaw/gateway/konnect-static-naming-cross-namespace/07-gateway-production.yaml
@@ -1,0 +1,16 @@
+# Gateway with the SAME name as the staging one, in a different namespace, also with
+# static naming. Before the #4079 fix both Gateways asked Konnect for a Control Plane
+# named "edge-gw", and this second create failed with HTTP 409.
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ($gateway_name)
+  namespace: ($production_namespace)
+  annotations:
+    gateway-operator.konghq.com/static-naming: "true"
+spec:
+  gatewayClassName: (join('-', [($test_name), 'production-gateway-class']))
+  listeners:
+    - name: http
+      protocol: HTTP
+      port: ($listener_http_port)

--- a/test/e2e/chainsaw/gateway/konnect-static-naming-cross-namespace/08-assert-kgcp-production.yaml
+++ b/test/e2e/chainsaw/gateway/konnect-static-naming-cross-namespace/08-assert-kgcp-production.yaml
@@ -1,0 +1,19 @@
+# This is the regression assertion of #4079.
+#
+# The spec check alone would pass even if Konnect rejected the request, because it only
+# inspects what the operator wrote locally. Programmed=True with a non-null Konnect ID on
+# THIS second Control Plane is what proves the create succeeded: before the fix this
+# resource stayed Programmed=False, looping on a 409 conflict with the staging one.
+apiVersion: konnect.konghq.com/v1alpha2
+kind: KonnectGatewayControlPlane
+metadata:
+  name: ($gateway_name)
+  namespace: ($production_namespace)
+spec:
+  createControlPlaneRequest:
+    name: (join('-', [($production_namespace), ($gateway_name)]))
+status:
+  (conditions[?type == 'Programmed']):
+    - status: 'True'
+      reason: Programmed
+  (id != null): true

--- a/test/e2e/chainsaw/gateway/konnect-static-naming-cross-namespace/09-assert-gateways-programmed.yaml
+++ b/test/e2e/chainsaw/gateway/konnect-static-naming-cross-namespace/09-assert-gateways-programmed.yaml
@@ -1,0 +1,50 @@
+# Both Gateways must be fully programmed: same name, different namespaces, no conflict.
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ($gateway_name)
+  namespace: ($staging_namespace)
+status:
+  (conditions[?type == 'Accepted']):
+    - status: 'True'
+      reason: Accepted
+  (conditions[?type == 'KonnectGatewayControlPlaneProgrammed']):
+    - status: 'True'
+      reason: Programmed
+  (conditions[?type == 'Programmed']):
+    - status: 'True'
+      reason: Programmed
+  (conditions[?type == 'DataPlaneReady']):
+    - status: 'True'
+      reason: Ready
+  (conditions[?type == 'KonnectExtensionReady']):
+    - status: 'True'
+      reason: Ready
+  (conditions[?type == 'GatewayService']):
+    - status: 'True'
+      reason: Ready
+---
+apiVersion: gateway.networking.k8s.io/v1
+kind: Gateway
+metadata:
+  name: ($gateway_name)
+  namespace: ($production_namespace)
+status:
+  (conditions[?type == 'Accepted']):
+    - status: 'True'
+      reason: Accepted
+  (conditions[?type == 'KonnectGatewayControlPlaneProgrammed']):
+    - status: 'True'
+      reason: Programmed
+  (conditions[?type == 'Programmed']):
+    - status: 'True'
+      reason: Programmed
+  (conditions[?type == 'DataPlaneReady']):
+    - status: 'True'
+      reason: Ready
+  (conditions[?type == 'KonnectExtensionReady']):
+    - status: 'True'
+      reason: Ready
+  (conditions[?type == 'GatewayService']):
+    - status: 'True'
+      reason: Ready

--- a/test/e2e/chainsaw/gateway/konnect-static-naming-cross-namespace/chainsaw-test.yaml
+++ b/test/e2e/chainsaw/gateway/konnect-static-naming-cross-namespace/chainsaw-test.yaml
@@ -1,0 +1,219 @@
+# Regression test for https://github.com/Kong/kong-operator/issues/4079.
+apiVersion: chainsaw.kyverno.io/v1alpha1
+kind: Test
+metadata:
+  name: gateway-konnect-static-naming-cross-namespace
+spec:
+  description: |
+    Validates that two Gateways sharing a name across namespaces, both opted into static
+    naming, each get their own Control Plane in Konnect.
+
+    A KonnectGatewayControlPlane carries two independent names with two different uniqueness
+    scopes: metadata.name is unique per (namespace, kind, name), while
+    spec.createControlPlaneRequest.name must be unique per (org_id, name) across the whole
+    Konnect organization. Static naming drops the random suffix, so before the fix both
+    Gateways requested a Control Plane named "edge-gw" and the second create failed with
+    HTTP 409, leaving that Gateway stuck at Programmed=False.
+
+    The Konnect name is now qualified with the namespace, while the Kubernetes resource name
+    stays the unqualified Gateway name.
+
+    This is the first Konnect-backed test in the gateway/ suite. It lives here rather than
+    under hybridgateway/ because the code under test is controller/gateway/.
+  bindings:
+    - name: test_name
+      value: ($namespace)
+    - name: konnect_token
+      value: (env('KONNECT_TOKEN'))
+    - name: konnect_url
+      value: (env('KONNECT_SERVER_URL') || 'eu.api.konghq.tech')
+    - name: gateway_image
+      value: (env('GATEWAY_IMAGE'))
+    # A fixed literal, IDENTICAL in both namespaces: this is the condition that triggers the
+    # bug. Uniqueness against concurrent runs and against other tests sharing the Konnect
+    # organization comes from $namespace, which chainsaw randomizes per test.
+    - name: gateway_name
+      value: edge-gw
+    - name: listener_http_port
+      value: 80
+    - name: staging_namespace
+      value: (join('-', [($namespace), 'staging']))
+    - name: production_namespace
+      value: (join('-', [($namespace), 'production']))
+
+  steps:
+    - name: 01-create-staging-namespace
+      description: Create the namespace standing in for a "staging" environment.
+      bindings:
+        - name: namespace_name
+          value: ($staging_namespace)
+      use:
+        template: ../../common/_step_templates/apply-assert-namespace.yaml
+
+    - name: 02-create-production-namespace
+      description: Create the namespace standing in for a "production" environment.
+      bindings:
+        - name: namespace_name
+          value: ($production_namespace)
+      use:
+        template: ../../common/_step_templates/apply-assert-namespace.yaml
+
+    - name: 03-create-staging-auth-secret
+      description: Create the Secret holding the Konnect token in the staging namespace.
+      bindings:
+        - name: auth_secret_name
+          value: (join('-', [($test_name), 'staging-konnect-auth-secret']))
+        - name: auth_secret_namespace
+          value: ($staging_namespace)
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAuthSecret.yaml
+
+    - name: 04-create-staging-konnect-api-auth
+      description: Create the KonnectAPIAuthConfiguration in the staging namespace.
+      bindings:
+        - name: auth_secret_name
+          value: (join('-', [($test_name), 'staging-konnect-auth-secret']))
+        - name: auth_secret_namespace
+          value: ($staging_namespace)
+        - name: konnect_auth_name
+          value: (join('-', [($test_name), 'staging-konnect-api-auth']))
+        - name: konnect_auth_namespace
+          value: ($staging_namespace)
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration-secretref.yaml
+
+    - name: 05-create-production-auth-secret
+      description: Create the Secret holding the Konnect token in the production namespace.
+      bindings:
+        - name: auth_secret_name
+          value: (join('-', [($test_name), 'production-konnect-auth-secret']))
+        - name: auth_secret_namespace
+          value: ($production_namespace)
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAuthSecret.yaml
+
+    - name: 06-create-production-konnect-api-auth
+      description: Create the KonnectAPIAuthConfiguration in the production namespace.
+      bindings:
+        - name: auth_secret_name
+          value: (join('-', [($test_name), 'production-konnect-auth-secret']))
+        - name: auth_secret_namespace
+          value: ($production_namespace)
+        - name: konnect_auth_name
+          value: (join('-', [($test_name), 'production-konnect-api-auth']))
+        - name: konnect_auth_namespace
+          value: ($production_namespace)
+      use:
+        template: ../../common/_step_templates/apply-assert-konnectAPIAuthConfiguration-secretref.yaml
+
+    - name: 07-create-staging-gateway-configuration
+      description: |
+        Create the Konnect-backed GatewayConfiguration and GatewayClass for staging.
+        These are local files rather than the shared templates: the shared
+        apply-assert-gatewayConfiguration.yaml always emits an explicit
+        authRef.namespace, which would require a KongReferenceGrant this test does not
+        need, and both shared templates derive their names from chainsaw's own $namespace
+        rather than a per-environment one.
+      try:
+        - apply:
+            file: 01-gatewayconfiguration-staging.yaml
+        - assert:
+            file: 02-assert-gatewayclass-staging.yaml
+
+    - name: 08-create-production-gateway-configuration
+      description: Create the Konnect-backed GatewayConfiguration and GatewayClass for production.
+      try:
+        - apply:
+            file: 05-gatewayconfiguration-production.yaml
+        - assert:
+            file: 06-assert-gatewayclass-production.yaml
+
+    - name: 09-create-staging-gateway
+      description: Create the staging Gateway with static naming and assert its Konnect Control Plane.
+      try:
+        - apply:
+            file: 03-gateway-staging.yaml
+        - assert:
+            file: 04-assert-kgcp-staging.yaml
+
+    - name: 10-create-production-gateway
+      description: |
+        Create the identically named Gateway in the production namespace and assert its
+        Konnect Control Plane. This is the regression assertion: before the fix the create
+        in Konnect failed with HTTP 409 and this Control Plane never became Programmed.
+      try:
+        - apply:
+            file: 07-gateway-production.yaml
+        - assert:
+            file: 08-assert-kgcp-production.yaml
+
+    - name: 11-assert-both-gateways-programmed
+      description: Both Gateways are fully programmed, with no conflict between them.
+      try:
+        - assert:
+            file: 09-assert-gateways-programmed.yaml
+
+    - name: 12-cleanup
+      description: |
+        Delete the Gateways and wait for their Konnect-backed children to be gone before
+        chainsaw tears the namespaces down. Chainsaw cleans up in reverse creation order,
+        which would remove the KonnectAPIAuthConfiguration while the operator still needs
+        it to authenticate to Konnect and drop the "konnectapiauth-in-use" finalizer --
+        deprovisioning would then hang. The error operation succeeds only when nothing
+        matches, so it doubles as "wait until gone".
+      timeouts:
+        delete: 120s
+        error: 120s
+      try:
+        - delete:
+            ref:
+              apiVersion: gateway.networking.k8s.io/v1
+              kind: Gateway
+              name: ($gateway_name)
+              namespace: ($staging_namespace)
+        - delete:
+            ref:
+              apiVersion: gateway.networking.k8s.io/v1
+              kind: Gateway
+              name: ($gateway_name)
+              namespace: ($production_namespace)
+        - error:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              metadata:
+                namespace: ($staging_namespace)
+        - error:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectExtension
+              metadata:
+                namespace: ($staging_namespace)
+        - error:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectGatewayControlPlane
+              metadata:
+                namespace: ($production_namespace)
+        - error:
+            resource:
+              apiVersion: konnect.konghq.com/v1alpha2
+              kind: KonnectExtension
+              metadata:
+                namespace: ($production_namespace)
+
+  catch:
+    - description: Capture debug snapshot
+      script:
+        env:
+          - name: TEST_NAME
+            value: gateway-konnect-static-naming-cross-namespace
+          - name: NAMESPACE
+            value: ($namespace)
+          # Comma-separated: debug_snapshot.sh splits on commas, not spaces.
+          - name: ADDITIONAL_NAMESPACES
+            value: (join(',', [($staging_namespace), ($production_namespace)]))
+          - name: OPERATOR_NAMESPACE
+            value: kong-system
+        content: |
+          bash ../../common/scripts/debug_snapshot.sh

--- a/test/envtest/gateway-api/gateway_konnect_static_naming_envtest_test.go
+++ b/test/envtest/gateway-api/gateway_konnect_static_naming_envtest_test.go
@@ -1,0 +1,224 @@
+package gatewayapi
+
+import (
+	"testing"
+
+	sdkkonnectcomp "github.com/Kong/sdk-konnect-go/models/components"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apimeta "k8s.io/apimachinery/pkg/api/meta"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	gatewayv1 "sigs.k8s.io/gateway-api/apis/v1"
+
+	kcfggateway "github.com/kong/kong-operator/v2/api/gateway-operator/gateway"
+	konnectv1alpha2 "github.com/kong/kong-operator/v2/api/konnect/v1alpha2"
+	kogateway "github.com/kong/kong-operator/v2/controller/gateway"
+	managerscheme "github.com/kong/kong-operator/v2/modules/manager/scheme"
+	"github.com/kong/kong-operator/v2/pkg/consts"
+	gatewayutils "github.com/kong/kong-operator/v2/pkg/utils/gateway"
+	k8sutils "github.com/kong/kong-operator/v2/pkg/utils/kubernetes"
+	testutils "github.com/kong/kong-operator/v2/pkg/utils/test"
+	"github.com/kong/kong-operator/v2/pkg/vars"
+	"github.com/kong/kong-operator/v2/test/envtest"
+	envtestconsts "github.com/kong/kong-operator/v2/test/envtest/consts"
+	"github.com/kong/kong-operator/v2/test/helpers/deploy"
+)
+
+// TestGatewayKonnectControlPlaneStaticNaming covers the naming of the KonnectGatewayControlPlane
+// created for a Gateway that opts into static naming via the
+// gateway-operator.konghq.com/static-naming annotation.
+//
+// The Kubernetes name and the Konnect name have different uniqueness scopes:
+// (namespace, kind, name) versus (org_id, name). Under static naming the Kubernetes name must
+// stay the unqualified Gateway name, while the Konnect name must be qualified with the namespace
+// so that same-named Gateways in different namespaces do not collide in Konnect with an HTTP 409
+// (#4079).
+func TestGatewayKonnectControlPlaneStaticNaming(t *testing.T) {
+	t.Parallel()
+
+	const gatewayName = "edge-gw"
+
+	scheme := managerscheme.Get()
+	ctx := t.Context()
+
+	cfg, gwNs := envtest.Setup(t, ctx, scheme, envtest.WithInstallGatewayCRDs(true))
+	mgr, logs := envtest.NewManager(t, ctx, cfg, scheme)
+
+	r := &kogateway.Reconciler{
+		Client:                mgr.GetClient(),
+		Scheme:                scheme,
+		Namespace:             gwNs.Name,
+		DefaultDataPlaneImage: "kong:latest",
+	}
+	envtest.StartReconcilers(ctx, t, mgr, logs, r)
+
+	c := mgr.GetClient()
+
+	gwConfig := deploy.GatewayConfiguration(t, ctx, c,
+		func(obj client.Object) { obj.SetName("static-naming-gwconfig"); obj.SetNamespace(gwNs.Name) },
+		deploy.WithGatewayConfigKonnectAuthRef("my-auth", gwNs.Name),
+	)
+	t.Cleanup(func() { _ = c.Delete(ctx, gwConfig) })
+
+	gc := deploy.GatewayClass(t, ctx, c,
+		func(obj client.Object) { obj.SetName("static-naming-gc") },
+		deploy.WithGatewayClassControllerName(vars.ControllerName()),
+		deploy.WithGatewayClassParametersRef("gateway-operator.konghq.com", "GatewayConfiguration", gwConfig.Name, gwNs.Name),
+	)
+	t.Cleanup(func() { _ = c.Delete(ctx, gc) })
+
+	t.Log("patching GatewayClass status to Accepted=True")
+	require.Eventually(t, testutils.GatewayClassAcceptedStatusUpdate(t, ctx, gc.Name, c), envtestconsts.WaitTime, envtestconsts.TickTime)
+
+	gw := deploy.Gateway(t, ctx, c,
+		func(obj client.Object) {
+			obj.SetName(gatewayName)
+			obj.SetNamespace(gwNs.Name)
+			obj.SetAnnotations(map[string]string{consts.GatewayStaticNamingAnnotation: "true"})
+		},
+		deploy.WithGatewayClassName(gc.Name),
+		deploy.WithGatewayListeners(gatewayv1.Listener{Name: "http", Protocol: gatewayv1.HTTPProtocolType, Port: 80}),
+	)
+	t.Cleanup(func() { _ = c.Delete(ctx, gw) })
+
+	t.Log("waiting for the KonnectGatewayControlPlane to be created")
+	var kgcp konnectv1alpha2.KonnectGatewayControlPlane
+	require.Eventually(t, func() bool {
+		var l konnectv1alpha2.KonnectGatewayControlPlaneList
+		if err := c.List(ctx, &l, client.InNamespace(gwNs.Name)); err != nil {
+			t.Logf("error listing KonnectGatewayControlPlanes: %v", err)
+			return false
+		}
+		if len(l.Items) != 1 {
+			return false
+		}
+		kgcp = l.Items[0]
+		return kgcp.Spec.CreateControlPlaneRequest != nil
+	}, envtestconsts.WaitTime, envtestconsts.TickTime, "exactly one KonnectGatewayControlPlane should be created")
+
+	// The Kubernetes name stays unqualified: that is the point of the annotation.
+	assert.Equal(t, gatewayName, kgcp.Name,
+		"the KonnectGatewayControlPlane Kubernetes name must match the Gateway name under static naming")
+	// The Konnect name is qualified with the namespace to keep it unique within the organization.
+	assert.Equal(t, gwNs.Name+"-"+gatewayName, kgcp.Spec.CreateControlPlaneRequest.Name,
+		"the Konnect Control Plane name must be qualified with the Gateway namespace")
+}
+
+// TestGatewayKonnectControlPlaneStaticNamingBackwardCompatibility asserts that a
+// KonnectGatewayControlPlane created before the #4079 fix -- whose
+// spec.createControlPlaneRequest.name is the old unqualified Gateway name -- is left alone on
+// upgrade. Renaming it would rename the Control Plane in Konnect, and creating a second one
+// would provision a duplicate Control Plane.
+func TestGatewayKonnectControlPlaneStaticNamingBackwardCompatibility(t *testing.T) {
+	t.Parallel()
+
+	const (
+		gatewayName = "edge-gw"
+		// legacyKonnectName is what the operator wrote before the fix: the unqualified name.
+		legacyKonnectName = gatewayName
+	)
+
+	scheme := managerscheme.Get()
+	ctx := t.Context()
+
+	cfg, gwNs := envtest.Setup(t, ctx, scheme, envtest.WithInstallGatewayCRDs(true))
+	mgr, logs := envtest.NewManager(t, ctx, cfg, scheme)
+
+	r := &kogateway.Reconciler{
+		Client:                mgr.GetClient(),
+		Scheme:                scheme,
+		Namespace:             gwNs.Name,
+		DefaultDataPlaneImage: "kong:latest",
+	}
+	envtest.StartReconcilers(ctx, t, mgr, logs, r)
+
+	c := mgr.GetClient()
+
+	gwConfig := deploy.GatewayConfiguration(t, ctx, c,
+		func(obj client.Object) { obj.SetName("static-naming-bc-gwconfig"); obj.SetNamespace(gwNs.Name) },
+		deploy.WithGatewayConfigKonnectAuthRef("my-auth", gwNs.Name),
+	)
+	t.Cleanup(func() { _ = c.Delete(ctx, gwConfig) })
+
+	// Create the GatewayClass without accepting it yet: the reconciler ignores Gateways whose
+	// GatewayClass is not Accepted, which gives us a window to seed the pre-existing
+	// KonnectGatewayControlPlane before any reconciliation happens.
+	gc := deploy.GatewayClass(t, ctx, c,
+		func(obj client.Object) { obj.SetName("static-naming-bc-gc") },
+		deploy.WithGatewayClassControllerName(vars.ControllerName()),
+		deploy.WithGatewayClassParametersRef("gateway-operator.konghq.com", "GatewayConfiguration", gwConfig.Name, gwNs.Name),
+	)
+	t.Cleanup(func() { _ = c.Delete(ctx, gc) })
+
+	gw := deploy.Gateway(t, ctx, c,
+		func(obj client.Object) {
+			obj.SetName(gatewayName)
+			obj.SetNamespace(gwNs.Name)
+			obj.SetAnnotations(map[string]string{consts.GatewayStaticNamingAnnotation: "true"})
+		},
+		deploy.WithGatewayClassName(gc.Name),
+		deploy.WithGatewayListeners(gatewayv1.Listener{Name: "http", Protocol: gatewayv1.HTTPProtocolType, Port: 80}),
+	)
+	t.Cleanup(func() { _ = c.Delete(ctx, gw) })
+
+	t.Log("seeding a pre-fix KonnectGatewayControlPlane with the old unqualified Konnect name")
+	existing := &konnectv1alpha2.KonnectGatewayControlPlane{
+		ObjectMeta: metav1.ObjectMeta{
+			Namespace: gwNs.Name,
+			Name:      gatewayName,
+		},
+	}
+	existing.Spec.CreateControlPlaneRequest = &sdkkonnectcomp.CreateControlPlaneRequest{
+		Name: legacyKonnectName,
+	}
+	existing.Spec.KonnectConfiguration.APIAuthConfigurationRef = konnectv1alpha2.ControlPlaneKonnectAPIAuthConfigurationRef{
+		Name:      "my-auth",
+		Namespace: new(gwNs.Name),
+	}
+	// Match what the reconciler looks for: same namespace, managed-by label, owned by the Gateway.
+	// The client strips TypeMeta from the object returned by Create, so restore it before
+	// deriving the owner reference from it.
+	gw.TypeMeta = metav1.TypeMeta{
+		APIVersion: gatewayv1.GroupVersion.String(),
+		Kind:       "Gateway",
+	}
+	k8sutils.SetOwnerForObject(existing, gw)
+	gatewayutils.LabelObjectAsGatewayManaged(existing, gw.Name)
+	require.NoError(t, c.Create(ctx, existing))
+
+	t.Log("accepting the GatewayClass so the Gateway starts reconciling")
+	require.Eventually(t, testutils.GatewayClassAcceptedStatusUpdate(t, ctx, gc.Name, c), envtestconsts.WaitTime, envtestconsts.TickTime)
+
+	// The seeded Control Plane never becomes Programmed (there is no Konnect backend in envtest),
+	// so this condition proves the reconciler took the "one existing Control Plane" branch and
+	// called enforceKonnectGatewayControlPlaneSpec rather than creating a new one.
+	t.Log("waiting for the Gateway to report on the existing KonnectGatewayControlPlane")
+	require.Eventually(t, func() bool {
+		var got gatewayv1.Gateway
+		if err := c.Get(ctx, client.ObjectKeyFromObject(gw), &got); err != nil {
+			return false
+		}
+		cond := apimeta.FindStatusCondition(got.Status.Conditions, string(kcfggateway.KonnectGatewayControlPlaneProgrammedType))
+		return cond != nil && cond.Status == metav1.ConditionFalse
+	}, envtestconsts.WaitTime, envtestconsts.TickTime, "the Gateway should report the existing KonnectGatewayControlPlane as not programmed")
+
+	t.Log("asserting the pre-existing Konnect name is never rewritten and no duplicate is created")
+	require.Never(t, func() bool {
+		var l konnectv1alpha2.KonnectGatewayControlPlaneList
+		if err := c.List(ctx, &l, client.InNamespace(gwNs.Name)); err != nil {
+			return false
+		}
+		if len(l.Items) != 1 {
+			t.Logf("expected 1 KonnectGatewayControlPlane, found %d", len(l.Items))
+			return true
+		}
+		req := l.Items[0].Spec.CreateControlPlaneRequest
+		if req == nil || req.Name != legacyKonnectName {
+			t.Logf("spec.createControlPlaneRequest.name changed: %v", req)
+			return true
+		}
+		return false
+	}, envtestconsts.WaitTime, envtestconsts.TickTime,
+		"an existing KonnectGatewayControlPlane must be neither renamed nor duplicated")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

> **TL;DR** — Under static naming, the Konnect Control Plane name is namespace-qualified again (`<namespace>_<gateway-name>`), so two same-named Gateways in different namespaces stop colliding in Konnect. The dynamic path is untouched.

**The bug.** A `KonnectGatewayControlPlane` has two names: `metadata.name`, unique per namespace, and `spec.createControlPlaneRequest.name`, which must be unique across the whole Konnect org. #3357 replaced the old deterministic `<namespace>-<gateway-name>` Konnect name with the Kubernetes name plus a client-side random suffix, and that suffix is the anti-collision mechanism. Static naming (#3024) has no suffix, by design, so on that path the namespace qualification was removed with nothing in its place.

**The symptom.** Two Gateways named `edge-gw` in `staging` and `production`, both statically named, are legal in Kubernetes but collide in Konnect. The second create returns HTTP 409 and that Gateway is stuck at `Programmed=False`.

**The fix and what it costs.** Static naming qualifies the Konnect name with the namespace again, joined with an underscore; the dynamic path keeps #3357's behaviour, locked by `gateway/konnect-dynamic-naming`. An underscore is valid in neither a namespace nor a Gateway name, so `<namespace>_<gateway-name>` splits unambiguously, where `<namespace>-<gateway-name>` does not: both sides may contain a hyphen. The cost is that the two names no longer match on the static path (`edge-gw` in Kubernetes, `staging_edge_gw` in Konnect). Nothing reads the Konnect name to find an entity — lookups go through the `k8s-uid` label or the Konnect ID — and the namespace is still exposed in Konnect as the `k8s-namespace` label. A bare predictable Kubernetes name, matching Kubernetes and Konnect names, and org-wide uniqueness can't all hold at once under static naming. This drops the second.

**No renames on upgrade.** `createKonnectGatewayControlPlane` runs only when the Gateway owns no Control Plane yet, and `enforceKonnectGatewayControlPlaneSpec` never touches the name, so existing Control Planes are left alone. To move an existing one onto the new scheme, edit `spec.createControlPlaneRequest.name`: Konnect renames in place and keeps the ID.

**Which issue this PR fixes**

Fixes #4079

**Special notes for your reviewer**:

> **TL;DR** — The fix lives at the call site, not in `setObjectNamespaceName`. Static naming had no test coverage anywhere in the repo before this PR; it now has unit, envtest, and Konnect-backed e2e coverage.

**Why not `setObjectNamespaceName`.** It sets `metadata.name` *and* returns the string that feeds the Konnect name, so changing it changes both — and `metadata.name` isn't where the bug is. A KGCP named `default_hybrid` breaks every manifest that references it by name, including the #3024 sample. The helper is also shared with `DataPlane` and `ControlPlane`, whose names never reach Konnect and play no part in the `(org_id, name)` collision. It stays functionally as is; only the duplicated annotation check moved out, into `hasStaticNaming()`.

**Tests.** `TestEnforceKonnectGatewayControlPlaneSpec` now seeds the pre-fix unqualified Konnect name in every case and asserts it survives. That name is write-once at creation and nothing enforced it, so without this test a future change there would silently rename every existing Konnect Control Plane on upgrade. An envtest covers the same on the reconciler path. `gateway/konnect-static-naming-cross-namespace` was confirmed to fail without the fix, on the qualified-name assertion for the first Gateway; its `Programmed=True` and non-null Konnect ID checks also verify that Konnect accepts both Control Planes, which envtest can't do without a Konnect backend. It's the first Konnect-backed test in the `gateway/` suite and needs no workflow change.

**Manual verification.** Against a real Konnect org, the two Gateways produce `staging_edge_gw` and `production_edge_gw` with distinct Konnect IDs, both `Programmed=True`.

**Out of scope.** The same namespace and name on two clusters sharing one Konnect org still conflict; this is noted in the release note. #3357 closes that axis with randomness, and static naming exists to make names deterministic, so closing it on the static path needs an explicit cluster identifier rather than a suffix.

**Docs.** [Kong/developer.konghq.com#7321](https://github.com/Kong/developer.konghq.com/pull/7321) updates the static naming how-to for the new name. It stays in draft until this ships, because the operator docs are not versioned: merging it earlier would put a page in front of readers that contradicts the release they are running.

**PR Readiness Checklist**:

Complete these before marking the PR as `ready to review`:

- [x] the `CHANGELOG.md` release notes have been updated to reflect significant changes

