### PR TITLE
chore(refactor): remove redundant `ReferenceGrant` guarding

### DIFF
--- a/ingress-controller/internal/controllers/gateway/gateway_controller.go
+++ b/ingress-controller/internal/controllers/gateway/gateway_controller.go
@@ -62,10 +62,6 @@ type GatewayReconciler struct {
 	// AddressOverridesUDP are addresses to use in Gateway status instead of the PublishServiceUDPRef addresses.
 	AddressOverridesUDP []string
 
-	// If enableReferenceGrant is true, controller will watch ReferenceGrants
-	// to invalidate or allow cross-namespace TLSConfigs in gateways.
-	// It's resolved on SetupWithManager call.
-	enableReferenceGrant bool
 	// referenceGrantVersion is the ReferenceGrant API GroupVersion (v1 or v1beta1)
 	// served by the cluster, resolved on SetupWithManager call.
 	referenceGrantVersion schema.GroupVersion
@@ -82,19 +78,14 @@ func (r *GatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		return fmt.Errorf("publish service must be configured")
 	}
 
-	// We're verifying whether ReferenceGrant CRD is installed at setup of the GatewayReconciler
-	// to decide whether we should run additional ReferenceGrant watch and handle ReferenceGrants
-	// when reconciling Gateways.
-	// Once the GatewayReconciler is set up without ReferenceGrant, there's no possibility to enable
-	// ReferenceGrant handling again in this reconciler at runtime.
-	gv, ok, err := ctrlutils.DetectReferenceGrantVersion(mgr.GetRESTMapper())
+	// The ReferenceGrant CRD is a hard requirement of this reconciler: it is needed to
+	// validate cross-namespace TLSConfigs in Gateways. Resolve which version the cluster
+	// serves at setup, and fail loudly if neither is installed.
+	gv, err := ctrlutils.DetectReferenceGrantVersion(mgr.GetRESTMapper())
 	if err != nil {
-		return fmt.Errorf("failed to detect the ReferenceGrant API version: %w", err)
+		return err
 	}
-	r.referenceGrantVersion, r.enableReferenceGrant = gv, ok
-	if !r.enableReferenceGrant {
-		r.Log.Error(nil, "Neither v1 nor v1beta1 ReferenceGrant CRD found; cross-namespace references will be rejected")
-	}
+	r.referenceGrantVersion = gv
 
 	blder := ctrl.NewControllerManagedBy(mgr).
 		// set the controller name
@@ -131,12 +122,10 @@ func (r *GatewayReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		)
 
 	// watch ReferenceGrants, which may invalidate or allow cross-namespace TLSConfigs
-	if r.enableReferenceGrant {
-		blder.Watches(gatewayapi.NewReferenceGrant(r.referenceGrantVersion),
-			handler.EnqueueRequestsFromMapFunc(r.listReferenceGrantsForGateway),
-			builder.WithPredicates(predicate.NewPredicateFuncs(referenceGrantHasGatewayFrom)),
-		)
-	}
+	blder.Watches(gatewayapi.NewReferenceGrant(r.referenceGrantVersion),
+		handler.EnqueueRequestsFromMapFunc(r.listReferenceGrantsForGateway),
+		builder.WithPredicates(predicate.NewPredicateFuncs(referenceGrantHasGatewayFrom)),
+	)
 
 	// Watch Secrets to immediately reconcile Gateways when referenced certificate Secrets change.
 	blder.WatchesRawSource(
@@ -651,10 +640,8 @@ func (r *GatewayReconciler) reconcileUnmanagedGateway(ctx context.Context, log l
 	// the ReferenceGrants need to be retrieved to ensure that all gateway listeners reference
 	// TLS secrets they are granted for
 	referenceGrantList := gatewayapi.NewReferenceGrantList(r.referenceGrantVersion)
-	if r.enableReferenceGrant {
-		if err := r.List(ctx, referenceGrantList); err != nil {
-			return ctrl.Result{}, err
-		}
+	if err := r.List(ctx, referenceGrantList); err != nil {
+		return ctrl.Result{}, err
 	}
 
 	listenerStatuses, err := getListenerStatus(ctx, gateway, combinedListeners, gatewayapi.ReferenceGrantItems(referenceGrantList), r.Client)

--- a/ingress-controller/internal/controllers/gateway/grpcroute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/grpcroute_controller.go
@@ -37,15 +37,11 @@ import (
 type GRPCRouteReconciler struct {
 	client.Client
 
-	Log             logr.Logger
-	Scheme          *runtime.Scheme
-	DataplaneClient controllers.DataPlane
-	StatusQueue     *status.Queue
-	// If EnableReferenceGrant is true, we will check for ReferenceGrant if backend in another
-	// namespace is in backendRefs.
-	// If it is false, referencing backend in different namespace will be rejected.
-	EnableReferenceGrant bool
-	CacheSyncTimeout     time.Duration
+	Log              logr.Logger
+	Scheme           *runtime.Scheme
+	DataplaneClient  controllers.DataPlane
+	StatusQueue      *status.Queue
+	CacheSyncTimeout time.Duration
 
 	// If GatewayNN is set,
 	// only resources managed by the specified Gateway are reconciled.

--- a/ingress-controller/internal/controllers/gateway/httproute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/httproute_controller.go
@@ -53,11 +53,6 @@ type HTTPRouteReconciler struct {
 	CacheSyncTimeout time.Duration
 	StatusQueue      *status.Queue
 
-	// If enableReferenceGrant is true, we will check for ReferenceGrant if backend in another
-	// namespace is in backendRefs.
-	// If it is false, referencing backend in different namespace will be rejected.
-	// It's resolved on SetupWithManager call.
-	enableReferenceGrant bool
 	// referenceGrantVersion is the ReferenceGrant API GroupVersion (v1 or v1beta1)
 	// served by the cluster, resolved on SetupWithManager call.
 	referenceGrantVersion schema.GroupVersion
@@ -69,19 +64,14 @@ type HTTPRouteReconciler struct {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *HTTPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	// We're verifying whether ReferenceGrant CRD is installed at setup of the HTTPRouteReconciler
-	// to decide whether we should run additional ReferenceGrant watch and handle ReferenceGrants
-	// when reconciling HTTPRoutes.
-	// Once the HTTPRouteReconciler is set up without ReferenceGrant, there's no possibility to enable
-	// ReferenceGrant handling again in this reconciler at runtime.
-	gv, ok, err := ctrlutils.DetectReferenceGrantVersion(mgr.GetRESTMapper())
+	// The ReferenceGrant CRD is a hard requirement of this reconciler: it is needed to
+	// resolve cross-namespace references. Resolve which version the cluster serves at
+	// setup, and fail loudly if neither is installed.
+	gv, err := ctrlutils.DetectReferenceGrantVersion(mgr.GetRESTMapper())
 	if err != nil {
-		return fmt.Errorf("failed to detect the ReferenceGrant API version: %w", err)
+		return err
 	}
-	r.referenceGrantVersion, r.enableReferenceGrant = gv, ok
-	if !r.enableReferenceGrant {
-		r.Log.Error(nil, "Neither v1 nor v1beta1 ReferenceGrant CRD found; cross-namespace references will be rejected")
-	}
+	r.referenceGrantVersion = gv
 
 	if err := setupHTTPRouteIndices(mgr); err != nil {
 		return err
@@ -121,12 +111,10 @@ func (r *HTTPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		handler.EnqueueRequestsFromMapFunc(r.listHTTPRoutesForKongPlugin),
 	)
 
-	if r.enableReferenceGrant {
-		blder.Watches(gatewayapi.NewReferenceGrant(r.referenceGrantVersion),
-			handler.EnqueueRequestsFromMapFunc(r.listHTTPRoutesForReferenceGrant),
-			builder.WithPredicates(predicate.NewPredicateFuncs(referenceGrantHasHTTPRouteFrom)),
-		)
-	}
+	blder.Watches(gatewayapi.NewReferenceGrant(r.referenceGrantVersion),
+		handler.EnqueueRequestsFromMapFunc(r.listHTTPRoutesForReferenceGrant),
+		builder.WithPredicates(predicate.NewPredicateFuncs(referenceGrantHasHTTPRouteFrom)),
+	)
 
 	if r.StatusQueue != nil {
 		blder.WatchesRawSource(
@@ -678,11 +666,6 @@ func (r *HTTPRouteReconciler) getHTTPRouteRuleReason(ctx context.Context, httpRo
 			// and if there is grant for that reference
 			if httpRoute.Namespace != backendNamespace {
 				differentNamespaceMsg := fmt.Sprintf("%s is in a different namespace than the HTTPRoute (namespace %s)", targetNN, httpRoute.Namespace)
-				if !r.enableReferenceGrant {
-					return gatewayapi.RouteReasonRefNotPermitted,
-						differentNamespaceMsg + " install ReferenceGrant CRD and configure a proper grant",
-						nil
-				}
 
 				referenceGrantList := gatewayapi.NewReferenceGrantList(r.referenceGrantVersion)
 				if err := r.List(ctx, referenceGrantList, client.InNamespace(backendNamespace)); err != nil {
@@ -768,29 +751,12 @@ func (r *HTTPRouteReconciler) validateAnnotationPluginReferences(
 			crossNSNamespaces[pluginNamespace] = struct{}{}
 		}
 	}
-	if len(crossNSNamespaces) > 0 {
-		if !r.enableReferenceGrant {
-			for _, pluginRef := range pluginRefs {
-				pluginNamespace := pluginRef.Namespace
-				if pluginNamespace == "" {
-					pluginNamespace = httpRoute.Namespace
-				}
-				if pluginNamespace != httpRoute.Namespace {
-					return gatewayapi.RouteReasonRefNotPermitted,
-						fmt.Sprintf("%s/%s is in a different namespace than the HTTPRoute (namespace %s) install ReferenceGrant CRD and configure a proper grant",
-							pluginNamespace, pluginRef.Name, httpRoute.Namespace,
-						),
-						nil
-				}
-			}
+	for ns := range crossNSNamespaces {
+		grants, err := r.listReferenceGrants(ctx, ns)
+		if err != nil {
+			return "", "", err
 		}
-		for ns := range crossNSNamespaces {
-			grants, err := r.listReferenceGrants(ctx, ns)
-			if err != nil {
-				return "", "", err
-			}
-			referenceGrants = append(referenceGrants, grants...)
-		}
+		referenceGrants = append(referenceGrants, grants...)
 	}
 
 	for _, pluginRef := range pluginRefs {

--- a/ingress-controller/internal/controllers/gateway/httproute_controller_test.go
+++ b/ingress-controller/internal/controllers/gateway/httproute_controller_test.go
@@ -283,15 +283,13 @@ func TestHTTPRouteRuleReasonPluginReferences(t *testing.T) {
 
 	tests := []struct {
 		name               string
-		enableRefGrant     bool
 		objects            []client.Object
 		route              gatewayapi.HTTPRoute
 		wantReason         gatewayapi.RouteConditionReason
 		wantMessageContain string
 	}{
 		{
-			name:           "extensionRef resolves",
-			enableRefGrant: true,
+			name: "extensionRef resolves",
 			objects: []client.Object{
 				&corev1.Service{Name: "svc", Namespace: "default"},
 				&kongPlugin,
@@ -311,8 +309,7 @@ func TestHTTPRouteRuleReasonPluginReferences(t *testing.T) {
 			wantReason: gatewayapi.RouteReasonResolvedRefs,
 		},
 		{
-			name:           "extensionRef missing",
-			enableRefGrant: true,
+			name: "extensionRef missing",
 			objects: []client.Object{
 				&corev1.Service{Name: "svc", Namespace: "default"},
 			},
@@ -332,8 +329,7 @@ func TestHTTPRouteRuleReasonPluginReferences(t *testing.T) {
 			wantMessageContain: "extensionRef default/missing-plugin does not exist",
 		},
 		{
-			name:           "extensionRef invalid kind",
-			enableRefGrant: true,
+			name: "extensionRef invalid kind",
 			objects: []client.Object{
 				&corev1.Service{Name: "svc", Namespace: "default"},
 			},
@@ -353,8 +349,7 @@ func TestHTTPRouteRuleReasonPluginReferences(t *testing.T) {
 			wantMessageContain: "unsupported type configuration.konghq.com/KongClusterPlugin",
 		},
 		{
-			name:           "annotation plugin missing",
-			enableRefGrant: true,
+			name: "annotation plugin missing",
 			objects: []client.Object{
 				&corev1.Service{Name: "svc", Namespace: "default"},
 			},
@@ -369,8 +364,7 @@ func TestHTTPRouteRuleReasonPluginReferences(t *testing.T) {
 			wantMessageContain: "referenced KongPlugin default/missing-plugin does not exist",
 		},
 		{
-			name:           "annotation plugin cross-namespace without grant",
-			enableRefGrant: true,
+			name: "annotation plugin cross-namespace without grant",
 			objects: []client.Object{
 				&corev1.Service{Name: "svc", Namespace: "default"},
 				&configurationv1.KongPlugin{
@@ -389,8 +383,7 @@ func TestHTTPRouteRuleReasonPluginReferences(t *testing.T) {
 			wantMessageContain: "and no ReferenceGrant allowing reference is configured",
 		},
 		{
-			name:           "annotation plugin cross-namespace with grant",
-			enableRefGrant: true,
+			name: "annotation plugin cross-namespace with grant",
 			objects: []client.Object{
 				&corev1.Service{Name: "svc", Namespace: "default"},
 				&configurationv1.KongPlugin{
@@ -421,26 +414,6 @@ func TestHTTPRouteRuleReasonPluginReferences(t *testing.T) {
 			}(),
 			wantReason: gatewayapi.RouteReasonResolvedRefs,
 		},
-		{
-			name:           "annotation plugin cross-namespace without ReferenceGrant CRD",
-			enableRefGrant: false,
-			objects: []client.Object{
-				&corev1.Service{Name: "svc", Namespace: "default"},
-				&configurationv1.KongPlugin{
-					Name: "rate-limit", Namespace: "plugins",
-					PluginName: "rate-limiting",
-				},
-			},
-			route: func() gatewayapi.HTTPRoute {
-				r := baseRoute.DeepCopy()
-				r.Annotations = map[string]string{
-					metadata.AnnotationKeyPlugins: "plugins:rate-limit",
-				}
-				return *r
-			}(),
-			wantReason:         gatewayapi.RouteReasonRefNotPermitted,
-			wantMessageContain: "install ReferenceGrant CRD and configure a proper grant",
-		},
 	}
 
 	for _, tc := range tests {
@@ -450,9 +423,8 @@ func TestHTTPRouteRuleReasonPluginReferences(t *testing.T) {
 				WithObjects(tc.objects...).
 				Build()
 			reconciler := &HTTPRouteReconciler{
-				Client:               cl,
-				Log:                  logger,
-				enableReferenceGrant: tc.enableRefGrant,
+				Client: cl,
+				Log:    logger,
 			}
 
 			reason, msg, err := reconciler.getHTTPRouteRuleReason(ctx, tc.route)

--- a/ingress-controller/internal/controllers/gateway/referencegrant_controller.go
+++ b/ingress-controller/internal/controllers/gateway/referencegrant_controller.go
@@ -52,12 +52,9 @@ type ReferenceGrantReconciler struct {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *ReferenceGrantReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	gv, ok, err := ctrlutils.DetectReferenceGrantVersion(mgr.GetRESTMapper())
+	gv, err := ctrlutils.DetectReferenceGrantVersion(mgr.GetRESTMapper())
 	if err != nil {
-		return fmt.Errorf("failed to detect the ReferenceGrant API version: %w", err)
-	}
-	if !ok {
-		return fmt.Errorf("neither v1 nor v1beta1 ReferenceGrant CRD found")
+		return err
 	}
 	r.referenceGrantVersion = gv
 

--- a/ingress-controller/internal/controllers/gateway/tcproute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/tcproute_controller.go
@@ -47,11 +47,6 @@ type TCPRouteReconciler struct {
 	CacheSyncTimeout time.Duration
 	StatusQueue      *status.Queue
 
-	// If enableReferenceGrant is true, we will check for ReferenceGrant if backend in another
-	// namespace is in backendRefs.
-	// If it is false, referencing backend in different namespace will be rejected.
-	// It's resolved on SetupWithManager call.
-	enableReferenceGrant bool
 	// referenceGrantVersion is the ReferenceGrant API GroupVersion (v1 or v1beta1)
 	// served by the cluster, resolved on SetupWithManager call.
 	referenceGrantVersion schema.GroupVersion
@@ -63,19 +58,14 @@ type TCPRouteReconciler struct {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *TCPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	// We're verifying whether ReferenceGrant CRD is installed at setup of the TCPRouteReconciler
-	// to decide whether we should run additional ReferenceGrant watch and handle ReferenceGrants
-	// when reconciling TCPRoutes.
-	// Once the TCPRouteReconciler is set up without ReferenceGrant, there's no possibility to enable
-	// ReferenceGrant handling again in this reconciler at runtime.
-	gv, ok, err := ctrlutils.DetectReferenceGrantVersion(mgr.GetRESTMapper())
+	// The ReferenceGrant CRD is a hard requirement of this reconciler: it is needed to
+	// resolve cross-namespace references. Resolve which version the cluster serves at
+	// setup, and fail loudly if neither is installed.
+	gv, err := ctrlutils.DetectReferenceGrantVersion(mgr.GetRESTMapper())
 	if err != nil {
-		return fmt.Errorf("failed to detect the ReferenceGrant API version: %w", err)
+		return err
 	}
-	r.referenceGrantVersion, r.enableReferenceGrant = gv, ok
-	if !r.enableReferenceGrant {
-		r.Log.Error(nil, "Neither v1 nor v1beta1 ReferenceGrant CRD found; cross-namespace references will be rejected")
-	}
+	r.referenceGrantVersion = gv
 
 	blder := ctrl.NewControllerManagedBy(mgr).
 		Named("tcproute-controller").
@@ -106,12 +96,10 @@ func (r *TCPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			handler.EnqueueRequestsFromMapFunc(r.listTCPRoutesForGateway),
 		)
 
-	if r.enableReferenceGrant {
-		blder.Watches(gatewayapi.NewReferenceGrant(r.referenceGrantVersion),
-			handler.EnqueueRequestsFromMapFunc(r.listTCPRoutesForReferenceGrant),
-			builder.WithPredicates(predicate.NewPredicateFuncs(referenceGrantHasTCPRouteFrom)),
-		)
-	}
+	blder.Watches(gatewayapi.NewReferenceGrant(r.referenceGrantVersion),
+		handler.EnqueueRequestsFromMapFunc(r.listTCPRoutesForReferenceGrant),
+		builder.WithPredicates(predicate.NewPredicateFuncs(referenceGrantHasTCPRouteFrom)),
+	)
 
 	if r.StatusQueue != nil {
 		blder.WatchesRawSource(
@@ -630,11 +618,6 @@ func (r *TCPRouteReconciler) getTCPRouteRuleReason(ctx context.Context, tcpRoute
 			// verify that a ReferenceGrant permits the reference.
 			if tcpRoute.Namespace != backendNamespace {
 				differentNamespaceMsg := fmt.Sprintf("%s is in a different namespace than the TCPRoute (namespace %s)", targetNN, tcpRoute.Namespace)
-				if !r.enableReferenceGrant {
-					return gatewayapi.RouteReasonRefNotPermitted,
-						differentNamespaceMsg + " install ReferenceGrant CRD and configure a proper grant",
-						nil
-				}
 
 				referenceGrantList := gatewayapi.NewReferenceGrantList(r.referenceGrantVersion)
 				if err := r.List(ctx, referenceGrantList, client.InNamespace(backendNamespace)); err != nil {

--- a/ingress-controller/internal/controllers/gateway/tcproute_controller_test.go
+++ b/ingress-controller/internal/controllers/gateway/tcproute_controller_test.go
@@ -51,15 +51,13 @@ func TestGetTCPRouteRuleReason(t *testing.T) {
 
 	tests := []struct {
 		name               string
-		enableRefGrant     bool
 		objects            []client.Object
 		route              gatewayapi.TCPRoute
 		wantReason         gatewayapi.RouteConditionReason
 		wantMessageContain string
 	}{
 		{
-			name:           "resolves",
-			enableRefGrant: true,
+			name: "resolves",
 			objects: []client.Object{
 				&corev1.Service{Name: "svc", Namespace: "default"},
 			},
@@ -68,16 +66,14 @@ func TestGetTCPRouteRuleReason(t *testing.T) {
 		},
 		{
 			name:               "backend service missing",
-			enableRefGrant:     true,
 			objects:            []client.Object{},
 			route:              newTCPRoute(serviceBackendRef(nil)),
 			wantReason:         gatewayapi.RouteReasonBackendNotFound,
 			wantMessageContain: "target default/svc",
 		},
 		{
-			name:           "unsupported backend kind",
-			enableRefGrant: true,
-			objects:        []client.Object{},
+			name:    "unsupported backend kind",
+			objects: []client.Object{},
 			route: newTCPRoute(gatewayapi.BackendRef{
 				Name:  "svc",
 				Kind:  util.StringToGatewayAPIKindPtr("Foo"),
@@ -87,18 +83,7 @@ func TestGetTCPRouteRuleReason(t *testing.T) {
 			wantMessageContain: "unsupported type example.com/Foo",
 		},
 		{
-			name:           "cross-namespace without ReferenceGrant CRD",
-			enableRefGrant: false,
-			objects: []client.Object{
-				&corev1.Service{Name: "svc", Namespace: "other"},
-			},
-			route:              newTCPRoute(serviceBackendRef(&otherNS)),
-			wantReason:         gatewayapi.RouteReasonRefNotPermitted,
-			wantMessageContain: "install ReferenceGrant CRD and configure a proper grant",
-		},
-		{
-			name:           "cross-namespace without matching grant",
-			enableRefGrant: true,
+			name: "cross-namespace without matching grant",
 			objects: []client.Object{
 				&corev1.Service{Name: "svc", Namespace: "other"},
 			},
@@ -107,8 +92,7 @@ func TestGetTCPRouteRuleReason(t *testing.T) {
 			wantMessageContain: "no ReferenceGrant allowing reference is configured",
 		},
 		{
-			name:           "cross-namespace with matching grant",
-			enableRefGrant: true,
+			name: "cross-namespace with matching grant",
 			objects: []client.Object{
 				&corev1.Service{Name: "svc", Namespace: "other"},
 				grantFromTCPRouteToService.DeepCopy(),
@@ -117,8 +101,7 @@ func TestGetTCPRouteRuleReason(t *testing.T) {
 			wantReason: gatewayapi.RouteReasonResolvedRefs,
 		},
 		{
-			name:           "cross-namespace grant for wrong from-kind (TLSRoute, not TCPRoute)",
-			enableRefGrant: true,
+			name: "cross-namespace grant for wrong from-kind (TLSRoute, not TCPRoute)",
 			objects: []client.Object{
 				&corev1.Service{Name: "svc", Namespace: "other"},
 				&gatewayapi.ReferenceGrant{
@@ -149,9 +132,8 @@ func TestGetTCPRouteRuleReason(t *testing.T) {
 				WithObjects(tc.objects...).
 				Build()
 			reconciler := &TCPRouteReconciler{
-				Client:               cl,
-				Log:                  logger,
-				enableReferenceGrant: tc.enableRefGrant,
+				Client: cl,
+				Log:    logger,
 			}
 
 			reason, msg, err := reconciler.getTCPRouteRuleReason(ctx, tc.route)
@@ -247,7 +229,7 @@ func TestSetRouteConditionResolvedRefsCondition_TCPRoute(t *testing.T) {
 			WithScheme(scheme.Get()).
 			WithObjects(&corev1.Service{Name: "svc", Namespace: "other"}).
 			Build()
-		r := &TCPRouteReconciler{Client: cl, Log: logger, enableReferenceGrant: true}
+		r := &TCPRouteReconciler{Client: cl, Log: logger}
 		route := newTCPRoute(serviceBackendRef(&otherNS))
 		parentStatuses := newParentStatuses()
 

--- a/ingress-controller/internal/controllers/gateway/tlsroute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/tlsroute_controller.go
@@ -47,11 +47,6 @@ type TLSRouteReconciler struct {
 	CacheSyncTimeout time.Duration
 	StatusQueue      *status.Queue
 
-	// If enableReferenceGrant is true, we will check for ReferenceGrant if backend in another
-	// namespace is in backendRefs.
-	// If it is false, referencing backend in different namespace will be rejected.
-	// It's resolved on SetupWithManager call.
-	enableReferenceGrant bool
 	// referenceGrantVersion is the ReferenceGrant API GroupVersion (v1 or v1beta1)
 	// served by the cluster, resolved on SetupWithManager call.
 	referenceGrantVersion schema.GroupVersion
@@ -63,19 +58,14 @@ type TLSRouteReconciler struct {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *TLSRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	// We're verifying whether ReferenceGrant CRD is installed at setup of the TLSRouteReconciler
-	// to decide whether we should run additional ReferenceGrant watch and handle ReferenceGrants
-	// when reconciling TLSRoutes.
-	// Once the TLSRouteReconciler is set up without ReferenceGrant, there's no possibility to enable
-	// ReferenceGrant handling again in this reconciler at runtime.
-	gv, ok, err := ctrlutils.DetectReferenceGrantVersion(mgr.GetRESTMapper())
+	// The ReferenceGrant CRD is a hard requirement of this reconciler: it is needed to
+	// resolve cross-namespace references. Resolve which version the cluster serves at
+	// setup, and fail loudly if neither is installed.
+	gv, err := ctrlutils.DetectReferenceGrantVersion(mgr.GetRESTMapper())
 	if err != nil {
-		return fmt.Errorf("failed to detect the ReferenceGrant API version: %w", err)
+		return err
 	}
-	r.referenceGrantVersion, r.enableReferenceGrant = gv, ok
-	if !r.enableReferenceGrant {
-		r.Log.Error(nil, "Neither v1 nor v1beta1 ReferenceGrant CRD found; cross-namespace references will be rejected")
-	}
+	r.referenceGrantVersion = gv
 
 	blder := ctrl.NewControllerManagedBy(mgr).
 		Named("tlsroute-controller").
@@ -102,12 +92,10 @@ func (r *TLSRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			handler.EnqueueRequestsFromMapFunc(r.listTLSRoutesForGateway),
 		)
 
-	if r.enableReferenceGrant {
-		blder.Watches(gatewayapi.NewReferenceGrant(r.referenceGrantVersion),
-			handler.EnqueueRequestsFromMapFunc(r.listTLSRoutesForReferenceGrant),
-			builder.WithPredicates(predicate.NewPredicateFuncs(referenceGrantHasTLSRouteFrom)),
-		)
-	}
+	blder.Watches(gatewayapi.NewReferenceGrant(r.referenceGrantVersion),
+		handler.EnqueueRequestsFromMapFunc(r.listTLSRoutesForReferenceGrant),
+		builder.WithPredicates(predicate.NewPredicateFuncs(referenceGrantHasTLSRouteFrom)),
+	)
 
 	if r.StatusQueue != nil {
 		blder.WatchesRawSource(
@@ -645,11 +633,6 @@ func (r *TLSRouteReconciler) getTLSRouteRuleReason(ctx context.Context, tlsRoute
 			// verify that a ReferenceGrant permits the reference.
 			if tlsRoute.Namespace != backendNamespace {
 				differentNamespaceMsg := fmt.Sprintf("%s is in a different namespace than the TLSRoute (namespace %s)", targetNN, tlsRoute.Namespace)
-				if !r.enableReferenceGrant {
-					return gatewayapi.RouteReasonRefNotPermitted,
-						differentNamespaceMsg + " install ReferenceGrant CRD and configure a proper grant",
-						nil
-				}
 
 				referenceGrantList := gatewayapi.NewReferenceGrantList(r.referenceGrantVersion)
 				if err := r.List(ctx, referenceGrantList, client.InNamespace(backendNamespace)); err != nil {

--- a/ingress-controller/internal/controllers/gateway/tlsroute_controller_test.go
+++ b/ingress-controller/internal/controllers/gateway/tlsroute_controller_test.go
@@ -60,15 +60,13 @@ func TestGetTLSRouteRuleReason(t *testing.T) {
 
 	tests := []struct {
 		name               string
-		enableRefGrant     bool
 		objects            []client.Object
 		route              gatewayapi.TLSRoute
 		wantReason         gatewayapi.RouteConditionReason
 		wantMessageContain string
 	}{
 		{
-			name:           "resolves",
-			enableRefGrant: true,
+			name: "resolves",
 			objects: []client.Object{
 				&corev1.Service{Name: "svc", Namespace: "default"},
 			},
@@ -77,16 +75,14 @@ func TestGetTLSRouteRuleReason(t *testing.T) {
 		},
 		{
 			name:               "backend service missing",
-			enableRefGrant:     true,
 			objects:            []client.Object{},
 			route:              newTLSRoute(serviceBackendRef(nil)),
 			wantReason:         gatewayapi.RouteReasonBackendNotFound,
 			wantMessageContain: "target default/svc",
 		},
 		{
-			name:           "unsupported backend kind",
-			enableRefGrant: true,
-			objects:        []client.Object{},
+			name:    "unsupported backend kind",
+			objects: []client.Object{},
 			route: newTLSRoute(gatewayapi.BackendRef{
 				Name:  "svc",
 				Kind:  util.StringToGatewayAPIKindPtr("Foo"),
@@ -96,18 +92,7 @@ func TestGetTLSRouteRuleReason(t *testing.T) {
 			wantMessageContain: "unsupported type example.com/Foo",
 		},
 		{
-			name:           "cross-namespace without ReferenceGrant CRD",
-			enableRefGrant: false,
-			objects: []client.Object{
-				&corev1.Service{Name: "svc", Namespace: "other"},
-			},
-			route:              newTLSRoute(serviceBackendRef(&otherNS)),
-			wantReason:         gatewayapi.RouteReasonRefNotPermitted,
-			wantMessageContain: "install ReferenceGrant CRD and configure a proper grant",
-		},
-		{
-			name:           "cross-namespace without matching grant",
-			enableRefGrant: true,
+			name: "cross-namespace without matching grant",
 			objects: []client.Object{
 				&corev1.Service{Name: "svc", Namespace: "other"},
 			},
@@ -116,8 +101,7 @@ func TestGetTLSRouteRuleReason(t *testing.T) {
 			wantMessageContain: "no ReferenceGrant allowing reference is configured",
 		},
 		{
-			name:           "cross-namespace with matching grant",
-			enableRefGrant: true,
+			name: "cross-namespace with matching grant",
 			objects: []client.Object{
 				&corev1.Service{Name: "svc", Namespace: "other"},
 				grantFromTLSRouteToService.DeepCopy(),
@@ -126,8 +110,7 @@ func TestGetTLSRouteRuleReason(t *testing.T) {
 			wantReason: gatewayapi.RouteReasonResolvedRefs,
 		},
 		{
-			name:           "cross-namespace grant for wrong to-kind",
-			enableRefGrant: true,
+			name: "cross-namespace grant for wrong to-kind",
 			objects: []client.Object{
 				&corev1.Service{Name: "svc", Namespace: "other"},
 				&gatewayapi.ReferenceGrant{
@@ -150,8 +133,7 @@ func TestGetTLSRouteRuleReason(t *testing.T) {
 			wantMessageContain: "no ReferenceGrant allowing reference is configured",
 		},
 		{
-			name:           "cross-namespace grant for wrong from-kind",
-			enableRefGrant: true,
+			name: "cross-namespace grant for wrong from-kind",
 			objects: []client.Object{
 				&corev1.Service{Name: "svc", Namespace: "other"},
 				&gatewayapi.ReferenceGrant{
@@ -182,9 +164,8 @@ func TestGetTLSRouteRuleReason(t *testing.T) {
 				WithObjects(tc.objects...).
 				Build()
 			reconciler := &TLSRouteReconciler{
-				Client:               cl,
-				Log:                  logger,
-				enableReferenceGrant: tc.enableRefGrant,
+				Client: cl,
+				Log:    logger,
 			}
 
 			reason, msg, err := reconciler.getTLSRouteRuleReason(ctx, tc.route)
@@ -282,7 +263,7 @@ func TestSetRouteConditionResolvedRefsCondition_TLSRoute(t *testing.T) {
 			WithScheme(scheme.Get()).
 			WithObjects(&corev1.Service{Name: "svc", Namespace: "other"}).
 			Build()
-		r := &TLSRouteReconciler{Client: cl, Log: logger, enableReferenceGrant: true}
+		r := &TLSRouteReconciler{Client: cl, Log: logger}
 		route := newTLSRoute(serviceBackendRef(&otherNS))
 		parentStatuses := newParentStatuses()
 

--- a/ingress-controller/internal/controllers/gateway/udproute_controller.go
+++ b/ingress-controller/internal/controllers/gateway/udproute_controller.go
@@ -47,11 +47,6 @@ type UDPRouteReconciler struct {
 	CacheSyncTimeout time.Duration
 	StatusQueue      *status.Queue
 
-	// If enableReferenceGrant is true, we will check for ReferenceGrant if backend in another
-	// namespace is in backendRefs.
-	// If it is false, referencing backend in different namespace will be rejected.
-	// It's resolved on SetupWithManager call.
-	enableReferenceGrant bool
 	// referenceGrantVersion is the ReferenceGrant API GroupVersion (v1 or v1beta1)
 	// served by the cluster, resolved on SetupWithManager call.
 	referenceGrantVersion schema.GroupVersion
@@ -63,19 +58,14 @@ type UDPRouteReconciler struct {
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *UDPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	// We're verifying whether ReferenceGrant CRD is installed at setup of the UDPRouteReconciler
-	// to decide whether we should run additional ReferenceGrant watch and handle ReferenceGrants
-	// when reconciling UDPRoutes.
-	// Once the UDPRouteReconciler is set up without ReferenceGrant, there's no possibility to enable
-	// ReferenceGrant handling again in this reconciler at runtime.
-	gv, ok, err := ctrlutils.DetectReferenceGrantVersion(mgr.GetRESTMapper())
+	// The ReferenceGrant CRD is a hard requirement of this reconciler: it is needed to
+	// resolve cross-namespace references. Resolve which version the cluster serves at
+	// setup, and fail loudly if neither is installed.
+	gv, err := ctrlutils.DetectReferenceGrantVersion(mgr.GetRESTMapper())
 	if err != nil {
-		return fmt.Errorf("failed to detect the ReferenceGrant API version: %w", err)
+		return err
 	}
-	r.referenceGrantVersion, r.enableReferenceGrant = gv, ok
-	if !r.enableReferenceGrant {
-		r.Log.Error(nil, "Neither v1 nor v1beta1 ReferenceGrant CRD found; cross-namespace references will be rejected")
-	}
+	r.referenceGrantVersion = gv
 
 	blder := ctrl.NewControllerManagedBy(mgr).
 		Named("udproute-controller").
@@ -106,12 +96,10 @@ func (r *UDPRouteReconciler) SetupWithManager(mgr ctrl.Manager) error {
 			handler.EnqueueRequestsFromMapFunc(r.listUDPRoutesForGateway),
 		)
 
-	if r.enableReferenceGrant {
-		blder.Watches(gatewayapi.NewReferenceGrant(r.referenceGrantVersion),
-			handler.EnqueueRequestsFromMapFunc(r.listUDPRoutesForReferenceGrant),
-			builder.WithPredicates(predicate.NewPredicateFuncs(referenceGrantHasUDPRouteFrom)),
-		)
-	}
+	blder.Watches(gatewayapi.NewReferenceGrant(r.referenceGrantVersion),
+		handler.EnqueueRequestsFromMapFunc(r.listUDPRoutesForReferenceGrant),
+		builder.WithPredicates(predicate.NewPredicateFuncs(referenceGrantHasUDPRouteFrom)),
+	)
 
 	if r.StatusQueue != nil {
 		blder.WatchesRawSource(
@@ -625,11 +613,6 @@ func (r *UDPRouteReconciler) getUDPRouteRuleReason(ctx context.Context, udpRoute
 			// namespace we have no permission to reference.
 			if udpRoute.Namespace != backendNamespace {
 				differentNamespaceMsg := fmt.Sprintf("%s is in a different namespace than the UDPRoute (namespace %s)", targetNN, udpRoute.Namespace)
-				if !r.enableReferenceGrant {
-					return gatewayapi.RouteReasonRefNotPermitted,
-						differentNamespaceMsg + " install ReferenceGrant CRD and configure a proper grant",
-						nil
-				}
 
 				referenceGrantList := gatewayapi.NewReferenceGrantList(r.referenceGrantVersion)
 				if err := r.List(ctx, referenceGrantList, client.InNamespace(backendNamespace)); err != nil {

--- a/ingress-controller/internal/controllers/utils/ingress_predicates.go
+++ b/ingress-controller/internal/controllers/utils/ingress_predicates.go
@@ -1,6 +1,9 @@
 package utils
 
 import (
+	"errors"
+	"fmt"
+
 	netv1 "k8s.io/api/networking/v1"
 	"k8s.io/apimachinery/pkg/api/meta"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -78,23 +81,27 @@ func IsIngressClassEmpty(obj client.Object) bool {
 	}
 }
 
+// ErrReferenceGrantCRDNotFound is returned by DetectReferenceGrantVersion when the
+// cluster serves neither the v1 nor the v1beta1 ReferenceGrant CRD.
+var ErrReferenceGrantCRDNotFound = errors.New("neither v1 nor v1beta1 ReferenceGrant CRD found")
+
 // DetectReferenceGrantVersion returns the GroupVersion of whichever ReferenceGrant
 // API version is served by the cluster, preferring v1 and falling back to v1beta1
 // (ReferenceGrant was promoted from v1beta1 to v1 in gateway-api v1.5.0; older
-// clusters only serve v1beta1). ok is false if neither is installed. An error is
-// returned when the lookup itself failed.
-func DetectReferenceGrantVersion(restMapper meta.RESTMapper) (gv schema.GroupVersion, ok bool, err error) {
+// clusters only serve v1beta1). It returns ErrReferenceGrantCRDNotFound if neither
+// is installed, and a wrapped lookup error if the lookup itself failed.
+func DetectReferenceGrantVersion(restMapper meta.RESTMapper) (schema.GroupVersion, error) {
 	for _, gv := range []schema.GroupVersion{
 		schema.GroupVersion(gatewayv1.GroupVersion),
 		schema.GroupVersion(gatewayv1beta1.GroupVersion),
 	} {
 		exists, err := k8sutils.CRDExists(restMapper, gv.WithResource("referencegrants"))
 		if err != nil {
-			return schema.GroupVersion{}, false, err
+			return schema.GroupVersion{}, fmt.Errorf("failed to detect the ReferenceGrant API version: %w", err)
 		}
 		if exists {
-			return gv, true, nil
+			return gv, nil
 		}
 	}
-	return schema.GroupVersion{}, false, nil
+	return schema.GroupVersion{}, ErrReferenceGrantCRDNotFound
 }

--- a/ingress-controller/internal/controllers/utils/referencegrant_version_test.go
+++ b/ingress-controller/internal/controllers/utils/referencegrant_version_test.go
@@ -24,68 +24,68 @@ func restMapperWithReferenceGrant(gvs ...schema.GroupVersion) meta.RESTMapper {
 	return mapper
 }
 
+// errDiscoveryUnavailable is what erroringRESTMapper fails with, so that tests can
+// assert the lookup error is propagated rather than just that some error occurred.
+var errDiscoveryUnavailable = errors.New("discovery is unavailable")
+
 type erroringRESTMapper struct {
 	meta.RESTMapper
 }
 
 func (erroringRESTMapper) KindFor(schema.GroupVersionResource) (schema.GroupVersionKind, error) {
-	return schema.GroupVersionKind{}, errors.New("discovery is unavailable")
+	return schema.GroupVersionKind{}, errDiscoveryUnavailable
 }
 
 func (erroringRESTMapper) KindsFor(schema.GroupVersionResource) ([]schema.GroupVersionKind, error) {
-	return nil, errors.New("discovery is unavailable")
+	return nil, errDiscoveryUnavailable
 }
 
 func TestDetectReferenceGrantVersion(t *testing.T) {
 	tests := []struct {
-		name        string
-		mapper      meta.RESTMapper
-		expectedGV  schema.GroupVersion
-		expectedOK  bool
-		expectedErr bool
+		name       string
+		mapper     meta.RESTMapper
+		expectedGV schema.GroupVersion
+		// expectedErr is the sentinel the returned error must match, nil when no
+		// error is expected.
+		expectedErr error
 	}{
 		{
 			name:        "lookup failure is reported as an error",
 			mapper:      erroringRESTMapper{RESTMapper: meta.NewDefaultRESTMapper(nil)},
 			expectedGV:  schema.GroupVersion{},
-			expectedOK:  false,
-			expectedErr: true,
+			expectedErr: errDiscoveryUnavailable,
 		},
 		{
 			name:       "only v1 is served",
 			mapper:     restMapperWithReferenceGrant(v1GroupVersion),
 			expectedGV: v1GroupVersion,
-			expectedOK: true,
 		},
 		{
 			name:       "only v1beta1 is served",
 			mapper:     restMapperWithReferenceGrant(v1beta1GroupVersion),
 			expectedGV: v1beta1GroupVersion,
-			expectedOK: true,
 		},
 		{
 			name:       "both versions served, v1 is preferred",
 			mapper:     restMapperWithReferenceGrant(v1GroupVersion, v1beta1GroupVersion),
 			expectedGV: v1GroupVersion,
-			expectedOK: true,
 		},
 		{
-			name:       "neither version served",
-			mapper:     restMapperWithReferenceGrant(),
-			expectedGV: schema.GroupVersion{},
-			expectedOK: false,
+			name:        "neither version served",
+			mapper:      restMapperWithReferenceGrant(),
+			expectedGV:  schema.GroupVersion{},
+			expectedErr: ErrReferenceGrantCRDNotFound,
 		},
 	}
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			gv, ok, err := DetectReferenceGrantVersion(tc.mapper)
-			if tc.expectedErr {
-				require.Error(t, err)
+			gv, err := DetectReferenceGrantVersion(tc.mapper)
+			if tc.expectedErr != nil {
+				require.ErrorIs(t, err, tc.expectedErr)
 			} else {
 				require.NoError(t, err)
 			}
-			require.Equal(t, tc.expectedOK, ok)
 			require.Equal(t, tc.expectedGV, gv)
 		})
 	}

--- a/ingress-controller/internal/manager/controllerdef.go
+++ b/ingress-controller/internal/manager/controllerdef.go
@@ -2,6 +2,7 @@ package manager
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"reflect"
 
@@ -70,13 +71,18 @@ func setupControllers(
 ) ([]ControllerDef, error) {
 	// Resolve which ReferenceGrant API version (v1 or v1beta1) is served by the
 	// cluster, so the ReferenceGrant DynamicCRDController waits on the version
-	// that's actually installed. Default to v1 (the GA version) as the
-	// wait-target if the CRD isn't installed yet at all.
-	referenceGrantGV, referenceGrantFound, err := utils.DetectReferenceGrantVersion(mgr.GetRESTMapper())
+	// that's actually installed. The CRD being absent is not fatal here: this
+	// value is only consumed by that controller, which may well be disabled (an
+	// ingress-only ControlPlane has every Gateway API controller turned off).
+	// Default to v1 (the GA version) as the wait-target so the
+	// DynamicCRDController can still pick the CRD up if it is installed later.
+	// Reconcilers that genuinely need ReferenceGrants fail loudly on their own,
+	// in their SetupWithManager.
+	referenceGrantGV, err := utils.DetectReferenceGrantVersion(mgr.GetRESTMapper())
 	if err != nil {
-		return nil, fmt.Errorf("failed to detect the ReferenceGrant API version: %w", err)
-	}
-	if !referenceGrantFound {
+		if !errors.Is(err, utils.ErrReferenceGrantCRDNotFound) {
+			return nil, err
+		}
 		referenceGrantGV = schema.GroupVersion(gatewayv1.GroupVersion)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR removes redundant `ReferenceGrant` guarding. 

When operator starts it runs 

https://github.com/Kong/kong-operator/blob/856ac42758a057b9d7366072e5e4fe200a9d06d9/modules/manager/controller_setup.go#L578-L579

where required CRDs are defined, and it includes `ReferenceGrant`

https://github.com/Kong/kong-operator/blob/856ac42758a057b9d7366072e5e4fe200a9d06d9/modules/manager/controller_setup.go#L269-L571

which makes further checks are baisically a deadcode worth removing.

**Which issue this PR fixes**

Follow-up for the PR
- https://github.com/Kong/kong-operator/pull/5635

Yak shaving for [FTI-7942](https://konghq.atlassian.net/browse/FTI-7942)

[FTI-7942]: https://konghq.atlassian.net/browse/FTI-7942?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ